### PR TITLE
Register Datalab specific magic commands as both line and cell magic

### DIFF
--- a/datalab/mlalpha/commands/_tensorboard.py
+++ b/datalab/mlalpha/commands/_tensorboard.py
@@ -20,9 +20,9 @@ import datalab.mlalpha
 import datalab.utils.commands
 
 
-@IPython.core.magic.register_line_magic
-def tensorboard(line):
-  """Implements the tensorboard line magic.
+@IPython.core.magic.register_line_cell_magic
+def tensorboard(line, cell=None):
+  """Implements the tensorboard cell magic.
 
   Args:
     line: the contents of the tensorboard line.
@@ -46,7 +46,7 @@ Execute tensorboard operations. Use "%tensorboard <command> -h" for help on a sp
                            required=True)
   stop_parser.set_defaults(func=_stop)
   namespace = datalab.utils.commands.notebook_environment()
-  return datalab.utils.commands.handle_magic_line(line, None, parser, namespace=namespace)
+  return datalab.utils.commands.handle_magic_line(line, cell, parser, namespace=namespace)
 
 
 def _list(args, _):

--- a/datalab/stackdriver/commands/_monitoring.py
+++ b/datalab/stackdriver/commands/_monitoring.py
@@ -23,9 +23,9 @@ import datalab.stackdriver.monitoring as gcm
 import datalab.utils.commands
 
 
-@IPython.core.magic.register_line_magic
-def monitoring(line):
-  """Implements the monitoring line magic for ipython notebooks.
+@IPython.core.magic.register_line_cell_magic
+def monitoring(line, cell=None):
+  """Implements the monitoring cell magic for ipython notebooks.
 
   Args:
     line: the contents of the storage line.
@@ -70,7 +70,7 @@ def monitoring(line):
       help='The name of the group(s) to list; can include wildchars.')
   list_group_parser.set_defaults(func=_list_groups)
 
-  return datalab.utils.commands.handle_magic_line(line, None, parser)
+  return datalab.utils.commands.handle_magic_line(line, cell, parser)
 
 
 def _list_metric_descriptors(args, _):

--- a/datalab/storage/commands/_storage.py
+++ b/datalab/storage/commands/_storage.py
@@ -51,9 +51,9 @@ def _extract_storage_api_response_error(message):
   return message
 
 
-@IPython.core.magic.register_line_magic
-def storage(line):
-  """Implements the storage line magic for ipython notebooks.
+@IPython.core.magic.register_line_cell_magic
+def storage(line, cell=None):
+  """Implements the storage cell magic for ipython notebooks.
 
   Args:
     line: the contents of the storage line.
@@ -130,7 +130,7 @@ for help on a specific command.
   write_parser.add_argument('-c', '--content_type', help='MIME type', default='text/plain')
   write_parser.set_defaults(func=_storage_write)
 
-  return datalab.utils.commands.handle_magic_line(line, None, parser)
+  return datalab.utils.commands.handle_magic_line(line, cell, parser)
 
 
 def _parser_exit(status=0, message=None):

--- a/datalab/utils/commands/_extension.py
+++ b/datalab/utils/commands/_extension.py
@@ -25,8 +25,8 @@ from . import _commands
 from . import _utils
 
 
-@IPython.core.magic.register_line_magic
-def extension(line):
+@IPython.core.magic.register_line_cell_magic
+def extension(line, cell=None):
   """ Load an extension. Use %extension --help for more details. """
   parser = _commands.CommandParser(prog='%extension', description="""
 Load an extension into Datalab. Currently only mathjax is supported.
@@ -34,7 +34,7 @@ Load an extension into Datalab. Currently only mathjax is supported.
   subparser = parser.subcommand('mathjax', 'Enabled MathJaX support in Datalab.')
   subparser.set_defaults(ext='mathjax')
   parser.set_defaults(func=_extension)
-  return _utils.handle_magic_line(line, None, parser)
+  return _utils.handle_magic_line(line, cell, parser)
 
 
 def _extension(args, cell):


### PR DESCRIPTION
Partial fix for #71 

The following Datalab magic commands were registered as line magic only:
```
%tensorboard
%monitoring
%storage
%extension
```

If the cell body contains data, line magic commands are automatically converted to cell magic commands.

Since the magic commands listed above are not registered for cell magic, we would see the following error in the Datalab console:
```
{"name":"app","hostname":"b476953e06bc","pid":52,"type":"jupyter","level":30,"msg":"[9000]: ERROR:root:Cell magic `%%tensorboard` not found (But line magic `%tensorboard` exists, did you mean that instead?).\n","time":"2016-09-29T23:56:51.188Z","v":0}
```

This PR should prevent the error from appearing in console.

I think this is only a partial fix for #71 because we still need to notify the user when there is data in the cell body which is not related to the magic command.  For example, a warning should be displayed for the following code snippet since `print(cars)` is unrelated to the `%storage` magic command.
```
%storage read --object gs://cloud-datalab-samples/cars.csv --variable cars
print(cars)
```