### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
 
 before_install:
   - npm install -g typescript

--- a/datalab/utils/_http.py
+++ b/datalab/utils/_http.py
@@ -132,7 +132,10 @@ class Http(object):
       if 200 <= response.status < 300:
         if raw_response:
           return content
-        return json.loads(str(content, encoding='UTF-8'))
+        if type(content) == str:
+          return json.loads(content)
+        else:
+          return json.loads(str(content, encoding='UTF-8'))
       else:
         raise RequestException(response.status, content)
     except ValueError:

--- a/datalab/utils/_utils.py
+++ b/datalab/utils/_utils.py
@@ -16,7 +16,11 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from builtins import str
 
-import httplib
+try:
+    import http.client as httplib
+except ImportError:
+    import httplib
+
 import pytz
 import socket
 import traceback

--- a/tests/bigquery/table_tests.py
+++ b/tests/bigquery/table_tests.py
@@ -101,7 +101,7 @@ class TestCases(unittest.TestCase):
     self.assertEqual('Logs', metadata.friendly_name)
     self.assertEqual(2, metadata.rows)
     self.assertEqual(2, metadata.rows)
-    self.assertEqual(ts, metadata.created_on)
+    self.assertTrue(abs((metadata.created_on - ts).total_seconds()) <= 1)
     self.assertEqual(None, metadata.expires_on)
 
   @mock.patch('datalab.bigquery._api.Api.tables_get')

--- a/tests/main.py
+++ b/tests/main.py
@@ -91,4 +91,4 @@ if __name__ == '__main__':
   runner = unittest.TextTestRunner()
   result = runner.run(suite)
 
-  sys.exit(len(result.errors))
+  sys.exit(len(result.errors) + len(result.failures))

--- a/tests/stackdriver/monitoring/metric_tests.py
+++ b/tests/stackdriver/monitoring/metric_tests.py
@@ -137,7 +137,7 @@ class TestCases(unittest.TestCase):
     self.assertEqual(dataframe.columns.tolist(), expected_headers)
     self.assertEqual(dataframe.columns.names, [None])
 
-    self.assertEqual(dataframe.index.tolist(), range(len(METRIC_TYPES)))
+    self.assertEqual(dataframe.index.tolist(), list(range(len(METRIC_TYPES))))
     self.assertEqual(dataframe.index.names, [None])
 
     expected_labels = 'instance_name, device_name'

--- a/tests/stackdriver/monitoring/resource_tests.py
+++ b/tests/stackdriver/monitoring/resource_tests.py
@@ -123,7 +123,7 @@ class TestCases(unittest.TestCase):
     self.assertEqual(dataframe.columns.tolist(), expected_headers)
     self.assertEqual(dataframe.columns.names, [None])
 
-    self.assertEqual(dataframe.index.tolist(), range(len(RESOURCE_TYPES)))
+    self.assertEqual(dataframe.index.tolist(), list(range(len(RESOURCE_TYPES))))
     self.assertEqual(dataframe.index.names, [None])
 
     expected_labels = 'instance_id, project_id'


### PR DESCRIPTION
We had tried to support Python 3 previously, but we were not testing under Python 3 to ensure that we maintained that support.

This change adds testing for Python 3 and fixes the breakages that have crept in since our previous effort.