### PR TITLE
Add ability to set the default BigQuery SQL dialect

### DIFF
--- a/datalab/bigquery/__init__.py
+++ b/datalab/bigquery/__init__.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 
 from ._csv_options import CSVOptions
 from ._dataset import Dataset, Datasets
+from ._dialect import Dialect
 from ._federated_table import FederatedTable
 from ._job import Job
 from ._query import Query

--- a/datalab/bigquery/_api.py
+++ b/datalab/bigquery/_api.py
@@ -17,6 +17,7 @@ from past.builtins import basestring
 from builtins import object
 
 import datalab.utils
+import datalab.bigquery
 
 
 class Api(object):
@@ -124,7 +125,7 @@ class Api(object):
 
   def jobs_insert_query(self, sql, code=None, imports=None, table_name=None, append=False,
                         overwrite=False, dry_run=False, use_cache=True, batch=True,
-                        allow_large_results=False, table_definitions=None, dialect='legacy',
+                        allow_large_results=False, table_definitions=None, dialect=None,
                         billing_tier=None):
     """Issues a request to insert a query job.
 
@@ -160,6 +161,10 @@ class Api(object):
       Exception if there is an error performing the operation.
     """
     url = Api._ENDPOINT + (Api._JOBS_PATH % (self._project_id, ''))
+
+    if dialect is None:
+        dialect = datalab.bigquery.Dialect.default().bq_dialect
+
     data = {
         'kind': 'bigquery#job',
         'configuration': {

--- a/datalab/bigquery/_dialect.py
+++ b/datalab/bigquery/_dialect.py
@@ -1,0 +1,49 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+"""Google Cloud Platform library - BigQuery SQL Dialect"""
+from __future__ import absolute_import
+
+
+class Dialect(object):
+  """
+  Represents the default BigQuery SQL dialect
+  """
+  _global_dialect = None
+
+  def __init__(self, bq_dialect):
+    self._global_dialect = bq_dialect
+
+  @property
+  def bq_dialect(self):
+    """Retrieves the value of the bq_dialect property.
+
+    Returns:
+      The default BigQuery SQL dialect
+    """
+    return self._global_dialect
+
+  def set_bq_dialect(self, bq_dialect):
+    """ Set the default BigQuery SQL dialect"""
+    if bq_dialect in ['legacy', 'standard']:
+      self._global_dialect = bq_dialect
+
+  @staticmethod
+  def default():
+    """Retrieves the default BigQuery SQL dialect, creating it if necessary.
+
+    Returns:
+      An initialized and shared instance of a Dialect object.
+    """
+    if Dialect._global_dialect is None:
+      Dialect._global_dialect = Dialect('legacy')
+    return Dialect._global_dialect

--- a/datalab/bigquery/_query.py
+++ b/datalab/bigquery/_query.py
@@ -206,7 +206,7 @@ class Query(object):
     """ Get the code for any Javascript UDFs used in the query. """
     return self._code
 
-  def results(self, use_cache=True, dialect='legacy', billing_tier=None):
+  def results(self, use_cache=True, dialect=None, billing_tier=None):
     """Retrieves table of results for the query. May block if the query must be executed first.
 
     Args:
@@ -229,7 +229,7 @@ class Query(object):
     return self._results.results
 
   def extract(self, storage_uris, format='csv', csv_delimiter=',', csv_header=True,
-              compress=False, use_cache=True, dialect='legacy', billing_tier=None):
+              compress=False, use_cache=True, dialect=None, billing_tier=None):
     """Exports the query results to GCS.
 
     Args:
@@ -262,7 +262,7 @@ class Query(object):
 
   @datalab.utils.async_method
   def extract_async(self, storage_uris, format='csv', csv_delimiter=',', csv_header=True,
-                    compress=False, use_cache=True, dialect='legacy', billing_tier=None):
+                    compress=False, use_cache=True, dialect=None, billing_tier=None):
     """Exports the query results to GCS. Returns a Job immediately.
 
     Note that there are two jobs that may need to be run sequentially, one to run the query,
@@ -300,7 +300,7 @@ class Query(object):
                         csv_header=csv_header, use_cache=use_cache, compress=compress,
                         dialect=dialect, billing_tier=billing_tier)
 
-  def to_dataframe(self, start_row=0, max_rows=None, use_cache=True, dialect='legacy',
+  def to_dataframe(self, start_row=0, max_rows=None, use_cache=True, dialect=None,
                    billing_tier=None):
     """ Exports the query results to a Pandas dataframe.
 
@@ -323,7 +323,7 @@ class Query(object):
         .to_dataframe(start_row=start_row, max_rows=max_rows)
 
   def to_file(self, path, format='csv', csv_delimiter=',', csv_header=True, use_cache=True,
-              dialect='legacy', billing_tier=None):
+              dialect=None, billing_tier=None):
     """Save the results to a local file in CSV format.
 
     Args:
@@ -351,7 +351,7 @@ class Query(object):
 
   @datalab.utils.async_method
   def to_file_async(self, path, format='csv', csv_delimiter=',', csv_header=True, use_cache=True,
-                    dialect='legacy', billing_tier=None):
+                    dialect=None, billing_tier=None):
     """Save the results to a local file in CSV format. Returns a Job immediately.
 
     Args:
