### PR TITLE
Add support for resource and metric descriptors.

### DIFF
--- a/datalab/stackdriver/commands/_monitoring.py
+++ b/datalab/stackdriver/commands/_monitoring.py
@@ -14,8 +14,6 @@
 from __future__ import absolute_import
 
 try:
-  import IPython
-  import IPython.core.display
   import IPython.core.magic
 except ImportError:
   raise Exception('This module can only be loaded in ipython.')
@@ -67,35 +65,15 @@ def monitoring(line):
   return datalab.utils.commands.handle_magic_line(line, None, parser)
 
 
-def _list_resource_descriptors(args, _):
-  """Lists the resource descriptors in the project."""
-  project_id = args['project']
-  pattern = args['type'] or '*'
-  data = [
-      collections.OrderedDict([
-          ('Resource type', resource.type),
-          ('Labels', ', '. join([l.key for l in resource.labels])),
-      ])
-      for resource in gcm._utils.list_resource_descriptors(project_id)
-      if fnmatch.fnmatch(resource.type, pattern)
-  ]
-  return IPython.core.display.HTML(
-      datalab.utils.commands.HtmlBuilder.render_table(data))
-
-
 def _list_metric_descriptors(args, _):
   """Lists the metric descriptors in the project."""
   project_id = args['project']
   pattern = args['type'] or '*'
-  data = [
-      collections.OrderedDict([
-          ('Metric type', metric.type),
-          ('Kind', metric.metric_kind),
-          ('Value', metric.value_type),
-          ('Labels', ', '. join([l.key for l in metric.labels])),
-      ])
-      for metric in gcm._utils.list_metric_descriptors(project_id)
-      if fnmatch.fnmatch(metric.type, pattern)
-  ]
-  return IPython.core.display.HTML(
-      datalab.utils.commands.HtmlBuilder.render_table(data))
+  return gcm.MetricDescriptors(project_id=project_id).table(pattern=pattern)
+
+
+def _list_resource_descriptors(args, _):
+  """Lists the resource descriptors in the project."""
+  project_id = args['project']
+  pattern = args['type'] or '*'
+  return gcm.ResourceDescriptors(project_id=project_id).table(pattern=pattern)

--- a/datalab/stackdriver/monitoring/__init__.py
+++ b/datalab/stackdriver/monitoring/__init__.py
@@ -15,4 +15,6 @@
 from __future__ import absolute_import
 
 from gcloud.monitoring import Aligner, Reducer
+from ._metric import MetricDescriptors
+from ._resource import ResourceDescriptors
 from ._timeseries import Query

