### PR TITLE
Performance fix for loading data into paged table. 

### DIFF
--- a/datalab/notebook/static/charting.ts
+++ b/datalab/notebook/static/charting.ts
@@ -854,6 +854,8 @@ module Charting {
     handlePageEvent(page:number):void {
       var offset = (page == 0) ? -1 : 1;
       this.firstRow += offset * this.pageSize;
+      this.refreshData.first = this.firstRow;
+      this.refreshData.count = this.pageSize;
       this.refresh(true);
     }
   }


### PR DESCRIPTION
Currently when user clicks next page on a paged table, it downloads ALL data for
that table which makes it very slow on clicking "next page" the first
time. Also it consumes memory unexpectedly. The fix adds the offset and
count to the query so only the data needed is downloaded.