### PR TITLE
Allow users to save charts as a PNG file or in a python variable

### DIFF
--- a/datalab/bigquery/commands/_bigquery.py
+++ b/datalab/bigquery/commands/_bigquery.py
@@ -946,7 +946,8 @@ def _table_viewer(table, rows_per_page=25, fields=None):
             }},
             {{source_index: {source_index}, fields: '{fields}'}},
             0,
-            {total_rows});
+            {total_rows},
+            '');
         }}
       );
     </script>

--- a/datalab/utils/commands/_utils.py
+++ b/datalab/utils/commands/_utils.py
@@ -545,7 +545,8 @@ def parse_control_options(controls, variable_defaults=None):
 
 
 def chart_html(driver_name, chart_type, source, chart_options=None, fields='*', refresh_interval=0,
-               refresh_data=None, control_defaults=None, control_ids=None, schema=None):
+               refresh_data=None, control_defaults={}, control_ids=[], schema=None,
+               output_location=''):
   """ Return HTML for a chart.
 
   Args:
@@ -566,6 +567,8 @@ def chart_html(driver_name, chart_type, source, chart_options=None, fields='*', 
         including this one.
     control_ids: the DIV IDs for controls that are shared across charts including this one.
     schema: an optional schema for the data; if not supplied one will be inferred.
+    output_location: optionally output the chart image to either a PNG file or python variable
+        which contains the chart output as a base64 encoded string.
 
   Returns:
     A string containing the HTML for the chart.
@@ -573,10 +576,6 @@ def chart_html(driver_name, chart_type, source, chart_options=None, fields='*', 
   """
   div_id = _html.Html.next_id()
   controls_html = ''
-  if control_defaults is None:
-    control_defaults = {}
-  if control_ids is None:
-    control_ids = []
   if chart_options is not None and 'variables' in chart_options:
     controls = chart_options['variables']
     del chart_options['variables']  # Just to make sure GCharts doesn't see them.
@@ -634,7 +633,8 @@ def chart_html(driver_name, chart_type, source, chart_options=None, fields='*', 
               {options},
               {refresh_data},
               {refresh_interval},
-              {total_rows});
+              {total_rows},
+              '{output_location}');
           }}
         );
     </script>
@@ -661,7 +661,8 @@ def chart_html(driver_name, chart_type, source, chart_options=None, fields='*', 
               refresh_data=json.dumps(refresh_data, cls=datalab.utils.JSONEncoder),
               refresh_interval=refresh_interval,
               control_ids=str(control_ids),
-              total_rows=total_count)
+              total_rows=total_count,
+              output_location=output_location)
 
 
 def profile_df(df):

--- a/tests/kernel/chart_tests.py
+++ b/tests/kernel/chart_tests.py
@@ -36,11 +36,13 @@ class TestCases(unittest.TestCase):
 
   def test_chart_cell(self):
     t = [{'country': 'US', 'quantity': 100}, {'country': 'ZA', 'quantity': 50}]
-    chart = datalab.utils.commands._chart._chart_cell({'chart': 'geo', 'data': t, 'fields': None}, '')
+    chart = datalab.utils.commands._chart._chart_cell({'chart': 'geo', 'data': t, 'fields': None,
+                                                       'output': 'chart.png'}, '')
     self.assertTrue(chart.find('charts.render(') > 0)
     self.assertTrue(chart.find('\'geo\'') > 0)
     self.assertTrue(chart.find('"fields": "*"') > 0)
-    self.assertTrue(chart.find('{"c": [{"v": "US"}, {"v": 100}]}') > 0 or 
+    self.assertTrue(chart.find('chart.png') > 0)
+    self.assertTrue(chart.find('{"c": [{"v": "US"}, {"v": 100}]}') > 0 or
                     chart.find('{"c": [{"v": 100}, {"v": "US"}]}') > 0)
     self.assertTrue(chart.find('{"c": [{"v": "ZA"}, {"v": 50}]}') > 0 or
                     chart.find('{"c": [{"v": 50}, {"v": "ZA"}]}') > 0)


### PR DESCRIPTION
Closes googledatalab/datalab#783

When using the `%%chart` magic command, allow users to export the chart image as either PNG or in a python variable as a base64 encoded string.

To save the chart as a PNG file, use the following sample code:

```
data = [
        {'date': '2016/01/01', 'count': 10}, 
        {'date': '2016/01/02', 'count': 35}, 
        {'date': '2016/01/03', 'count': 25} 
       ]
%chart pie -d data --output my_cool_chart.png
```

Alternatively, specify the name of a python variable where the chart data will be exported in base64 encoded string format.

```
data = [
        {'date': '2016/01/01', 'count': 10}, 
        {'date': '2016/01/02', 'count': 35}, 
        {'date': '2016/01/03', 'count': 25} 
       ]
%chart pie -d data --output my_cool_chart
```

Followed by:
```
from IPython.display import Image
Image(my_cool_chart) 
```

![screenshot from 2016-12-04 23-01-22](https://cloud.githubusercontent.com/assets/5184014/20873539/59b4728e-ba76-11e6-8e44-46250f743c76.png)