--- a/datalab/stackdriver/monitoring/_metric.py
+++ b/datalab/stackdriver/monitoring/_metric.py
@@ -1,0 +1,101 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations under
+# the License.
+
+"""Provides the MetricDescriptors in the monitoring API."""
+
+from __future__ import absolute_import
+from builtins import object
+
+import fnmatch
+import pandas
+
+from . import _utils
+from . import _visualization
+
+
+class MetricDescriptors(object):
+  """MetricDescriptors object for retrieving the metric descriptors."""
+
+  _DISPLAY_HEADERS = ('Metric type', 'Display name', 'Kind', 'Value', 'Unit',
+                      'Labels')
+
+  def __init__(self, filter_string=None, type_prefix=None,
+               project_id=None, context=None):
+    """Initializes the MetricDescriptors based on the specified filters.
+
+    Args:
+      filter_string: An optional filter expression describing the resource
+        descriptors to be returned.
+      type_prefix: An optional prefix constraining the selected metric types.
+        This adds ``metric.type = starts_with("<prefix>")`` to the filter.
+      project_id: An optional project ID or number to override the one provided
+          by the context.
+      context: An optional Context object to use instead of the global default.
+    """
+    self._client = _utils.make_client(project_id, context)
+    self._filter_string = filter_string
+    self._type_prefix = type_prefix
+    self._descriptors = None
+
+  def list(self, pattern='*'):
+    """Returns a list of metric descriptors that match the filters.
+
+    Args:
+      pattern: An optional pattern to further filter the descriptors. This can
+        include Unix shell-style wildcards. E.g. "compute*", "*cpu/load_??m".
+
+    Returns:
+      A list of MetricDescriptor objects that match the filters.
+    """
+    if self._descriptors is None:
+      self._descriptors = self._client.list_metric_descriptors(
+          filter_string=self._filter_string, type_prefix=self._type_prefix)
+    return [metric for metric in self._descriptors
+            if fnmatch.fnmatch(metric.type, pattern)]
+
+  def as_dataframe(self, pattern='*', max_rows=None):
+    """Creates a pandas dataframe from the descriptors that match the filters.
+
+    Args:
+      pattern: An optional pattern to further filter the descriptors. This can
+        include Unix shell-style wildcards. E.g. "compute*", "*/cpu/load_??m".
+      max_rows: The maximum number of descriptors to return. If None, return
+        all.
+
+    Returns:
+      A pandas dataframe containing matching metric descriptors.
+    """
+    data = []
+    for i, metric in enumerate(self.list(pattern)):
+      if max_rows is not None and i >= max_rows:
+        break
+      labels = ', '. join([l.key for l in metric.labels])
+      data.append([
+          metric.type, metric.display_name, metric.metric_kind,
+          metric.value_type, metric.unit, labels])
+
+    return pandas.DataFrame(data, columns=self._DISPLAY_HEADERS)
+
+  def table(self, pattern='*', max_rows=None):
+    """Visualize the matching descriptors as an HTML table.
+
+    Args:
+      pattern: An optional pattern to further filter the descriptors. This can
+        include Unix shell-style wildcards. E.g. "aws*", "*cluster*".
+      max_rows: The maximum number of descriptors to display. If None, display
+        all.
+
+    Returns:
+      The HTML rendering for a table of matching metric descriptors.
+    """
+    dataframe = self.as_dataframe(pattern, max_rows)
+    return _visualization.table(dataframe, show_index=False)

--- a/datalab/stackdriver/monitoring/_resource.py
+++ b/datalab/stackdriver/monitoring/_resource.py
@@ -1,0 +1,94 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations under
+# the License.
+
+"""Provides the ResourceDescriptors in the monitoring API."""
+
+from __future__ import absolute_import
+from builtins import object
+
+import fnmatch
+import pandas
+
+from . import _utils
+from . import _visualization
+
+
+class ResourceDescriptors(object):
+  """ResourceDescriptors object for retrieving the resource descriptors."""
+
+  _DISPLAY_HEADERS = ('Resource type', 'Display name', 'Labels')
+
+  def __init__(self, filter_string=None, project_id=None, context=None):
+    """Initializes the ResourceDescriptors based on the specified filters.
+
+    Args:
+      filter_string: An optional filter expression describing the resource
+        descriptors to be returned.
+      project_id: An optional project ID or number to override the one provided
+          by the context.
+      context: An optional Context object to use instead of the global default.
+    """
+    self._client = _utils.make_client(project_id, context)
+    self._filter_string = filter_string
+    self._descriptors = None
+
+  def list(self, pattern='*'):
+    """Returns a list of resource descriptors that match the filters.
+
+    Args:
+      pattern: An optional pattern to further filter the descriptors. This can
+        include Unix shell-style wildcards. E.g. "aws*", "*cluster*".
+
+    Returns:
+      A list of ResourceDescriptor objects that match the filters.
+    """
+    if self._descriptors is None:
+      self._descriptors = self._client.list_resource_descriptors(
+          filter_string=self._filter_string)
+    return [resource for resource in self._descriptors
+            if fnmatch.fnmatch(resource.type, pattern)]
+
+  def as_dataframe(self, pattern='*', max_rows=None):
+    """Creates a pandas dataframe from the descriptors that match the filters.
+
+    Args:
+      pattern: An optional pattern to further filter the descriptors. This can
+        include Unix shell-style wildcards. E.g. "aws*", "*cluster*".
+      max_rows: The maximum number of descriptors to return. If None, return
+        all.
+
+    Returns:
+      A pandas dataframe containing matching resource descriptors.
+    """
+    data = []
+    for i, resource in enumerate(self.list(pattern)):
+      if max_rows is not None and i >= max_rows:
+        break
+      labels = ', '. join([l.key for l in resource.labels])
+      data.append([resource.type, resource.display_name, labels])
+
+    return pandas.DataFrame(data, columns=self._DISPLAY_HEADERS)
+
+  def table(self, pattern='*', max_rows=None):
+    """Visualize the matching descriptors as an HTML table.
+
+    Args:
+      pattern: An optional pattern to further filter the descriptors. This can
+        include Unix shell-style wildcards. E.g. "aws*", "*cluster*".
+      max_rows: The maximum number of descriptors to display. If None, display
+        all.
+
+    Returns:
+      The HTML rendering for a table of matching resource descriptors.
+    """
+    dataframe = self.as_dataframe(pattern, max_rows)
+    return _visualization.table(dataframe, show_index=False)

