### PR TITLE
Allow users to specify the content type when using %%storage write

### DIFF
--- a/datalab/storage/commands/_storage.py
+++ b/datalab/storage/commands/_storage.py
@@ -127,6 +127,7 @@ for help on a specific command.
                             required=True)
   write_parser.add_argument('-o', '--object', required=True,
                             help='The name of the destination GCS object to write')
+  write_parser.add_argument('-c', '--content_type', help='MIME type', default='text/plain')
   write_parser.set_defaults(func=_storage_write)
 
   return datalab.utils.commands.handle_magic_line(line, None, parser)
@@ -380,4 +381,4 @@ def _storage_write(args, _):
   ipy = IPython.get_ipython()
   contents = ipy.user_ns[args['variable']]
   # TODO(gram): would we want to to do any special handling here; e.g. for DataFrames?
-  target.write_to(str(contents), 'text/plain')
+  target.write_to(str(contents), args['content_type'])


### PR DESCRIPTION
Fixes #69 

The following code works with the changes in this PR:

```
import pandas as pd
import pickle
from StringIO import StringIO

# Create a local pickle file
df_1 = pd.DataFrame(data=[{1,2,3},{4,5,6}],columns=['a','b','c'])
df_1.to_pickle('my_pickle_file.pkl')

# Write pickle to Google Cloud Storage using %storage write
with open('my_pickle_file.pkl', 'rb') as f:
    my_pickle_var = bytearray(f.read())
    %storage write --variable my_pickle_var --object 'gs://my-project-example/my_pickle_file.pkl' -c 'application/octet-stream'

# Read pickle from Google Cloud storage using %storage read
%storage read --object 'gs://my-project-example/my_pickle_file.pkl' --variable remote_pickle
df_2 = pickle.load(StringIO(remote_pickle))
print(df_2)
```