@@ -376,7 +376,7 @@ class Query(object):
     return self.to_file(path, format=format, csv_delimiter=csv_delimiter, csv_header=csv_header,
                         use_cache=use_cache, dialect=dialect, billing_tier=billing_tier)
 
-  def sample(self, count=5, fields=None, sampling=None, use_cache=True, dialect='legacy',
+  def sample(self, count=5, fields=None, sampling=None, use_cache=True, dialect=None,
              billing_tier=None):
     """Retrieves a sampling of rows for the query.
 
@@ -405,7 +405,7 @@ class Query(object):
                                                                          dialect=dialect,
                                                                          billing_tier=billing_tier)
 
-  def execute_dry_run(self, dialect='legacy', billing_tier=None):
+  def execute_dry_run(self, dialect=None, billing_tier=None):
     """Dry run a query, to check the validity of the query and return some useful statistics.
 
     Args:
@@ -431,7 +431,7 @@ class Query(object):
     return query_result['statistics']['query']
 
   def execute_async(self, table_name=None, table_mode='create', use_cache=True,
-                    priority='interactive', allow_large_results=False, dialect='legacy',
+                    priority='interactive', allow_large_results=False, dialect=None,
                     billing_tier=None):
     """ Initiate the query and return a QueryJob.
 
@@ -493,7 +493,7 @@ class Query(object):
     return _query_job.QueryJob(job_id, table_name, self._sql, context=self._context)
 
   def execute(self, table_name=None, table_mode='create', use_cache=True, priority='interactive',
-              allow_large_results=False, dialect='legacy', billing_tier=None):
+              allow_large_results=False, dialect=None, billing_tier=None):
     """ Initiate the query, blocking until complete and then return the results.
 
     Args:

--- a/datalab/bigquery/_table.py
+++ b/datalab/bigquery/_table.py
@@ -237,7 +237,7 @@ class Table(object):
       return self
     raise Exception("Table %s could not be created as it already exists" % self._full_name)
 
-  def sample(self, fields=None, count=5, sampling=None, use_cache=True, dialect='legacy',
+  def sample(self, fields=None, count=5, sampling=None, use_cache=True, dialect=None,
              billing_tier=None):
     """Retrieves a sampling of data from the table.
 

--- a/datalab/bigquery/_view.py
+++ b/datalab/bigquery/_view.py
@@ -109,7 +109,7 @@ class View(object):
       return self
     raise Exception("View %s could not be created as it already exists" % str(self))
 
-  def sample(self, fields=None, count=5, sampling=None, use_cache=True, dialect='legacy',
+  def sample(self, fields=None, count=5, sampling=None, use_cache=True, dialect=None,
              billing_tier=None):
     """Retrieves a sampling of data from the view.
 
@@ -163,7 +163,7 @@ class View(object):
       self._table._info['view'] = {'query': query}
     self._table.update(friendly_name=friendly_name, description=description)
 
-  def results(self, use_cache=True, dialect='legacy', billing_tier=None):
+  def results(self, use_cache=True, dialect=None, billing_tier=None):
     """Materialize the view synchronously.
 
     If you require more control over the execution, use execute() or execute_async().
@@ -187,7 +187,7 @@ class View(object):
                                          billing_tier=billing_tier)
 
   def execute_async(self, table_name=None, table_mode='create', use_cache=True, priority='high',
-                    allow_large_results=False, dialect='legacy', billing_tier=None):
+                    allow_large_results=False, dialect=None, billing_tier=None):
     """Materialize the View asynchronously.
 
     Args:
@@ -219,7 +219,7 @@ class View(object):
                                                dialect=dialect, billing_tier=billing_tier)
 
   def execute(self, table_name=None, table_mode='create', use_cache=True, priority='high',
-              allow_large_results=False, dialect='legacy', billing_tier=None):
+              allow_large_results=False, dialect=None, billing_tier=None):
     """Materialize the View synchronously.
 
     Args:

--- a/datalab/bigquery/commands/_bigquery.py
+++ b/datalab/bigquery/commands/_bigquery.py
@@ -76,7 +76,7 @@ def _create_sample_subparser(parser):
   group.add_argument('-t', '--table', help='the name of the table to sample')
   group.add_argument('-v', '--view', help='the name of the view to sample')
   sample_parser.add_argument('-d', '--dialect', help='BigQuery SQL dialect',
-                             choices=['legacy', 'standard'], default='legacy')
+                             choices=['legacy', 'standard'])
   sample_parser.add_argument('-b', '--billing', type=int, help='BigQuery billing tier')
   sample_parser.add_argument('-c', '--count', type=int, default=10,
                              help='The number of rows to limit to, if sampling')
@@ -108,7 +108,7 @@ def _create_dry_run_subparser(parser):
   dry_run_parser.add_argument('-q', '--query',
                               help='The name of the query to be dry run')
   dry_run_parser.add_argument('-d', '--dialect', help='BigQuery SQL dialect',
-                             choices=['legacy', 'standard'], default='legacy')
+                             choices=['legacy', 'standard'])
   dry_run_parser.add_argument('-b', '--billing', type=int, help='BigQuery billing tier')
   dry_run_parser.add_argument('-v', '--verbose',
                               help='Show the expanded SQL that is being executed',
@@ -123,7 +123,7 @@ def _create_execute_subparser(parser):
   execute_parser.add_argument('-nc', '--nocache', help='Don\'t use previously cached results',
                               action='store_true')
   execute_parser.add_argument('-d', '--dialect', help='BigQuery SQL dialect',
-                             choices=['legacy', 'standard'], default='legacy')
+                             choices=['legacy', 'standard'])
   execute_parser.add_argument('-b', '--billing', type=int, help='BigQuery billing tier')
   execute_parser.add_argument('-m', '--mode', help='The table creation mode', default='create',
                               choices=['create', 'append', 'overwrite'])
@@ -145,7 +145,7 @@ def _create_pipeline_subparser(parser):
   pipeline_parser.add_argument('-nc', '--nocache', help='Don\'t use previously cached results',
                                action='store_true')
   pipeline_parser.add_argument('-d', '--dialect', help='BigQuery SQL dialect',
-                             choices=['legacy', 'standard'], default='legacy')
+                             choices=['legacy', 'standard'])
   pipeline_parser.add_argument('-b', '--billing', type=int, help='BigQuery billing tier')
   pipeline_parser.add_argument('-m', '--mode', help='The table creation mode', default='create',
                                choices=['create', 'append', 'overwrite'])

--- a/datalab/data/commands/_sql.py
+++ b/datalab/data/commands/_sql.py
@@ -78,7 +78,7 @@ with the specified name.
 """)
   sql_parser.add_argument('-m', '--module', help='The name for this SQL module')
   sql_parser.add_argument('-d', '--dialect', help='BigQuery SQL dialect',
-                             choices=['legacy', 'standard'], default='legacy')
+                             choices=['legacy', 'standard'])
   sql_parser.add_argument('-b', '--billing', type=int, help='BigQuery billing tier')
   sql_parser.set_defaults(func=lambda args, cell: sql_cell(args, cell))
   return sql_parser