--- a/datalab/stackdriver/monitoring/_visualization.py
+++ b/datalab/stackdriver/monitoring/_visualization.py
@@ -10,19 +10,21 @@
 # or implied.  See the License for the specific language governing permissions and limitations under
 # the License.
 
-"""Provides utility methods for the Monitoring API."""
+"""Visualization methods."""
 
 from __future__ import absolute_import
 
-import gcloud.monitoring
 
-import datalab.context
+def table(dataframe, show_index=True):
+  """Visualize a dataframe as an HTML table.
 
+  Args:
+    dataframe: the pandas dataframe to display.
+    show_index: if False, the dataframe index is hidden.
 
-def make_client(project_id=None, context=None):
-  context = context or datalab.context.Context.default()
-  project_id = project_id or context.project_id
-  return gcloud.monitoring.Client(
-      project=project_id,
-      credentials=context.credentials,
-  )
+  Returns:
+    The HTML rendering of the dataframe as a table.
+  """
+  import IPython.core.display
+
+  return IPython.core.display.HTML(dataframe.to_html(index=show_index))

--- a/tests/main.py
+++ b/tests/main.py
@@ -40,6 +40,8 @@ import kernel.module_tests
 import kernel.sql_tests
 import kernel.storage_tests
 import kernel.utils_tests
+import stackdriver.monitoring.metric_tests
+import stackdriver.monitoring.resource_tests
 import storage.api_tests
 import storage.bucket_tests
 import storage.item_tests
