### PR TITLE
Stackdriver groups

### DIFF
--- a/datalab/stackdriver/commands/_monitoring.py
+++ b/datalab/stackdriver/commands/_monitoring.py
@@ -60,6 +60,16 @@ def monitoring(line):
       help='The resource type(s) to list; can include wildchars.')
   list_resource_parser.set_defaults(func=_list_resource_descriptors)
 
+  list_group_parser = list_parser.subcommand(
+      'groups',
+      ('List the Stackdriver groups in this project.'))
+  list_group_parser.add_argument(
+      '-p', '--project', help='The project on which to execute the request.')
+  list_group_parser.add_argument(
+      '-n', '--name',
+      help='The name of the group(s) to list; can include wildchars.')
+  list_group_parser.set_defaults(func=_list_groups)
+
   return datalab.utils.commands.handle_magic_line(line, None, parser)
 
 
@@ -69,7 +79,7 @@ def _list_metric_descriptors(args, _):
   pattern = args['type'] or '*'
   descriptors = gcm.MetricDescriptors(project_id=project_id)
   dataframe = descriptors.as_dataframe(pattern=pattern)
-  return _render_dataframe(dataframe, show_index=False)
+  return _render_dataframe(dataframe)
 
 
 def _list_resource_descriptors(args, _):
@@ -78,7 +88,16 @@ def _list_resource_descriptors(args, _):
   pattern = args['type'] or '*'
   descriptors = gcm.ResourceDescriptors(project_id=project_id)
   dataframe = descriptors.as_dataframe(pattern=pattern)
-  return _render_dataframe(dataframe, show_index=False)
+  return _render_dataframe(dataframe)
+
+
+def _list_groups(args, _):
+  """Lists the groups in the project."""
+  project_id = args['project']
+  pattern = args['name'] or '*'
+  groups = gcm.Groups(project_id=project_id)
+  dataframe = groups.as_dataframe(pattern=pattern)
+  return _render_dataframe(dataframe)
 
 
 def _render_dataframe(dataframe):

--- a/datalab/stackdriver/monitoring/__init__.py
+++ b/datalab/stackdriver/monitoring/__init__.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 from google.cloud.monitoring import Aligner, Reducer
+from ._group import Groups
 from ._metric import MetricDescriptors
 from ._query import Query
 from ._query_metadata import QueryMetadata

--- a/datalab/stackdriver/monitoring/_group.py
+++ b/datalab/stackdriver/monitoring/_group.py
@@ -1,0 +1,88 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations under
+# the License.
+
+"""Groups for the Google Monitoring API."""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import object
+
+import collections
+import fnmatch
+
+import pandas
+
+import datalab.context
+
+from . import _utils
+
+
+class Groups(object):
+  """Represents a list of Stackdriver groups for a project."""
+
+  _DISPLAY_HEADERS = ('Group ID', 'Group name', 'Parent ID', 'Parent name',
+                      'Is cluster', 'Filter')
+
+  def __init__(self, project_id=None, context=None):
+    """Initializes the Groups for a Stackdriver project.
+
+    Args:
+      project_id: An optional project ID or number to override the one provided
+          by the context.
+      context: An optional Context object to use instead of the global default.
+    """
+    self._context = context or datalab.context.Context.default()
+    self._project_id = project_id or self._context.project_id
+    self._client = _utils.make_client(project_id, context)
+    self._group_dict = None
+
+  def list(self, pattern='*'):
+    """Returns a list of groups that match the filters.
+
+    Args:
+      pattern: An optional pattern to filter the groups based on their display
+          name. This can include Unix shell-style wildcards. E.g.
+          ``"Production*"``.
+
+    Returns:
+      A list of Group objects that match the filters.
+    """
+    if self._group_dict is None:
+      self._group_dict = collections.OrderedDict(
+          (group.id, group) for group in self._client.list_groups())
+
+    return [group for group in self._group_dict.values()
+            if fnmatch.fnmatch(group.display_name, pattern)]
+
+  def as_dataframe(self, pattern='*', max_rows=None):
+    """Creates a pandas dataframe from the groups that match the filters.
+
+    Args:
+      pattern: An optional pattern to further filter the groups. This can
+          include Unix shell-style wildcards. E.g. ``"Production *"``,
+          ``"*-backend"``.
+      max_rows: The maximum number of groups to return. If None, return all.
+
+    Returns:
+      A pandas dataframe containing matching groups.
+    """
+    data = []
+    for i, group in enumerate(self.list(pattern)):
+      if max_rows is not None and i >= max_rows:
+        break
+      parent = self._group_dict.get(group.parent_id)
+      parent_display_name = '' if parent is None else parent.display_name
+      data.append([
+          group.id, group.display_name, group.parent_id,
+          parent_display_name, group.is_cluster, group.filter])
+
+    return pandas.DataFrame(data, columns=self._DISPLAY_HEADERS)