--- a/datalab/kernel/__init__.py
+++ b/datalab/kernel/__init__.py
@@ -110,10 +110,18 @@ def load_ipython_extension(shell):
     context = _context.Context.default()
     context.set_project_id(project_id)
 
+  def _get_bq_dialect():
+    return datalab.bigquery.Dialect.default().bq_dialect
+
+  def _set_bq_dialect(bq_dialect):
+    datalab.bigquery.Dialect.default().set_bq_dialect(bq_dialect)
+
   try:
     if 'datalab_project_id' not in _IPython.get_ipython().user_ns:
       _IPython.get_ipython().user_ns['datalab_project_id'] = _get_project_id
       _IPython.get_ipython().user_ns['set_datalab_project_id'] = _set_project_id
+      _IPython.get_ipython().user_ns['datalab_bq_dialect'] = _get_bq_dialect
+      _IPython.get_ipython().user_ns['set_datalab_bq_dialect'] = _set_bq_dialect
   except TypeError:
     pass
 


### PR DESCRIPTION
Closes #93

By default, Datalab will set the BigQuery SQL dialect to legacy for all queries.

Use `set_datalab_bq_dialect('standard')` to set the default BigQuery SQL dialect to Standard SQL for the notebook, and `datalab_bq_dialect()` to read the BigQuery SQL dialect specified for the notebook.

Note: If the dialect parameter is provided on a per query basis, then the dialect parameter for that query will be honored (i.e. we will ignore the notebook default).

For example,
If the SQL dialect for the notebook is set to legacy, the following query will still execute successfully since the dialect is specified on a per query basis.
```
%%sql -d standard
WITH UniqueNames2013 AS
(SELECT DISTINCT name
  FROM `bigquery-public-data.usa_names.usa_1910_2013`
  WHERE Year = 2013)
SELECT COUNT(*) FROM UniqueNames2013
```