@@ -71,6 +73,8 @@ _TEST_MODULES = [
     kernel.sql_tests,
     kernel.storage_tests,
     kernel.utils_tests,
+    stackdriver.monitoring.metric_tests,
+    stackdriver.monitoring.resource_tests,
     storage.api_tests,
     storage.bucket_tests,
     storage.item_tests,

--- a/tests/stackdriver/__init__.py
+++ b/tests/stackdriver/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.

--- a/tests/stackdriver/monitoring/__init__.py
+++ b/tests/stackdriver/monitoring/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.

--- a/tests/stackdriver/monitoring/metric_tests.py
+++ b/tests/stackdriver/monitoring/metric_tests.py
@@ -1,0 +1,189 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+from __future__ import absolute_import
+import mock
+from oauth2client.client import AccessTokenCredentials
+import unittest
+
+import gcloud.monitoring
+import pandas
+
+import datalab.context
+import datalab.stackdriver.monitoring as gcm
+
+PROJECT = 'my-project'
+METRIC_TYPES = ['compute.googleapis.com/instances/cpu/utilization',
+                'compute.googleapis.com/instances/cpu/usage_time']
+DISPLAY_NAMES = ['CPU Utilization', 'CPU Usage']
+METRIC_KIND = 'GAUGE'
+VALUE_TYPE = 'DOUBLE'
+UNIT = '1'
+LABELS = [dict(key='instance_name', value_type='STRING',
+               description='VM instance'),
+          dict(key='device_name', value_type='STRING',
+               description='Device name')]
+FILTER_STRING = 'metric.type:"cpu"'
+TYPE_PREFIX = 'compute'
+
+
+class TestCases(unittest.TestCase):
+
+  def setUp(self):
+    self.context = self._create_context()
+    self.descriptors = gcm.MetricDescriptors(context=self.context)
+
+  @mock.patch('datalab.context._context.Context.default')
+  def test_constructor_minimal(self, mock_context_default):
+    mock_context_default.return_value = self.context
+
+    descriptors = gcm.MetricDescriptors()
+
+    expected_client = gcm._utils.make_client(context=self.context)
+    self.assertEqual(descriptors._client.project, expected_client.project)
+    self.assertEqual(descriptors._client.connection.credentials,
+                     expected_client.connection.credentials)
+
+    self.assertIsNone(descriptors._filter_string)
+    self.assertIsNone(descriptors._type_prefix)
+    self.assertIsNone(descriptors._descriptors)
+
+  def test_constructor_maximal(self):
+    context = self._create_context(PROJECT)
+    descriptors = gcm.MetricDescriptors(
+        filter_string=FILTER_STRING, type_prefix=TYPE_PREFIX,
+        project_id=PROJECT, context=context)
+
+    expected_client = gcm._utils.make_client(
+        context=context, project_id=PROJECT)
+    self.assertEqual(descriptors._client.project, expected_client.project)
+    self.assertEqual(descriptors._client.connection.credentials,
+                     expected_client.connection.credentials)
+
+    self.assertEqual(descriptors._filter_string, FILTER_STRING)
+    self.assertEqual(descriptors._type_prefix, TYPE_PREFIX)
+    self.assertIsNone(descriptors._descriptors)
+
+  @mock.patch('gcloud.monitoring.Client.list_metric_descriptors')
+  def test_list(self, mock_gcloud_list_descriptors):
+    mock_gcloud_list_descriptors.return_value = self._list_metrics_get_result(
+        context=self.context)
+
+    metric_descriptor_list = self.descriptors.list()
+
+    mock_gcloud_list_descriptors.assert_called_once_with(
+        filter_string=None, type_prefix=None)
+    self.assertEqual(len(metric_descriptor_list), 2)
+    self.assertEqual(metric_descriptor_list[0].type, METRIC_TYPES[0])
+    self.assertEqual(metric_descriptor_list[1].type, METRIC_TYPES[1])
+
+  @mock.patch('gcloud.monitoring.Client.list_metric_descriptors')
+  def test_list_w_api_filter(self, mock_gcloud_list_descriptors):
+    mock_gcloud_list_descriptors.return_value = self._list_metrics_get_result(
+        context=self.context)
+
+    descriptors = gcm.MetricDescriptors(
+        filter_string=FILTER_STRING, type_prefix=TYPE_PREFIX,
+        context=self.context)
+    metric_descriptor_list = descriptors.list()
+
+    mock_gcloud_list_descriptors.assert_called_once_with(
+        filter_string=FILTER_STRING, type_prefix=TYPE_PREFIX)
+    self.assertEqual(len(metric_descriptor_list), 2)
+    self.assertEqual(metric_descriptor_list[0].type, METRIC_TYPES[0])
+    self.assertEqual(metric_descriptor_list[1].type, METRIC_TYPES[1])
+
+  @mock.patch('gcloud.monitoring.Client.list_metric_descriptors')
+  def test_list_w_pattern_match(self, mock_gcloud_list_descriptors):
+    mock_gcloud_list_descriptors.return_value = self._list_metrics_get_result(
+        context=self.context)
+
+    metric_descriptor_list = self.descriptors.list(pattern='*usage_time')
+
+    mock_gcloud_list_descriptors.assert_called_once_with(
+        filter_string=None, type_prefix=None)
+    self.assertEqual(len(metric_descriptor_list), 1)
+    self.assertEqual(metric_descriptor_list[0].type, METRIC_TYPES[1])
+
+  @mock.patch('gcloud.monitoring.Client.list_metric_descriptors')
+  def test_list_caching(self, mock_gcloud_list_descriptors):
+    mock_gcloud_list_descriptors.return_value = self._list_metrics_get_result(
+        context=self.context)
+
+    actual_list1 = self.descriptors.list()
+    actual_list2 = self.descriptors.list()
+
+    mock_gcloud_list_descriptors.assert_called_once_with(
+        filter_string=None, type_prefix=None)
+    self.assertEqual(actual_list1, actual_list2)
+
+  @mock.patch('datalab.stackdriver.monitoring.MetricDescriptors.list')
+  def test_as_dataframe(self, mock_datalab_list_descriptors):
+    mock_datalab_list_descriptors.return_value = self._list_metrics_get_result(
+        context=self.context)
+    dataframe = self.descriptors.as_dataframe()
+    mock_datalab_list_descriptors.assert_called_once_with('*')
+
+    expected_headers = list(gcm.MetricDescriptors._DISPLAY_HEADERS)
+    self.assertEqual(dataframe.columns.tolist(), expected_headers)
+    self.assertEqual(dataframe.columns.names, [None])
+
+    self.assertEqual(dataframe.index.tolist(), range(len(METRIC_TYPES)))
+    self.assertEqual(dataframe.index.names, [None])
+
+    expected_labels = 'instance_name, device_name'
+    expected_values = [
+        [metric_type, display_name, METRIC_KIND, VALUE_TYPE, UNIT,
+         expected_labels]
+        for metric_type, display_name in zip(METRIC_TYPES, DISPLAY_NAMES)]
+    self.assertEqual(dataframe.values.tolist(), expected_values)
+
+  @mock.patch('datalab.stackdriver.monitoring.MetricDescriptors.list')
+  def test_as_dataframe_w_all_args(self, mock_datalab_list_descriptors):
+    mock_datalab_list_descriptors.return_value = self._list_metrics_get_result(
+        context=self.context)
+    dataframe = self.descriptors.as_dataframe(pattern='*cpu*', max_rows=1)
+    mock_datalab_list_descriptors.assert_called_once_with('*cpu*')
+
+    expected_headers = list(gcm.MetricDescriptors._DISPLAY_HEADERS)
+    self.assertEqual(dataframe.columns.tolist(), expected_headers)
+    self.assertEqual(dataframe.index.tolist(), [0])
+    self.assertEqual(dataframe.iloc[0, 0], METRIC_TYPES[0])
+
+  @mock.patch('datalab.stackdriver.monitoring._visualization.table')
+  @mock.patch('datalab.stackdriver.monitoring.MetricDescriptors.as_dataframe')
+  def test_table(self, mock_datalab_as_dataframe, mock_display_table):
+    DATAFRAME = pandas.DataFrame(METRIC_TYPES, columns=['Metric type'])
+    mock_datalab_as_dataframe.return_value = DATAFRAME
+
+    self.descriptors.table(pattern='*cpu*', max_rows=1)
+
+    mock_datalab_as_dataframe.assert_called_once_with('*cpu*', 1)
+    mock_display_table.assert_called_once_with(DATAFRAME, show_index=False)
+
+  @staticmethod
+  def _create_context(project_id='test'):
+    creds = AccessTokenCredentials('test_token', 'test_ua')
+    return datalab.context.Context(project_id, creds)
+
+  @staticmethod
+  def _list_metrics_get_result(context):
+    client = gcm._utils.make_client(context=context)
+    all_labels = [gcloud.monitoring.LabelDescriptor(**labels)
+                  for labels in LABELS]
+    descriptors = [
+        client.metric_descriptor(
+            metric_type, metric_kind=METRIC_KIND, value_type=VALUE_TYPE,
+            unit=UNIT, display_name=display_name, labels=all_labels,
+        )
+        for metric_type, display_name in zip(METRIC_TYPES, DISPLAY_NAMES)]
+    return descriptors

--- a/tests/stackdriver/monitoring/resource_tests.py
+++ b/tests/stackdriver/monitoring/resource_tests.py
@@ -1,0 +1,173 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+from __future__ import absolute_import
+import mock
+from oauth2client.client import AccessTokenCredentials
+import unittest
+
+import gcloud.monitoring
+import pandas
+
+import datalab.context
+import datalab.stackdriver.monitoring as gcm
+
+PROJECT = 'my-project'
+RESOURCE_TYPES = ['gce_instance', 'aws_ec2_instance']
+DISPLAY_NAMES = ['GCE VM Instance', 'Amazon EC2 Instance']
+
+LABELS = [dict(key='instance_id', value_type='STRING',
+               description='VM instance ID'),
+          dict(key='project_id', value_type='STRING',
+               description='Project ID')]
+FILTER_STRING = 'resource.type = ends_with("instance")'
+
+
+class TestCases(unittest.TestCase):
+
+  def setUp(self):
+    self.context = self._create_context()
+    self.descriptors = gcm.ResourceDescriptors(context=self.context)
+
+  @mock.patch('datalab.context._context.Context.default')
+  def test_constructor_minimal(self, mock_context_default):
+    mock_context_default.return_value = self.context
+
+    descriptors = gcm.ResourceDescriptors()
+
+    expected_client = gcm._utils.make_client(context=self.context)
+    self.assertEqual(descriptors._client.project, expected_client.project)
+    self.assertEqual(descriptors._client.connection.credentials,
+                     expected_client.connection.credentials)
+
+    self.assertIsNone(descriptors._filter_string)
+    self.assertIsNone(descriptors._descriptors)
+
+  def test_constructor_maximal(self):
+    context = self._create_context(PROJECT)
+    descriptors = gcm.ResourceDescriptors(
+        filter_string=FILTER_STRING, project_id=PROJECT, context=context)
+
+    expected_client = gcm._utils.make_client(
+        context=context, project_id=PROJECT)
+    self.assertEqual(descriptors._client.project, expected_client.project)
+    self.assertEqual(descriptors._client.connection.credentials,
+                     expected_client.connection.credentials)
+
+    self.assertEqual(descriptors._filter_string, FILTER_STRING)
+    self.assertIsNone(descriptors._descriptors)
+
+  @mock.patch('gcloud.monitoring.Client.list_resource_descriptors')
+  def test_list(self, mock_api_list_descriptors):
+    mock_api_list_descriptors.return_value = self._list_resources_get_result()
+
+    resource_descriptor_list = self.descriptors.list()
+
+    mock_api_list_descriptors.assert_called_once_with(filter_string=None)
+    self.assertEqual(len(resource_descriptor_list), 2)
+    self.assertEqual(resource_descriptor_list[0].type, RESOURCE_TYPES[0])
+    self.assertEqual(resource_descriptor_list[1].type, RESOURCE_TYPES[1])
+
+  @mock.patch('gcloud.monitoring.Client.list_resource_descriptors')
+  def test_list_w_api_filter(self, mock_api_list_descriptors):
+    mock_api_list_descriptors.return_value = self._list_resources_get_result()
+
+    descriptors = gcm.ResourceDescriptors(
+        filter_string=FILTER_STRING, context=self.context)
+    resource_descriptor_list = descriptors.list()
+
+    mock_api_list_descriptors.assert_called_once_with(
+        filter_string=FILTER_STRING)
+    self.assertEqual(len(resource_descriptor_list), 2)
+    self.assertEqual(resource_descriptor_list[0].type, RESOURCE_TYPES[0])
+    self.assertEqual(resource_descriptor_list[1].type, RESOURCE_TYPES[1])
+
+  @mock.patch('gcloud.monitoring.Client.list_resource_descriptors')
+  def test_list_w_pattern_match(self, mock_api_list_descriptors):
+    mock_api_list_descriptors.return_value = self._list_resources_get_result()
+
+    resource_descriptor_list = self.descriptors.list(pattern='*ec2*')
+
+    mock_api_list_descriptors.assert_called_once_with(filter_string=None)
+    self.assertEqual(len(resource_descriptor_list), 1)
+    self.assertEqual(resource_descriptor_list[0].type, RESOURCE_TYPES[1])
+
+  @mock.patch('gcloud.monitoring.Client.list_resource_descriptors')
+  def test_list_caching(self, mock_gcloud_list_descriptors):
+    mock_gcloud_list_descriptors.return_value = (
+        self._list_resources_get_result())
+
+    actual_list1 = self.descriptors.list()
+    actual_list2 = self.descriptors.list()
+
+    mock_gcloud_list_descriptors.assert_called_once_with(filter_string=None)
+    self.assertEqual(actual_list1, actual_list2)
+
+  @mock.patch('datalab.stackdriver.monitoring.ResourceDescriptors.list')
+  def test_as_dataframe(self, mock_datalab_list_descriptors):
+    mock_datalab_list_descriptors.return_value = (
+        self._list_resources_get_result())
+    dataframe = self.descriptors.as_dataframe()
+    mock_datalab_list_descriptors.assert_called_once_with('*')
+
+    expected_headers = list(gcm.ResourceDescriptors._DISPLAY_HEADERS)
+    self.assertEqual(dataframe.columns.tolist(), expected_headers)
+    self.assertEqual(dataframe.columns.names, [None])
+
+    self.assertEqual(dataframe.index.tolist(), range(len(RESOURCE_TYPES)))
+    self.assertEqual(dataframe.index.names, [None])
+
+    expected_labels = 'instance_id, project_id'
+    expected_values = [
+        [resource_type, display_name, expected_labels]
+        for resource_type, display_name in zip(RESOURCE_TYPES, DISPLAY_NAMES)]
+    self.assertEqual(dataframe.values.tolist(), expected_values)
+
+  @mock.patch('datalab.stackdriver.monitoring.ResourceDescriptors.list')
+  def test_as_dataframe_w_all_args(self, mock_datalab_list_descriptors):
+    mock_datalab_list_descriptors.return_value = (
+        self._list_resources_get_result())
+    dataframe = self.descriptors.as_dataframe(pattern='*instance*', max_rows=1)
+    mock_datalab_list_descriptors.assert_called_once_with('*instance*')
+
+    expected_headers = list(gcm.ResourceDescriptors._DISPLAY_HEADERS)
+    self.assertEqual(dataframe.columns.tolist(), expected_headers)
+    self.assertEqual(dataframe.index.tolist(), [0])
+    self.assertEqual(dataframe.iloc[0, 0], RESOURCE_TYPES[0])
+
+  @mock.patch('datalab.stackdriver.monitoring._visualization.table')
+  @mock.patch('datalab.stackdriver.monitoring.ResourceDescriptors.as_dataframe')
+  def test_table(self, mock_datalab_as_dataframe, mock_display_table):
+    DATAFRAME = pandas.DataFrame(RESOURCE_TYPES, columns=['Resource type'])
+    mock_datalab_as_dataframe.return_value = DATAFRAME
+
+    self.descriptors.table(pattern='*instance*', max_rows=1)
+
+    mock_datalab_as_dataframe.assert_called_once_with('*instance*', 1)
+    mock_display_table.assert_called_once_with(DATAFRAME, show_index=False)
+
+  @staticmethod
+  def _create_context(project_id='test'):
+    creds = AccessTokenCredentials('test_token', 'test_ua')
+    return datalab.context.Context(project_id, creds)
+
+  @staticmethod
+  def _list_resources_get_result():
+    all_labels = [gcloud.monitoring.LabelDescriptor(**labels)
+                  for labels in LABELS]
+    descriptors = [
+        gcloud.monitoring.ResourceDescriptor(
+            name=None, type_=resource_type, display_name=display_name,
+            description=None, labels=all_labels,
+        )
+        for resource_type, display_name in zip(RESOURCE_TYPES, DISPLAY_NAMES)]
+    return descriptors


### PR DESCRIPTION
With this change, users can now access metric descriptors and monitored
resource descriptors outside just python magic.

E.g.

    from datalab.stackdriver import monitoring as gcm

    metric_descriptors = gcm.MetricDescriptors()
    metric_descriptors.table(pattern='compute*', max_rows=5)

    resource_descriptors = gcm.ResourceDescriptors()
    resource_descriptors.table(pattern='*instance*')