--- a/docs/datalab.stackdriver.monitoring.rst
+++ b/docs/datalab.stackdriver.monitoring.rst
@@ -4,6 +4,9 @@ datalab.stackdriver.monitoring package
 Module contents
 ---------------
 
+.. autoclass:: datalab.stackdriver.monitoring.Groups
+    :members:
+
 .. autoclass:: datalab.stackdriver.monitoring.MetricDescriptors
     :members:
 

--- a/tests/main.py
+++ b/tests/main.py
@@ -40,6 +40,7 @@ import kernel.module_tests
 import kernel.sql_tests
 import kernel.storage_tests
 import kernel.utils_tests
+import stackdriver.monitoring.group_tests
 import stackdriver.monitoring.metric_tests
 import stackdriver.monitoring.resource_tests
 import stackdriver.monitoring.query_metadata_tests
@@ -76,6 +77,7 @@ _TEST_MODULES = [
     kernel.sql_tests,
     kernel.storage_tests,
     kernel.utils_tests,
+    stackdriver.monitoring.group_tests,
     stackdriver.monitoring.metric_tests,
     stackdriver.monitoring.resource_tests,
     stackdriver.monitoring.query_metadata_tests,

--- a/tests/main.py
+++ b/tests/main.py
@@ -40,6 +40,7 @@ import kernel.module_tests
 import kernel.sql_tests
 import kernel.storage_tests
 import kernel.utils_tests
+import stackdriver.commands.monitoring_tests
 import stackdriver.monitoring.group_tests
 import stackdriver.monitoring.metric_tests
 import stackdriver.monitoring.resource_tests
@@ -77,6 +78,7 @@ _TEST_MODULES = [
     kernel.sql_tests,
     kernel.storage_tests,
     kernel.utils_tests,
+    stackdriver.commands.monitoring_tests,
     stackdriver.monitoring.group_tests,
     stackdriver.monitoring.metric_tests,
     stackdriver.monitoring.resource_tests,

--- a/tests/stackdriver/commands/__init__.py
+++ b/tests/stackdriver/commands/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.

--- a/tests/stackdriver/commands/monitoring_tests.py
+++ b/tests/stackdriver/commands/monitoring_tests.py
@@ -1,0 +1,76 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+from __future__ import absolute_import
+import mock
+import unittest
+
+import pandas
+
+import datalab.stackdriver.commands._monitoring as monitoring_commands
+
+PROJECT = 'my-project'
+
+
+class TestCases(unittest.TestCase):
+
+  @mock.patch('datalab.stackdriver.commands._monitoring._render_dataframe')
+  @mock.patch('datalab.stackdriver.monitoring.MetricDescriptors')
+  def test_list_metric_descriptors(self, mock_metric_descriptors, mock_render_dataframe):
+    METRIC_TYPES = ['compute.googleapis.com/instances/cpu/utilization',
+                    'compute.googleapis.com/instances/cpu/usage_time']
+    DATAFRAME = pandas.DataFrame(METRIC_TYPES, columns=['Metric type'])
+    PATTERN = 'compute*cpu*'
+
+    mock_metric_class = mock_metric_descriptors.return_value
+    mock_metric_class.as_dataframe.return_value = DATAFRAME
+
+    monitoring_commands._list_metric_descriptors(
+        {'project': PROJECT, 'type': PATTERN}, None)
+
+    mock_metric_descriptors.assert_called_once_with(project_id=PROJECT)
+    mock_metric_class.as_dataframe.assert_called_once_with(pattern=PATTERN)
+    mock_render_dataframe.assert_called_once_with(DATAFRAME)
+
+  @mock.patch('datalab.stackdriver.commands._monitoring._render_dataframe')
+  @mock.patch('datalab.stackdriver.monitoring.ResourceDescriptors')
+  def test_list_resource_descriptors(self, mock_resource_descriptors, mock_render_dataframe):
+    RESOURCE_TYPES = ['gce_instance', 'aws_ec2_instance']
+    DATAFRAME = pandas.DataFrame(RESOURCE_TYPES, columns=['Resource type'])
+    PATTERN = '*instance*'
+
+    mock_resource_class = mock_resource_descriptors.return_value
+    mock_resource_class.as_dataframe.return_value = DATAFRAME
+
+    monitoring_commands._list_resource_descriptors(
+        {'project': PROJECT, 'type': PATTERN}, None)
+
+    mock_resource_descriptors.assert_called_once_with(project_id=PROJECT)
+    mock_resource_class.as_dataframe.assert_called_once_with(pattern=PATTERN)
+    mock_render_dataframe.assert_called_once_with(DATAFRAME)
+
+  @mock.patch('datalab.stackdriver.commands._monitoring._render_dataframe')
+  @mock.patch('datalab.stackdriver.monitoring.Groups')
+  def test_list_groups(self, mock_groups, mock_render_dataframe):
+    GROUP_IDS = ['GROUP-205', 'GROUP-101']
+    DATAFRAME = pandas.DataFrame(GROUP_IDS, columns=['Group ID'])
+    PATTERN = 'GROUP-*'
+
+    mock_group_class = mock_groups.return_value
+    mock_group_class.as_dataframe.return_value = DATAFRAME
+
+    monitoring_commands._list_groups(
+        {'project': PROJECT, 'name': PATTERN}, None)
+
+    mock_groups.assert_called_once_with(project_id=PROJECT)
+    mock_group_class.as_dataframe.assert_called_once_with(pattern=PATTERN)
+    mock_render_dataframe.assert_called_once_with(DATAFRAME)

--- a/tests/stackdriver/monitoring/group_tests.py
+++ b/tests/stackdriver/monitoring/group_tests.py
@@ -1,0 +1,133 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+from __future__ import absolute_import
+import mock
+from oauth2client.client import AccessTokenCredentials
+import unittest
+
+import datalab.context
+import datalab.stackdriver.monitoring as gcm
+
+PROJECT = 'my-project'
+GROUP_IDS = ['GROUP-205', 'GROUP-101']
+PARENT_IDS = [None, GROUP_IDS[0]]
+DISPLAY_NAMES = ['All Instances', 'GCE Instances']
+PARENT_DISPLAY_NAMES = ['', DISPLAY_NAMES[0]]
+FILTER_STRINGS = ['resource.type = ends_with("instance")',
+                  'resource.type = "gce_instance"']
+IS_CLUSTERS = [False, True]
+
+
+class TestCases(unittest.TestCase):
+
+  def setUp(self):
+    self.context = self._create_context()
+    self.groups = gcm.Groups(context=self.context)
+
+  @mock.patch('datalab.context._context.Context.default')
+  def test_constructor(self, mock_context_default):
+    mock_context_default.return_value = self.context
+
+    groups = gcm.Groups()
+
+    self.assertIs(groups._context, self.context)
+    self.assertIs(groups._project_id, self.context.project_id)
+    self.assertIsNone(groups._group_dict)
+
+    expected_client = gcm._utils.make_client(context=self.context)
+    self.assertEqual(groups._client.project, expected_client.project)
+    self.assertEqual(groups._client.connection.credentials,
+                     expected_client.connection.credentials)
+
+  @mock.patch('google.cloud.monitoring.Client.list_groups')
+  def test_list(self, mock_api_list_groups):
+    mock_api_list_groups.return_value = self._list_groups_get_result(
+        context=self.context)
+
+    group_list = self.groups.list()
+
+    mock_api_list_groups.assert_called_once_with()
+    self.assertEqual(len(group_list), 2)
+    self.assertEqual(group_list[0].id, GROUP_IDS[0])
+    self.assertEqual(group_list[1].id, GROUP_IDS[1])
+
+  @mock.patch('google.cloud.monitoring.Client.list_groups')
+  def test_list_w_pattern_match(self, mock_api_list_groups):
+    mock_api_list_groups.return_value = self._list_groups_get_result(
+        context=self.context)
+
+    group_list = self.groups.list(pattern='GCE*')
+
+    mock_api_list_groups.assert_called_once_with()
+    self.assertEqual(len(group_list), 1)
+    self.assertEqual(group_list[0].id, GROUP_IDS[1])
+
+  @mock.patch('google.cloud.monitoring.Client.list_groups')
+  def test_list_caching(self, mock_gcloud_list_groups):
+    mock_gcloud_list_groups.return_value = self._list_groups_get_result(
+        context=self.context)
+
+    actual_list1 = self.groups.list()
+    actual_list2 = self.groups.list()
+
+    mock_gcloud_list_groups.assert_called_once_with()
+    self.assertEqual(actual_list1, actual_list2)
+
+  @mock.patch('google.cloud.monitoring.Client.list_groups')
+  def test_as_dataframe(self, mock_gcloud_list_groups):
+    mock_gcloud_list_groups.return_value = self._list_groups_get_result(
+        context=self.context)
+    dataframe = self.groups.as_dataframe()
+    mock_gcloud_list_groups.assert_called_once_with()
+
+    expected_headers = list(gcm.Groups._DISPLAY_HEADERS)
+    self.assertEqual(dataframe.columns.tolist(), expected_headers)
+    self.assertEqual(dataframe.columns.names, [None])
+
+    self.assertEqual(dataframe.index.tolist(), list(range(len(GROUP_IDS))))
+    self.assertEqual(dataframe.index.names, [None])
+
+    expected_values = [list(row) for row in
+                       zip(GROUP_IDS, DISPLAY_NAMES, PARENT_IDS,
+                           PARENT_DISPLAY_NAMES, IS_CLUSTERS, FILTER_STRINGS)]
+    self.assertEqual(dataframe.values.tolist(), expected_values)
+
+  @mock.patch('google.cloud.monitoring.Client.list_groups')
+  def test_as_dataframe_w_all_args(self, mock_gcloud_list_groups):
+    mock_gcloud_list_groups.return_value = self._list_groups_get_result(
+        context=self.context)
+    dataframe = self.groups.as_dataframe(pattern='*Instance*', max_rows=1)
+    mock_gcloud_list_groups.assert_called_once_with()
+
+    expected_headers = list(gcm.Groups._DISPLAY_HEADERS)
+    self.assertEqual(dataframe.columns.tolist(), expected_headers)
+    self.assertEqual(dataframe.index.tolist(), [0])
+    self.assertEqual(dataframe.iloc[0, 0], GROUP_IDS[0])
+
+  @staticmethod
+  def _create_context(project_id='test'):
+    creds = AccessTokenCredentials('test_token', 'test_ua')
+    return datalab.context.Context(project_id, creds)
+
+  @staticmethod
+  def _list_groups_get_result(context):
+    client = gcm._utils.make_client(context=context)
+    groups = []
+    for group_id, parent_id, display_name, filter_string, is_cluster in zip(
+        GROUP_IDS, PARENT_IDS, DISPLAY_NAMES, FILTER_STRINGS, IS_CLUSTERS):
+      group = client.group(group_id=group_id, display_name=display_name,
+                           parent_id=parent_id, filter_string=filter_string,
+                           is_cluster=is_cluster)
+      groups.append(group)
+
+    return groups


### PR DESCRIPTION
Users can now list groups, via the library, as well as IPython cell magic.

E.g.

    from datalab.stackdriver import monitoring as gcm
    gcm.Groups().as_dataframe()

OR

    % monitoring list groups