### PR TITLE
Remove unused imports

### DIFF
--- a/datalab/bigquery/_table.py
+++ b/datalab/bigquery/_table.py
@@ -22,7 +22,6 @@ import calendar
 import codecs
 import csv
 import datetime
-import math
 import pandas
 import time
 import traceback

--- a/datalab/context/_project.py
+++ b/datalab/context/_project.py
@@ -15,8 +15,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from builtins import object
 
-import os
-
 import datalab.utils
 
 from . import _api

--- a/datalab/data/_csv.py
+++ b/datalab/data/_csv.py
@@ -23,7 +23,7 @@ import csv
 import os
 import pandas as pd
 import random
-from sklearn.feature_extraction.text import CountVectorizer
+
 try:
     from StringIO import StringIO
 except ImportError:

--- a/datalab/data/_sql_module.py
+++ b/datalab/data/_sql_module.py
@@ -18,7 +18,6 @@ from past.builtins import basestring
 from builtins import object
 
 import shlex
-import types
 
 from . import _sql_statement
 from . import _utils

--- a/datalab/mlalpha/_cloud_predictor.py
+++ b/datalab/mlalpha/_cloud_predictor.py
@@ -12,16 +12,10 @@
 
 
 from googleapiclient import discovery
-import json
-from numbers import Number
 import pandas as pd
-
-import google.cloud.ml as ml
 
 import datalab.context
 import datalab.utils
-
-from . import _metadata
 
 
 # TODO(qimingj) Remove once the API is public since it will no longer be needed

--- a/datalab/mlalpha/_cloud_runner.py
+++ b/datalab/mlalpha/_cloud_runner.py
@@ -12,9 +12,6 @@
 
 import datetime
 from googleapiclient import discovery
-import json
-import google.cloud.ml as ml
-import os
 
 import datalab.context
 

--- a/datalab/mlalpha/_dataset.py
+++ b/datalab/mlalpha/_dataset.py
@@ -17,7 +17,7 @@ import numpy as np
 import os
 import pandas as pd
 import pandas_profiling
-from plotly.graph_objs import Bar, Figure, Histogram, Layout, Scatter, Scatter3d
+from plotly.graph_objs import Histogram, Scatter, Scatter3d
 from plotly.offline import iplot
 from plotly import tools
 import seaborn as sns

--- a/datalab/mlalpha/_local_predictor.py
+++ b/datalab/mlalpha/_local_predictor.py
@@ -17,7 +17,6 @@ from numbers import Number
 import numpy
 import os
 import pandas as pd
-import yaml
 
 import google.cloud.ml as ml
 

--- a/datalab/mlalpha/_local_runner.py
+++ b/datalab/mlalpha/_local_runner.py
@@ -15,7 +15,6 @@ import io
 import json
 import os
 import psutil
-import socket
 import subprocess
 import tempfile
 import time

--- a/datalab/utils/commands/_job.py
+++ b/datalab/utils/commands/_job.py
@@ -25,7 +25,6 @@ except ImportError:
 
 import datalab.utils
 
-from . import _commands
 from . import _html
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,6 @@
 
 import sys
 import os
-import shlex
 import sphinx_rtd_theme
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/tests/_util/http_tests.py
+++ b/tests/_util/http_tests.py
@@ -18,7 +18,6 @@ import unittest
 # The httplib2 import is implicitly used when mocking its functionality.
 # pylint: disable=unused-import
 from datalab.utils._http import Http
-from datalab.utils._http import httplib2
 
 
 class TestCases(unittest.TestCase):


### PR DESCRIPTION
This PR removes unused imports as reported by [flake8](https://pypi.python.org/pypi/flake8) with code [F401: module imported but unused](http://flake8.pycqa.org/en/latest/user/error-codes.html?highlight=f401)

When I ran `flake8`, I excluded `__init__.py` files by adding `# flake8: noqa` to the top of those files. I didn't include that change in this PR, although it can be added in another PR that enables flake8 on Travis (if decided). Here is the output from `flake8 --select=F401` after ignoring `__init__.py`

```
tony@tonypc:~/pydatalab-parthea/datalab$ flake8 --select=F401
./storage/_item.py:264:7: F841 local variable '_' is assigned to but never used
./storage/_bucket.py:229:7: F841 local variable '_' is assigned to but never used
./data/_csv.py:164:35: F821 undefined name 'xrange'
```