### PR TITLE
Remove no longer needed mathjax extension

### DIFF
--- a/datalab/utils/commands/_extension.py
+++ b/datalab/utils/commands/_extension.py
@@ -40,22 +40,8 @@ Load an extension into Datalab. Currently only mathjax is supported.
 def _extension(args, cell):
   ext = args['ext']
   if ext == 'mathjax':
-    url = "https://cdn.mathjax.org/mathjax/latest/MathJax.js"
-    config = 'TeX-AMS-MML_HTMLorMML'
-    return IPython.core.display.HTML("""
-      <script>
-        if (!window.mathjax_url) {
-          var script = document.createElement("script");
-          script.type = "text/javascript";
-          script.onload = function() {
-            window.mathjax_url="%s";
-            var mathjaxutils = require('notebook/js/mathjaxutils');
-            mathjaxutils.init();
-          };
-          script.src = "%s?config=%s&delayStartupUntil=configured";
-          document.getElementsByTagName("head")[0].appendChild(script);
-        }
-      </script>
-    """ % (url, url, config))
+    # TODO: remove this with the next version update
+    # MathJax is now loaded by default for all notebooks
+    return
   raise Exception('Unsupported extension %s' % ext)
 


### PR DESCRIPTION
MathJax is not added by default for all notebooks, it's not needed as an extension. We'll keep it for now for backward compatibility.