### PR TITLE
Resolve issue introduced in #40 that prevented highlighting of SQL keywords

### DIFF
--- a/datalab/notebook/static/codemirror/mode/sql.js
+++ b/datalab/notebook/static/codemirror/mode/sql.js
@@ -24,7 +24,7 @@ define(["require", 'codemirror/lib/codemirror'], function (require, CodeMirror) 
     var keywords = wordRegexp([
       'ALL',
       'AND',
-      'ARRAY'
+      'ARRAY',
       'AS',
       'ASC',
       'BETWEEN',
@@ -33,7 +33,7 @@ define(["require", 'codemirror/lib/codemirror'], function (require, CodeMirror) 
       'CONTAINS',
       'COUNT',
       'CROSS',
-      'DELETE'
+      'DELETE',
       'DESC',
       'DISTINCT',
       'EACH',
@@ -47,7 +47,7 @@ define(["require", 'codemirror/lib/codemirror'], function (require, CodeMirror) 
       'IGNORE',
       'IN',
       'INNER',
-      'INSERT'
+      'INSERT',
       'IS',
       'JOIN',
       'LEFT',
@@ -72,11 +72,11 @@ define(["require", 'codemirror/lib/codemirror'], function (require, CodeMirror) 
       'TRUE',
       'UNION',
       'UNNEST',
-      'UPDATE'
-      'VALUES'
+      'UPDATE',
+      'VALUES',
       'WHEN',
       'WHERE',
-      'WITH'
+      'WITH',
       'WITHIN',
       'XOR',
 


### PR DESCRIPTION
Fixes #85 

Keyword highlighting is working again with `%%sql` ! 
![fixed](https://cloud.githubusercontent.com/assets/5184014/19373631/8c7ac92c-9193-11e6-993b-c863196a281a.png)

I'm sorry for introducing this bug, and glad that it is now fixed!