### PR TITLE
Fetch the application default credentials correctly

### DIFF
--- a/datalab/context/_utils.py
+++ b/datalab/context/_utils.py
@@ -21,6 +21,16 @@ import json
 import os
 
 
+# TODO(ojarjur): This limits the APIs against which Datalab can be called
+# (when using a service account with a credentials file) to only being those
+# that are part of the Google Cloud Platform. We should either extend this
+# to all of the API scopes that Google supports, or make it extensible so
+# that the user can define for themselves which scopes they want to use.
+CREDENTIAL_SCOPES = [
+  'https://www.googleapis.com/auth/cloud-platform',
+]
+
+
 def _in_datalab_docker():
   return os.path.exists('/datalab') and os.getenv('DATALAB_ENV')
 
@@ -50,7 +60,9 @@ def get_credentials():
       overriding these the defaults should suffice.
   """
   try:
-    return oauth2client.client.GoogleCredentials.get_application_default()
+    credentials = oauth2client.client.GoogleCredentials.get_application_default()
+    credentials = credentials.create_scoped(CREDENTIAL_SCOPES)
+    return credentials
   except Exception as e:
 
     # Try load user creds from file


### PR DESCRIPTION
After calling `GoogleCredentials.get_application_default()`, the
returned credentials are not guaranteed to be usable until after
calling `.create_scoped(...)` on them with the set of scopes
requested.

There are 4 types of credentials that may be returned when we
call into `GoogleCredentials.get_application_default()`:

0. An instance of `client.GoogleCredentials`
1. An instance of `gce.AppAssertionCredentials`
2. An instance of `appengine.AppAssertionCredentials`
3. An instance of `service_account._JWTAccessCredentials`

For cases 0 and 1, that subsequent call is actually a no-op, so
we did not realize previously that we were missing it.

However, for cases 2 and 3 that subsequent call is required, and
attempting to use the credentials without it will result in error
messages from the server saying that scopes being missing or empty
is not supported.

This change fixes that by setting the scopes to the singleton list
of the 'cloud-platform' scope. That is not ideal, as there are APIs
outside of the Cloud Platform that a Datalab user may want to use.

However, it is a step forward, as it does not impact the scenarios
which already worked (because the `create_scoped` call in those
cases does nothing), but it does allow previously broken scenarios
to work for Cloud Platform APIs.