### PR TITLE
Use -e in all shell scripts to fail on error

### DIFF
--- a/install-no-virtualenv.sh
+++ b/install-no-virtualenv.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/install-virtualenv.sh
+++ b/install-virtualenv.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # Copyright 2016 Google Inc. All rights reserved.
 #

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # Copyright 2016 Google Inc. All rights reserved.
 #


### PR DESCRIPTION
Use -e in all shell scripts to fail on error.  It was difficult to spot the error in #106 while building pydatalab. I actually noticed the error while building Datalab because the Datalab build scripts already have `-e`.