### PR TITLE
Flake8 configuration. Set max line length to 100. Ignore E111, E114

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,11 @@
 [metadata]
 description-file = README.md
 
+[flake8]
+max-line-length = 100
+ignore =
+    # Indentation is not a multiple of four
+    E111,
+    # Indentation is not a multiple of four (comment)
+    E114
+


### PR DESCRIPTION
During development I often use the flake8 syntax checker. I manually update the `setup.cfg` file to ignore the following:
- Only report warnings if line length exceeds 100
- Ignore the warning: "Indentation is not a multiple of four"

I'd like to submit this configuration into the pydatalab project.

I use the following command to check the syntax of my branch against master prior to committing:
`git diff master | flake8 --diff`

Would it be helpful to add this command to Travis CI ?

(If there is a concern that builds will start to fail in the short term, a potential solution could be to display the output of the command rather than cause builds to fail. Although having a build failure may help trigger an  update the flake8 configuration or clean up of code after pushing)