### PR TITLE
Resolve build error: Duplicate identifier '_this'

### DIFF
--- a/datalab/notebook/static/charting.ts
+++ b/datalab/notebook/static/charting.ts
@@ -807,9 +807,9 @@ module Charting {
         this.base_options.showRowNumber = true;
       }
       this.base_options.sort = 'disable';
-      var _this = this;
+      var __this = this;
       this.driver.addPageChangedHandler(function (page:number) {
-        _this.handlePageEvent(page);
+        __this.handlePageEvent(page);
       });
     }
 


### PR DESCRIPTION
Fixes #106. As described in the error message, the typescript compiler already uses a variable `_this` so we need to use a different variable name. 

Resolves: `error TS2399: Duplicate identifier '_this'. Compiler uses variable declaration '_this' to capture 'this' reference.`