### PR TITLE
Datalab Inception (image classification) solution.

### DIFF
--- a/solutionbox/inception/datalab_solutions/__init__.py
+++ b/solutionbox/inception/datalab_solutions/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2017 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/solutionbox/inception/datalab_solutions/__init__.py
+++ b/solutionbox/inception/datalab_solutions/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+

--- a/solutionbox/inception/datalab_solutions/inception/__init__.py
+++ b/solutionbox/inception/datalab_solutions/inception/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+
+from ._package import local_preprocess, cloud_preprocess, local_train, cloud_train, local_predict, cloud_predict

--- a/solutionbox/inception/datalab_solutions/inception/_cloud.py
+++ b/solutionbox/inception/datalab_solutions/inception/_cloud.py
@@ -1,0 +1,140 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Cloud implementation for preprocessing, training and prediction for inception model.
+"""
+
+import apache_beam as beam
+import base64
+import collections
+import datetime
+from googleapiclient import discovery
+import google.cloud.ml as ml
+import logging
+import os
+
+from . import _model
+from . import _preprocess
+from . import _trainer
+from . import _util
+
+
+_CLOUDML_DISCOVERY_URL = 'https://storage.googleapis.com/cloud-ml/discovery/' \
+                         'ml_v1beta1_discovery.json'
+_TF_GS_URL= 'gs://cloud-datalab/deploy/tf/tensorflow-0.12.0rc0-cp27-none-linux_x86_64.whl'
+
+
+class Cloud(object):
+  """Class for cloud training, preprocessing and prediction."""
+
+  def __init__(self, project, checkpoint=None):
+    self._project = project
+    self._checkpoint = checkpoint
+    if self._checkpoint is None:
+      self._checkpoint = _util._DEFAULT_CHECKPOINT_GSURL
+
+  def preprocess(self, input_csvs, labels_file, output_dir, pipeline_option=None):
+    """Cloud preprocessing with Cloud DataFlow."""
+
+    job_name = 'preprocess-inception-' + datetime.datetime.now().strftime('%y%m%d-%H%M%S')
+    options = {
+        'staging_location': os.path.join(output_dir, 'tmp', 'staging'),
+        'temp_location': os.path.join(output_dir, 'tmp'),
+        'job_name': job_name,
+        'project': self._project,
+        'extra_packages': [ml.sdk_location, _util._PACKAGE_GS_URL, _TF_GS_URL],
+        'teardown_policy': 'TEARDOWN_ALWAYS',
+        'no_save_main_session': True
+    }
+    if pipeline_option is not None:
+      options.update(pipeline_option)
+
+    opts = beam.pipeline.PipelineOptions(flags=[], **options)
+    p = beam.Pipeline('DataflowPipelineRunner', options=opts)
+    _preprocess.configure_pipeline(
+        p, self._checkpoint, input_csvs, labels_file, output_dir, job_name)
+    p.run()
+
+  def train(self, labels_file, input_dir, batch_size, max_steps, output_path, credentials,
+            region, scale_tier):
+    """Cloud training with CloudML trainer service."""
+
+    num_classes = len(_util.get_labels(labels_file))
+    job_id = 'inception_train_' + datetime.datetime.now().strftime('%y%m%d_%H%M%S')
+    job_args_dict = {
+      'input_dir': input_dir,
+      'output_path': output_path,
+      'max_steps': max_steps,
+      'batch_size': batch_size,
+      'num_classes': num_classes,
+      'checkpoint': self._checkpoint
+    }
+    # convert job_args from dict to list as service required.
+    job_args = []
+    for k,v in job_args_dict.iteritems():
+      if isinstance(v, list):
+        for item in v:
+
+          job_args.append('--' + k)
+          job_args.append(str(item))
+      else:
+        job_args.append('--' + k)
+        job_args.append(str(v))
+
+    job_request = {
+      'package_uris': _util._PACKAGE_GS_URL,
+      'python_module': 'datalab_solutions.inception.task',
+      'scale_tier': scale_tier,
+      'region': region,
+      'args': job_args
+    }
+    job = {
+      'job_id': job_id,
+      'training_input': job_request,
+    }
+    cloudml = discovery.build('ml', 'v1beta1', discoveryServiceUrl=_CLOUDML_DISCOVERY_URL,
+        credentials=credentials)
+    request = cloudml.projects().jobs().create(body=job,
+                                               parent='projects/' + self._project)
+    request.headers['user-agent'] = 'GoogleCloudDataLab/1.0'
+    job_info = request.execute()
+    return job_info
+
+  def predict(self, model_id, image_files, labels_file, credentials):
+    """Cloud prediction with CloudML prediction service."""
+
+    labels = _util.get_labels(labels_file)
+    data = []
+    for ii, img_file in enumerate(image_files):
+      with ml.util._file.open_local_or_gcs(img_file, 'rb') as f:
+        img = base64.b64encode(f.read())
+      data.append({
+        'key': str(ii),
+        'image_bytes': {'b64': img}
+      })
+    parts = model_id.split('.')
+    if len(parts) != 2:
+      raise Exception('Invalid model name for cloud prediction. Use "model.version".')    
+    full_version_name = ('projects/%s/models/%s/versions/%s' % (self._project, parts[0], parts[1]))
+    api = discovery.build('ml', 'v1beta1', credentials=credentials,
+                          discoveryServiceUrl=_CLOUDML_DISCOVERY_URL)
+    request = api.projects().predict(body={'instances': data}, name=full_version_name)
+    job_results = request.execute()
+    if 'predictions' not in job_results:
+      raise Exception('Invalid response from service. Cannot find "predictions" in response.')
+    predictions = job_results['predictions']
+    labels_and_scores = [(labels[x['prediction']], x['scores'][x['prediction']])
+                         for x in predictions]
+    return labels_and_scores

--- a/solutionbox/inception/datalab_solutions/inception/_inceptionlib.py
+++ b/solutionbox/inception/datalab_solutions/inception/_inceptionlib.py
@@ -1,0 +1,599 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Inception model building libraries.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+slim = tf.contrib.slim
+trunc_normal = lambda stddev: tf.truncated_normal_initializer(0.0, stddev)
+
+
+def inception_v3_base(inputs,
+                      final_endpoint='Mixed_7c',
+                      min_depth=16,
+                      depth_multiplier=1.0,
+                      scope=None):
+  """Inception model from http://arxiv.org/abs/1512.00567.
+
+  Constructs an Inception v3 network from inputs to the given final endpoint.
+  This method can construct the network up to the final inception block
+  Mixed_7c.
+
+  Note that the names of the layers in the paper do not correspond to the names
+  of the endpoints registered by this function although they build the same
+  network.
+
+  Here is a mapping from the old_names to the new names:
+  Old name          | New name
+  =======================================
+  conv0             | Conv2d_1a_3x3
+  conv1             | Conv2d_2a_3x3
+  conv2             | Conv2d_2b_3x3
+  pool1             | MaxPool_3a_3x3
+  conv3             | Conv2d_3b_1x1
+  conv4             | Conv2d_4a_3x3
+  pool2             | MaxPool_5a_3x3
+  mixed_35x35x256a  | Mixed_5b
+  mixed_35x35x288a  | Mixed_5c
+  mixed_35x35x288b  | Mixed_5d
+  mixed_17x17x768a  | Mixed_6a
+  mixed_17x17x768b  | Mixed_6b
+  mixed_17x17x768c  | Mixed_6c
+  mixed_17x17x768d  | Mixed_6d
+  mixed_17x17x768e  | Mixed_6e
+  mixed_8x8x1280a   | Mixed_7a
+  mixed_8x8x2048a   | Mixed_7b
+  mixed_8x8x2048b   | Mixed_7c
+
+  Args:
+    inputs: a tensor of size [batch_size, height, width, channels].
+    final_endpoint: specifies the endpoint to construct the network up to. It
+      can be one of ['Conv2d_1a_3x3', 'Conv2d_2a_3x3', 'Conv2d_2b_3x3',
+      'MaxPool_3a_3x3', 'Conv2d_3b_1x1', 'Conv2d_4a_3x3', 'MaxPool_5a_3x3',
+      'Mixed_5b', 'Mixed_5c', 'Mixed_5d', 'Mixed_6a', 'Mixed_6b', 'Mixed_6c',
+      'Mixed_6d', 'Mixed_6e', 'Mixed_7a', 'Mixed_7b', 'Mixed_7c'].
+    min_depth: Minimum depth value (number of channels) for all convolution ops.
+      Enforced when depth_multiplier < 1, and not an active constraint when
+      depth_multiplier >= 1.
+    depth_multiplier: Float multiplier for the depth (number of channels)
+      for all convolution ops. The value must be greater than zero. Typical
+      usage will be to set this value in (0, 1) to reduce the number of
+      parameters or computation cost of the model.
+    scope: Optional variable_scope.
+
+  Returns:
+    tensor_out: output tensor corresponding to the final_endpoint.
+    end_points: a set of activations for external use, for example summaries or
+                losses.
+
+  Raises:
+    ValueError: if final_endpoint is not set to one of the predefined values,
+                or depth_multiplier <= 0
+  """
+  # end_points will collect relevant activations for external use, for example
+  # summaries or losses.
+  end_points = {}
+
+  if depth_multiplier <= 0:
+    raise ValueError('depth_multiplier is not greater than zero.')
+  depth = lambda d: max(int(d * depth_multiplier), min_depth)
+
+  with tf.variable_scope(scope, 'InceptionV3', [inputs]):
+    with slim.arg_scope([slim.conv2d, slim.max_pool2d, slim.avg_pool2d],
+                        stride=1, padding='VALID'):
+      # 299 x 299 x 3
+      end_point = 'Conv2d_1a_3x3'
+      net = slim.conv2d(inputs, depth(32), [3, 3], stride=2, scope=end_point)
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+      # 149 x 149 x 32
+      end_point = 'Conv2d_2a_3x3'
+      net = slim.conv2d(net, depth(32), [3, 3], scope=end_point)
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+      # 147 x 147 x 32
+      end_point = 'Conv2d_2b_3x3'
+      net = slim.conv2d(net, depth(64), [3, 3], padding='SAME', scope=end_point)
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+      # 147 x 147 x 64
+      end_point = 'MaxPool_3a_3x3'
+      net = slim.max_pool2d(net, [3, 3], stride=2, scope=end_point)
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+      # 73 x 73 x 64
+      end_point = 'Conv2d_3b_1x1'
+      net = slim.conv2d(net, depth(80), [1, 1], scope=end_point)
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+      # 73 x 73 x 80.
+      end_point = 'Conv2d_4a_3x3'
+      net = slim.conv2d(net, depth(192), [3, 3], scope=end_point)
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+      # 71 x 71 x 192.
+      end_point = 'MaxPool_5a_3x3'
+      net = slim.max_pool2d(net, [3, 3], stride=2, scope=end_point)
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+      # 35 x 35 x 192.
+
+    # Inception blocks
+    with slim.arg_scope([slim.conv2d, slim.max_pool2d, slim.avg_pool2d],
+                        stride=1, padding='SAME'):
+      # mixed: 35 x 35 x 256.
+      end_point = 'Mixed_5b'
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
+          branch_0 = slim.conv2d(net, depth(64), [1, 1], scope='Conv2d_0a_1x1')
+        with tf.variable_scope('Branch_1'):
+          branch_1 = slim.conv2d(net, depth(48), [1, 1], scope='Conv2d_0a_1x1')
+          branch_1 = slim.conv2d(branch_1, depth(64), [5, 5],
+                                 scope='Conv2d_0b_5x5')
+        with tf.variable_scope('Branch_2'):
+          branch_2 = slim.conv2d(net, depth(64), [1, 1], scope='Conv2d_0a_1x1')
+          branch_2 = slim.conv2d(branch_2, depth(96), [3, 3],
+                                 scope='Conv2d_0b_3x3')
+          branch_2 = slim.conv2d(branch_2, depth(96), [3, 3],
+                                 scope='Conv2d_0c_3x3')
+        with tf.variable_scope('Branch_3'):
+          branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
+          branch_3 = slim.conv2d(branch_3, depth(32), [1, 1],
+                                 scope='Conv2d_0b_1x1')
+        net = tf.concat(3, [branch_0, branch_1, branch_2, branch_3])
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+
+      # mixed_1: 35 x 35 x 288.
+      end_point = 'Mixed_5c'
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
+          branch_0 = slim.conv2d(net, depth(64), [1, 1], scope='Conv2d_0a_1x1')
+        with tf.variable_scope('Branch_1'):
+          branch_1 = slim.conv2d(net, depth(48), [1, 1], scope='Conv2d_0b_1x1')
+          branch_1 = slim.conv2d(branch_1, depth(64), [5, 5],
+                                 scope='Conv_1_0c_5x5')
+        with tf.variable_scope('Branch_2'):
+          branch_2 = slim.conv2d(net, depth(64), [1, 1],
+                                 scope='Conv2d_0a_1x1')
+          branch_2 = slim.conv2d(branch_2, depth(96), [3, 3],
+                                 scope='Conv2d_0b_3x3')
+          branch_2 = slim.conv2d(branch_2, depth(96), [3, 3],
+                                 scope='Conv2d_0c_3x3')
+        with tf.variable_scope('Branch_3'):
+          branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
+          branch_3 = slim.conv2d(branch_3, depth(64), [1, 1],
+                                 scope='Conv2d_0b_1x1')
+        net = tf.concat(3, [branch_0, branch_1, branch_2, branch_3])
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+
+      # mixed_2: 35 x 35 x 288.
+      end_point = 'Mixed_5d'
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
+          branch_0 = slim.conv2d(net, depth(64), [1, 1], scope='Conv2d_0a_1x1')
+        with tf.variable_scope('Branch_1'):
+          branch_1 = slim.conv2d(net, depth(48), [1, 1], scope='Conv2d_0a_1x1')
+          branch_1 = slim.conv2d(branch_1, depth(64), [5, 5],
+                                 scope='Conv2d_0b_5x5')
+        with tf.variable_scope('Branch_2'):
+          branch_2 = slim.conv2d(net, depth(64), [1, 1], scope='Conv2d_0a_1x1')
+          branch_2 = slim.conv2d(branch_2, depth(96), [3, 3],
+                                 scope='Conv2d_0b_3x3')
+          branch_2 = slim.conv2d(branch_2, depth(96), [3, 3],
+                                 scope='Conv2d_0c_3x3')
+        with tf.variable_scope('Branch_3'):
+          branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
+          branch_3 = slim.conv2d(branch_3, depth(64), [1, 1],
+                                 scope='Conv2d_0b_1x1')
+        net = tf.concat(3, [branch_0, branch_1, branch_2, branch_3])
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+
+      # mixed_3: 17 x 17 x 768.
+      end_point = 'Mixed_6a'
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
+          branch_0 = slim.conv2d(net, depth(384), [3, 3], stride=2,
+                                 padding='VALID', scope='Conv2d_1a_1x1')
+        with tf.variable_scope('Branch_1'):
+          branch_1 = slim.conv2d(net, depth(64), [1, 1], scope='Conv2d_0a_1x1')
+          branch_1 = slim.conv2d(branch_1, depth(96), [3, 3],
+                                 scope='Conv2d_0b_3x3')
+          branch_1 = slim.conv2d(branch_1, depth(96), [3, 3], stride=2,
+                                 padding='VALID', scope='Conv2d_1a_1x1')
+        with tf.variable_scope('Branch_2'):
+          branch_2 = slim.max_pool2d(net, [3, 3], stride=2, padding='VALID',
+                                     scope='MaxPool_1a_3x3')
+        net = tf.concat(3, [branch_0, branch_1, branch_2])
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+
+      # mixed4: 17 x 17 x 768.
+      end_point = 'Mixed_6b'
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
+          branch_0 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
+        with tf.variable_scope('Branch_1'):
+          branch_1 = slim.conv2d(net, depth(128), [1, 1], scope='Conv2d_0a_1x1')
+          branch_1 = slim.conv2d(branch_1, depth(128), [1, 7],
+                                 scope='Conv2d_0b_1x7')
+          branch_1 = slim.conv2d(branch_1, depth(192), [7, 1],
+                                 scope='Conv2d_0c_7x1')
+        with tf.variable_scope('Branch_2'):
+          branch_2 = slim.conv2d(net, depth(128), [1, 1], scope='Conv2d_0a_1x1')
+          branch_2 = slim.conv2d(branch_2, depth(128), [7, 1],
+                                 scope='Conv2d_0b_7x1')
+          branch_2 = slim.conv2d(branch_2, depth(128), [1, 7],
+                                 scope='Conv2d_0c_1x7')
+          branch_2 = slim.conv2d(branch_2, depth(128), [7, 1],
+                                 scope='Conv2d_0d_7x1')
+          branch_2 = slim.conv2d(branch_2, depth(192), [1, 7],
+                                 scope='Conv2d_0e_1x7')
+        with tf.variable_scope('Branch_3'):
+          branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
+          branch_3 = slim.conv2d(branch_3, depth(192), [1, 1],
+                                 scope='Conv2d_0b_1x1')
+        net = tf.concat(3, [branch_0, branch_1, branch_2, branch_3])
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+
+      # mixed_5: 17 x 17 x 768.
+      end_point = 'Mixed_6c'
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
+          branch_0 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
+        with tf.variable_scope('Branch_1'):
+          branch_1 = slim.conv2d(net, depth(160), [1, 1], scope='Conv2d_0a_1x1')
+          branch_1 = slim.conv2d(branch_1, depth(160), [1, 7],
+                                 scope='Conv2d_0b_1x7')
+          branch_1 = slim.conv2d(branch_1, depth(192), [7, 1],
+                                 scope='Conv2d_0c_7x1')
+        with tf.variable_scope('Branch_2'):
+          branch_2 = slim.conv2d(net, depth(160), [1, 1], scope='Conv2d_0a_1x1')
+          branch_2 = slim.conv2d(branch_2, depth(160), [7, 1],
+                                 scope='Conv2d_0b_7x1')
+          branch_2 = slim.conv2d(branch_2, depth(160), [1, 7],
+                                 scope='Conv2d_0c_1x7')
+          branch_2 = slim.conv2d(branch_2, depth(160), [7, 1],
+                                 scope='Conv2d_0d_7x1')
+          branch_2 = slim.conv2d(branch_2, depth(192), [1, 7],
+                                 scope='Conv2d_0e_1x7')
+        with tf.variable_scope('Branch_3'):
+          branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
+          branch_3 = slim.conv2d(branch_3, depth(192), [1, 1],
+                                 scope='Conv2d_0b_1x1')
+        net = tf.concat(3, [branch_0, branch_1, branch_2, branch_3])
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+      # mixed_6: 17 x 17 x 768.
+      end_point = 'Mixed_6d'
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
+          branch_0 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
+        with tf.variable_scope('Branch_1'):
+          branch_1 = slim.conv2d(net, depth(160), [1, 1], scope='Conv2d_0a_1x1')
+          branch_1 = slim.conv2d(branch_1, depth(160), [1, 7],
+                                 scope='Conv2d_0b_1x7')
+          branch_1 = slim.conv2d(branch_1, depth(192), [7, 1],
+                                 scope='Conv2d_0c_7x1')
+        with tf.variable_scope('Branch_2'):
+          branch_2 = slim.conv2d(net, depth(160), [1, 1], scope='Conv2d_0a_1x1')
+          branch_2 = slim.conv2d(branch_2, depth(160), [7, 1],
+                                 scope='Conv2d_0b_7x1')
+          branch_2 = slim.conv2d(branch_2, depth(160), [1, 7],
+                                 scope='Conv2d_0c_1x7')
+          branch_2 = slim.conv2d(branch_2, depth(160), [7, 1],
+                                 scope='Conv2d_0d_7x1')
+          branch_2 = slim.conv2d(branch_2, depth(192), [1, 7],
+                                 scope='Conv2d_0e_1x7')
+        with tf.variable_scope('Branch_3'):
+          branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
+          branch_3 = slim.conv2d(branch_3, depth(192), [1, 1],
+                                 scope='Conv2d_0b_1x1')
+        net = tf.concat(3, [branch_0, branch_1, branch_2, branch_3])
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+
+      # mixed_7: 17 x 17 x 768.
+      end_point = 'Mixed_6e'
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
+          branch_0 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
+        with tf.variable_scope('Branch_1'):
+          branch_1 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
+          branch_1 = slim.conv2d(branch_1, depth(192), [1, 7],
+                                 scope='Conv2d_0b_1x7')
+          branch_1 = slim.conv2d(branch_1, depth(192), [7, 1],
+                                 scope='Conv2d_0c_7x1')
+        with tf.variable_scope('Branch_2'):
+          branch_2 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
+          branch_2 = slim.conv2d(branch_2, depth(192), [7, 1],
+                                 scope='Conv2d_0b_7x1')
+          branch_2 = slim.conv2d(branch_2, depth(192), [1, 7],
+                                 scope='Conv2d_0c_1x7')
+          branch_2 = slim.conv2d(branch_2, depth(192), [7, 1],
+                                 scope='Conv2d_0d_7x1')
+          branch_2 = slim.conv2d(branch_2, depth(192), [1, 7],
+                                 scope='Conv2d_0e_1x7')
+        with tf.variable_scope('Branch_3'):
+          branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
+          branch_3 = slim.conv2d(branch_3, depth(192), [1, 1],
+                                 scope='Conv2d_0b_1x1')
+        net = tf.concat(3, [branch_0, branch_1, branch_2, branch_3])
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+
+      # mixed_8: 8 x 8 x 1280.
+      end_point = 'Mixed_7a'
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
+          branch_0 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
+          branch_0 = slim.conv2d(branch_0, depth(320), [3, 3], stride=2,
+                                 padding='VALID', scope='Conv2d_1a_3x3')
+        with tf.variable_scope('Branch_1'):
+          branch_1 = slim.conv2d(net, depth(192), [1, 1], scope='Conv2d_0a_1x1')
+          branch_1 = slim.conv2d(branch_1, depth(192), [1, 7],
+                                 scope='Conv2d_0b_1x7')
+          branch_1 = slim.conv2d(branch_1, depth(192), [7, 1],
+                                 scope='Conv2d_0c_7x1')
+          branch_1 = slim.conv2d(branch_1, depth(192), [3, 3], stride=2,
+                                 padding='VALID', scope='Conv2d_1a_3x3')
+        with tf.variable_scope('Branch_2'):
+          branch_2 = slim.max_pool2d(net, [3, 3], stride=2, padding='VALID',
+                                     scope='MaxPool_1a_3x3')
+        net = tf.concat(3, [branch_0, branch_1, branch_2])
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+      # mixed_9: 8 x 8 x 2048.
+      end_point = 'Mixed_7b'
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
+          branch_0 = slim.conv2d(net, depth(320), [1, 1], scope='Conv2d_0a_1x1')
+        with tf.variable_scope('Branch_1'):
+          branch_1 = slim.conv2d(net, depth(384), [1, 1], scope='Conv2d_0a_1x1')
+          branch_1 = tf.concat(3, [
+              slim.conv2d(branch_1, depth(384), [1, 3], scope='Conv2d_0b_1x3'),
+              slim.conv2d(branch_1, depth(384), [3, 1], scope='Conv2d_0b_3x1')])
+        with tf.variable_scope('Branch_2'):
+          branch_2 = slim.conv2d(net, depth(448), [1, 1], scope='Conv2d_0a_1x1')
+          branch_2 = slim.conv2d(
+              branch_2, depth(384), [3, 3], scope='Conv2d_0b_3x3')
+          branch_2 = tf.concat(3, [
+              slim.conv2d(branch_2, depth(384), [1, 3], scope='Conv2d_0c_1x3'),
+              slim.conv2d(branch_2, depth(384), [3, 1], scope='Conv2d_0d_3x1')])
+        with tf.variable_scope('Branch_3'):
+          branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
+          branch_3 = slim.conv2d(
+              branch_3, depth(192), [1, 1], scope='Conv2d_0b_1x1')
+        net = tf.concat(3, [branch_0, branch_1, branch_2, branch_3])
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+
+      # mixed_10: 8 x 8 x 2048.
+      end_point = 'Mixed_7c'
+      with tf.variable_scope(end_point):
+        with tf.variable_scope('Branch_0'):
+          branch_0 = slim.conv2d(net, depth(320), [1, 1], scope='Conv2d_0a_1x1')
+        with tf.variable_scope('Branch_1'):
+          branch_1 = slim.conv2d(net, depth(384), [1, 1], scope='Conv2d_0a_1x1')
+          branch_1 = tf.concat(3, [
+              slim.conv2d(branch_1, depth(384), [1, 3], scope='Conv2d_0b_1x3'),
+              slim.conv2d(branch_1, depth(384), [3, 1], scope='Conv2d_0c_3x1')])
+        with tf.variable_scope('Branch_2'):
+          branch_2 = slim.conv2d(net, depth(448), [1, 1], scope='Conv2d_0a_1x1')
+          branch_2 = slim.conv2d(
+              branch_2, depth(384), [3, 3], scope='Conv2d_0b_3x3')
+          branch_2 = tf.concat(3, [
+              slim.conv2d(branch_2, depth(384), [1, 3], scope='Conv2d_0c_1x3'),
+              slim.conv2d(branch_2, depth(384), [3, 1], scope='Conv2d_0d_3x1')])
+        with tf.variable_scope('Branch_3'):
+          branch_3 = slim.avg_pool2d(net, [3, 3], scope='AvgPool_0a_3x3')
+          branch_3 = slim.conv2d(
+              branch_3, depth(192), [1, 1], scope='Conv2d_0b_1x1')
+        net = tf.concat(3, [branch_0, branch_1, branch_2, branch_3])
+      end_points[end_point] = net
+      if end_point == final_endpoint: return net, end_points
+    raise ValueError('Unknown final endpoint %s' % final_endpoint)
+
+
+def inception_v3(inputs,
+                 num_classes=1000,
+                 is_training=True,
+                 dropout_keep_prob=0.8,
+                 min_depth=16,
+                 depth_multiplier=1.0,
+                 prediction_fn=slim.softmax,
+                 spatial_squeeze=True,
+                 reuse=None,
+                 scope='InceptionV3'):
+  """Inception model from http://arxiv.org/abs/1512.00567.
+
+  "Rethinking the Inception Architecture for Computer Vision"
+
+  Christian Szegedy, Vincent Vanhoucke, Sergey Ioffe, Jonathon Shlens,
+  Zbigniew Wojna.
+
+  With the default arguments this method constructs the exact model defined in
+  the paper. However, one can experiment with variations of the inception_v3
+  network by changing arguments dropout_keep_prob, min_depth and
+  depth_multiplier.
+
+  The default image size used to train this network is 299x299.
+
+  Args:
+    inputs: a tensor of size [batch_size, height, width, channels].
+    num_classes: number of predicted classes.
+    is_training: whether is training or not.
+    dropout_keep_prob: the percentage of activation values that are retained.
+    min_depth: Minimum depth value (number of channels) for all convolution ops.
+      Enforced when depth_multiplier < 1, and not an active constraint when
+      depth_multiplier >= 1.
+    depth_multiplier: Float multiplier for the depth (number of channels)
+      for all convolution ops. The value must be greater than zero. Typical
+      usage will be to set this value in (0, 1) to reduce the number of
+      parameters or computation cost of the model.
+    prediction_fn: a function to get predictions out of logits.
+    spatial_squeeze: if True, logits is of shape is [B, C], if false logits is
+        of shape [B, 1, 1, C], where B is batch_size and C is number of classes.
+    reuse: whether or not the network and its variables should be reused. To be
+      able to reuse 'scope' must be given.
+    scope: Optional variable_scope.
+
+  Returns:
+    logits: the pre-softmax activations, a tensor of size
+      [batch_size, num_classes]
+    end_points: a dictionary from components of the network to the corresponding
+      activation.
+
+  Raises:
+    ValueError: if 'depth_multiplier' is less than or equal to zero.
+  """
+  if depth_multiplier <= 0:
+    raise ValueError('depth_multiplier is not greater than zero.')
+  depth = lambda d: max(int(d * depth_multiplier), min_depth)
+
+  with tf.variable_scope(scope, 'InceptionV3', [inputs, num_classes],
+                         reuse=reuse) as scope:
+    with slim.arg_scope([slim.batch_norm, slim.dropout],
+                        is_training=is_training):
+      net, end_points = inception_v3_base(
+          inputs, scope=scope, min_depth=min_depth,
+          depth_multiplier=depth_multiplier)
+
+      # Auxiliary Head logits
+      with slim.arg_scope([slim.conv2d, slim.max_pool2d, slim.avg_pool2d],
+                          stride=1, padding='SAME'):
+        aux_logits = end_points['Mixed_6e']
+        with tf.variable_scope('AuxLogits'):
+          aux_logits = slim.avg_pool2d(
+              aux_logits, [5, 5], stride=3, padding='VALID',
+              scope='AvgPool_1a_5x5')
+          aux_logits = slim.conv2d(aux_logits, depth(128), [1, 1],
+                                   scope='Conv2d_1b_1x1')
+
+          # Shape of feature map before the final layer.
+          kernel_size = _reduced_kernel_size_for_small_input(
+              aux_logits, [5, 5])
+          aux_logits = slim.conv2d(
+              aux_logits, depth(768), kernel_size,
+              weights_initializer=trunc_normal(0.01),
+              padding='VALID', scope='Conv2d_2a_{}x{}'.format(*kernel_size))
+          aux_logits = slim.conv2d(
+              aux_logits, num_classes, [1, 1], activation_fn=None,
+              normalizer_fn=None, weights_initializer=trunc_normal(0.001),
+              scope='Conv2d_2b_1x1')
+          if spatial_squeeze:
+            aux_logits = tf.squeeze(aux_logits, [1, 2], name='SpatialSqueeze')
+          end_points['AuxLogits'] = aux_logits
+
+      # Final pooling and prediction
+      with tf.variable_scope('Logits'):
+        kernel_size = _reduced_kernel_size_for_small_input(net, [8, 8])
+        net = slim.avg_pool2d(net, kernel_size, padding='VALID',
+                              scope='AvgPool_1a_{}x{}'.format(*kernel_size))
+        # 1 x 1 x 2048
+        net = slim.dropout(net, keep_prob=dropout_keep_prob, scope='Dropout_1b')
+        end_points['PreLogits'] = net
+        # 2048
+        logits = slim.conv2d(net, num_classes, [1, 1], activation_fn=None,
+                             normalizer_fn=None, scope='Conv2d_1c_1x1')
+        if spatial_squeeze:
+          logits = tf.squeeze(logits, [1, 2], name='SpatialSqueeze')
+        # 1000
+      end_points['Logits'] = logits
+      end_points['Predictions'] = prediction_fn(logits, scope='Predictions')
+  return logits, end_points
+inception_v3.default_image_size = 299
+
+
+def _reduced_kernel_size_for_small_input(input_tensor, kernel_size):
+  """Define kernel size which is automatically reduced for small input.
+
+  If the shape of the input images is unknown at graph construction time this
+  function assumes that the input images are is large enough.
+
+  Args:
+    input_tensor: input tensor of size [batch_size, height, width, channels].
+    kernel_size: desired kernel size of length 2: [kernel_height, kernel_width]
+
+  Returns:
+    a tensor with the kernel size.
+
+  TODO(jrru): Make this function work with unknown shapes. Theoretically, this
+  can be done with the code below. Problems are two-fold: (1) If the shape was
+  known, it will be lost. (2) inception.slim.ops._two_element_tuple cannot
+  handle tensors that define the kernel size.
+      shape = tf.shape(input_tensor)
+      return = tf.stack([tf.minimum(shape[1], kernel_size[0]),
+                        tf.minimum(shape[2], kernel_size[1])])
+
+  """
+  shape = input_tensor.get_shape().as_list()
+  if shape[1] is None or shape[2] is None:
+    kernel_size_out = kernel_size
+  else:
+    kernel_size_out = [min(shape[1], kernel_size[0]),
+                       min(shape[2], kernel_size[1])]
+  return kernel_size_out
+
+
+def inception_v3_arg_scope(weight_decay=0.00004,
+                           stddev=0.1,
+                           batch_norm_var_collection='moving_vars'):
+  """Defines the default InceptionV3 arg scope.
+
+  Args:
+    weight_decay: The weight decay to use for regularizing the model.
+    stddev: The standard deviation of the trunctated normal weight initializer.
+    batch_norm_var_collection: The name of the collection for the batch norm
+      variables.
+
+  Returns:
+    An `arg_scope` to use for the inception v3 model.
+  """
+  batch_norm_params = {
+      # Decay for the moving averages.
+      'decay': 0.9997,
+      # epsilon to prevent 0s in variance.
+      'epsilon': 0.001,
+      # collection containing update_ops.
+      'updates_collections': tf.GraphKeys.UPDATE_OPS,
+      # collection containing the moving mean and moving variance.
+      'variables_collections': {
+          'beta': None,
+          'gamma': None,
+          'moving_mean': [batch_norm_var_collection],
+          'moving_variance': [batch_norm_var_collection],
+      }
+  }
+
+  # Set weight_decay for weights in Conv and FC layers.
+  with slim.arg_scope([slim.conv2d, slim.fully_connected],
+                      weights_regularizer=slim.l2_regularizer(weight_decay)):
+    with slim.arg_scope(
+        [slim.conv2d],
+        weights_initializer=tf.truncated_normal_initializer(stddev=stddev),
+        activation_fn=tf.nn.relu,
+        normalizer_fn=slim.batch_norm,
+        normalizer_params=batch_norm_params) as sc:
+      return sc

--- a/solutionbox/inception/datalab_solutions/inception/_local.py
+++ b/solutionbox/inception/datalab_solutions/inception/_local.py
@@ -1,0 +1,79 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Local implementation for preprocessing, training and prediction for inception model.
+"""
+
+import apache_beam as beam
+import collections
+import datetime
+import json
+import os
+import tensorflow as tf
+
+from . import _preprocess
+from . import _model
+from . import _trainer
+from . import _util
+
+
+class Local(object):
+  """Class for local training, preprocessing and prediction."""
+
+  def __init__(self, checkpoint=None):
+    self._checkpoint = checkpoint
+    if self._checkpoint is None:
+      self._checkpoint = _util._DEFAULT_CHECKPOINT_GSURL
+
+  def preprocess(self, input_csvs, labels_file, output_dir):
+    """Local preprocessing with local DataFlow."""
+
+    job_id = 'inception_preprocessed_' + datetime.datetime.now().strftime('%y%m%d_%H%M%S')
+    p = beam.Pipeline('DirectPipelineRunner')
+    _preprocess.configure_pipeline(p, self._checkpoint, input_csvs, labels_file,
+                                   output_dir, job_id)
+    p.run()
+
+  def train(self, labels_file, input_dir, batch_size, max_steps, output_path):
+    """Local training."""
+
+    num_classes = len(_util.get_labels(labels_file))
+    model = _model.Model(num_classes, 0.5, self._checkpoint)
+    task_data = {'type': 'master', 'index': 0}
+    task = type('TaskSpec', (object,), task_data)
+    _trainer.Trainer(input_dir, batch_size, max_steps, output_path,
+                     model, None, task).run_training()
+
+  def predict(self, model_dir, image_files, labels_file):
+    """Local prediction."""
+    labels = _util.get_labels(labels_file)
+    model_dir = os.path.join(model_dir, 'model')
+    with tf.Session() as sess:
+      new_saver = tf.train.import_meta_graph(os.path.join(model_dir, 'export.meta'))
+      new_saver.restore(sess, os.path.join(model_dir, 'export'))
+      inputs = json.loads(tf.get_collection('inputs')[0])
+      outputs = json.loads(tf.get_collection('outputs')[0])
+      feed_dict = collections.defaultdict(list)
+      for ii, image_filename in enumerate(image_files):
+        with open(image_filename) as ff:
+          image_bytes = ff.read()
+          feed_dict[inputs['image_bytes']].append(image_bytes)
+          feed_dict[inputs['key']].append(str(ii))
+      predictions, scores = sess.run([outputs['prediction'], outputs['scores']],
+                                     feed_dict=feed_dict)
+    
+    labels_and_scores = [(labels[predicted_index], class_scores[predicted_index])
+                         for predicted_index, class_scores in zip(predictions, scores)]
+    return labels_and_scores

--- a/solutionbox/inception/datalab_solutions/inception/_model.py
+++ b/solutionbox/inception/datalab_solutions/inception/_model.py
@@ -1,0 +1,393 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Inception model tensorflow implementation.
+"""
+
+from enum import Enum
+import json
+import logging
+import os
+import tensorflow as tf
+from tensorflow.contrib import layers
+
+from . import _inceptionlib
+from . import _util
+
+
+slim = tf.contrib.slim
+
+LOGITS_TENSOR_NAME = 'logits_tensor'
+IMAGE_URI_COLUMN = 'image_uri'
+LABEL_COLUMN = 'label'
+EMBEDDING_COLUMN = 'embedding'
+
+BOTTLENECK_TENSOR_SIZE = 2048
+
+
+class GraphMod(Enum):
+  TRAIN = 1
+  EVALUATE = 2
+  PREDICT = 3
+
+
+class GraphReferences(object):
+  """Holder of base tensors used for training model using common task."""
+
+  def __init__(self):
+    self.examples = None
+    self.train = None
+    self.global_step = None
+    self.metric_updates = []
+    self.metric_values = []
+    self.keys = None
+    self.predictions = []
+
+
+class Model(object):
+  """TensorFlow model for the flowers problem."""
+
+  def __init__(self, label_count, dropout, inception_checkpoint_file):
+    self.label_count = label_count
+    self.dropout = dropout
+    self.inception_checkpoint_file = inception_checkpoint_file
+
+  def add_final_training_ops(self,
+                             embeddings,
+                             all_labels_count,
+                             bottleneck_tensor_size,
+                             hidden_layer_size=BOTTLENECK_TENSOR_SIZE / 4,
+                             dropout_keep_prob=None):
+    """Adds a new softmax and fully-connected layer for training.
+
+     The set up for the softmax and fully-connected layers is based on:
+     https://tensorflow.org/versions/master/tutorials/mnist/beginners/index.html
+
+     This function can be customized to add arbitrary layers for
+     application-specific requirements.
+    Args:
+      embeddings: The embedding (bottleneck) tensor.
+      all_labels_count: The number of all labels including the default label.
+      bottleneck_tensor_size: The number of embeddings.
+      hidden_layer_size: The size of the hidden_layer. Roughtly, 1/4 of the
+                         bottleneck tensor size.
+      dropout_keep_prob: the percentage of activation values that are retained.
+    Returns:
+      softmax: The softmax or tensor. It stores the final scores.
+      logits: The logits tensor.
+    """
+    with tf.name_scope('input'):
+      bottleneck_input = tf.placeholder_with_default(
+          embeddings,
+          shape=[None, bottleneck_tensor_size],
+          name='ReshapeSqueezed')
+      bottleneck_with_no_gradient = tf.stop_gradient(bottleneck_input)
+
+      with tf.name_scope('Wx_plus_b'):
+        hidden = layers.fully_connected(bottleneck_with_no_gradient,
+                                        hidden_layer_size)
+        # We need a dropout when the size of the dataset is rather small.
+        if dropout_keep_prob:
+          hidden = tf.nn.dropout(hidden, dropout_keep_prob)
+        logits = layers.fully_connected(
+            hidden, all_labels_count, activation_fn=None)
+
+    softmax = tf.nn.softmax(logits, name='softmax')
+    return softmax, logits
+
+  def build_inception_graph(self):
+    """Builds an inception graph and add the necessary input & output tensors.
+
+      To use other Inception models modify this file. Also preprocessing must be
+      modified accordingly.
+
+      See tensorflow/contrib/slim/python/slim/nets/inception_v3.py for
+      details about InceptionV3.
+
+    Returns:
+      input_jpeg: A placeholder for jpeg string batch that allows feeding the
+                  Inception layer with image bytes for prediction.
+      inception_embeddings: The embeddings tensor.
+    """
+
+    # These constants are set by Inception v3's expectations.
+    height = 299
+    width = 299
+    channels = 3
+
+    image_str_tensor = tf.placeholder(tf.string, shape=[None])
+
+    # The CloudML Prediction API always "feeds" the Tensorflow graph with
+    # dynamic batch sizes e.g. (?,).  decode_jpeg only processes scalar
+    # strings because it cannot guarantee a batch of images would have
+    # the same output size.  We use tf.map_fn to give decode_jpeg a scalar
+    # string from dynamic batches.
+    def decode_and_resize(image_str_tensor):
+      """Decodes jpeg string, resizes it and returns a uint8 tensor."""
+
+      image = tf.image.decode_jpeg(image_str_tensor, channels=channels)
+
+      # Note resize expects a batch_size, but tf_map supresses that index,
+      # thus we have to expand then squeeze.  Resize returns float32 in the
+      # range [0, uint8_max]
+      image = tf.expand_dims(image, 0)
+      image = tf.image.resize_bilinear(
+          image, [height, width], align_corners=False)
+      image = tf.squeeze(image, squeeze_dims=[0])
+      image = tf.cast(image, dtype=tf.uint8)
+      return image
+
+    image = tf.map_fn(
+        decode_and_resize, image_str_tensor, back_prop=False, dtype=tf.uint8)
+    # convert_image_dtype, also scales [0, uint8_max] -> [0 ,1).
+    image = tf.image.convert_image_dtype(image, dtype=tf.float32)
+
+    # Then shift images to [-1, 1) for Inception.
+    image = tf.sub(image, 0.5)
+    image = tf.mul(image, 2.0)
+
+    # Build Inception layers, which expect A tensor of type float from [-1, 1)
+    # and shape [batch_size, height, width, channels].
+    with slim.arg_scope(_inceptionlib.inception_v3_arg_scope()):
+      _, end_points = _inceptionlib.inception_v3(image, is_training=False)
+
+    inception_embeddings = end_points['PreLogits']
+    inception_embeddings = tf.squeeze(
+        inception_embeddings, [1, 2], name='SpatialSqueeze')
+    return image_str_tensor, inception_embeddings
+
+  def build_graph(self, data_paths, batch_size, graph_mod):
+    """Builds generic graph for training or eval."""
+    tensors = GraphReferences()
+    is_training = graph_mod == GraphMod.TRAIN
+    if data_paths:
+      _, tensors.examples = _util.read_examples(
+          data_paths,
+          batch_size,
+          shuffle=is_training,
+          num_epochs=None if is_training else 2)
+    else:
+      tensors.examples = tf.placeholder(tf.string, name='input', shape=(None,))
+
+    if graph_mod == GraphMod.PREDICT:
+      inception_input, inception_embeddings = self.build_inception_graph()
+      # Build the Inception graph. We later add final training layers
+      # to this graph. This is currently used only for prediction.
+      # For training, we use pre-processed data, so it is not needed.
+      embeddings = inception_embeddings
+      tensors.input_jpeg = inception_input
+    else:
+      # For training and evaluation we assume data is preprocessed, so the
+      # inputs are tf-examples.
+      # Generate placeholders for examples.
+      with tf.name_scope('inputs'):
+        feature_map = {
+            'image_uri':
+                tf.FixedLenFeature(
+                    shape=[], dtype=tf.string, default_value=['']),
+            # Some images may have no labels. For those, we assume a default
+            # label. So the number of labels is label_count+1 for the default
+            # label.
+            'label':
+                tf.FixedLenFeature(
+                    shape=[1], dtype=tf.int64,
+                    default_value=[self.label_count]),
+            'embedding':
+                tf.FixedLenFeature(
+                    shape=[BOTTLENECK_TENSOR_SIZE], dtype=tf.float32)
+        }
+        parsed = tf.parse_example(tensors.examples, features=feature_map)
+        labels = tf.squeeze(parsed['label'])
+        uris = tf.squeeze(parsed['image_uri'])
+        embeddings = parsed['embedding']
+
+    # We assume a default label, so the total number of labels is equal to
+    # label_count+1.
+    all_labels_count = self.label_count + 1
+    with tf.name_scope('final_ops'):
+      softmax, logits = self.add_final_training_ops(
+          embeddings,
+          all_labels_count,
+          BOTTLENECK_TENSOR_SIZE,
+          dropout_keep_prob=self.dropout if is_training else None)
+
+    # Prediction is the index of the label with the highest score. We are
+    # interested only in the top score.
+    prediction = tf.argmax(softmax, 1)
+    tensors.predictions = [prediction, softmax, embeddings]
+
+    if graph_mod == GraphMod.PREDICT:
+      return tensors
+
+    with tf.name_scope('evaluate'):
+      loss_value = loss(logits, labels)
+
+    # Add to the Graph the Ops that calculate and apply gradients.
+    if is_training:
+      tensors.train, tensors.global_step = training(loss_value)
+    else:
+      tensors.global_step = tf.Variable(0, name='global_step', trainable=False)
+      tensors.uris = uris
+
+    # Add means across all batches.
+    loss_updates, loss_op = _util.loss(loss_value)
+    accuracy_updates, accuracy_op = _util.accuracy(logits, labels)
+
+    if not is_training:
+      tf.summary.scalar('accuracy', accuracy_op)
+      tf.summary.scalar('loss', loss_op)
+
+    tensors.metric_updates = loss_updates + accuracy_updates
+    tensors.metric_values = [loss_op, accuracy_op]
+    return tensors
+    
+
+  def build_train_graph(self, data_paths, batch_size):
+    return self.build_graph(data_paths, batch_size, GraphMod.TRAIN)
+
+  def build_eval_graph(self, data_paths, batch_size):
+    return self.build_graph(data_paths, batch_size, GraphMod.EVALUATE)
+
+  def restore_from_checkpoint(self, session, inception_checkpoint_file,
+                              trained_checkpoint_file):
+    """To restore model variables from the checkpoint file.
+
+       The graph is assumed to consist of an inception model and other
+       layers including a softmax and a fully connected layer. The former is
+       pre-trained and the latter is trained using the pre-processed data. So
+       we restore this from two checkpoint files.
+    Args:
+      session: The session to be used for restoring from checkpoint.
+      inception_checkpoint_file: Path to the checkpoint file for the Inception
+                                 graph.
+      trained_checkpoint_file: path to the trained checkpoint for the other
+                               layers.
+    """
+    inception_exclude_scopes = [
+        'InceptionV3/AuxLogits', 'InceptionV3/Logits', 'global_step',
+        'final_ops'
+    ]
+    reader = tf.train.NewCheckpointReader(inception_checkpoint_file)
+    var_to_shape_map = reader.get_variable_to_shape_map()
+
+    # Get all variables to restore. Exclude Logits and AuxLogits because they
+    # depend on the input data and we do not need to intialize them.
+    all_vars = tf.contrib.slim.get_variables_to_restore(
+        exclude=inception_exclude_scopes)
+    # Remove variables that do not exist in the inception checkpoint (for
+    # example the final softmax and fully-connected layers).
+    inception_vars = {
+        var.op.name: var
+        for var in all_vars if var.op.name in var_to_shape_map
+    }
+    inception_saver = tf.train.Saver(inception_vars)
+    inception_saver.restore(session, inception_checkpoint_file)
+
+    # Restore the rest of the variables from the trained checkpoint.
+    trained_vars = tf.contrib.slim.get_variables_to_restore(
+        exclude=inception_exclude_scopes + inception_vars.keys())
+    trained_saver = tf.train.Saver(trained_vars)
+    trained_saver.restore(session, trained_checkpoint_file)
+
+  def build_prediction_graph(self):
+    """Builds prediction graph and registers appropriate endpoints."""
+
+    tensors = self.build_graph(None, 1, GraphMod.PREDICT)
+
+    keys_placeholder = tf.placeholder(tf.string, shape=[None])
+    inputs = {
+        'key': keys_placeholder.name,
+        'image_bytes': tensors.input_jpeg.name
+    }
+
+    tf.add_to_collection('inputs', json.dumps(inputs))
+
+    # To extract the id, we need to add the identity function.
+    keys = tf.identity(keys_placeholder)
+    outputs = {
+        'key': keys.name,
+        'prediction': tensors.predictions[0].name,
+        'scores': tensors.predictions[1].name
+    }
+    tf.add_to_collection('outputs', json.dumps(outputs))
+
+  def export(self, last_checkpoint, output_dir):
+    """Builds a prediction graph and xports the model.
+
+    Args:
+      last_checkpoint: Path to the latest checkpoint file from training.
+      output_dir: Path to the folder to be used to output the model.
+    """
+    logging.info('Exporting prediction graph to %s', output_dir)
+    with tf.Session(graph=tf.Graph()) as sess:
+      # Build and save prediction meta graph and trained variable values.
+      self.build_prediction_graph()
+      init_op = tf.global_variables_initializer()
+      sess.run(init_op)
+      self.restore_from_checkpoint(sess, self.inception_checkpoint_file,
+                                   last_checkpoint)
+      saver = tf.train.Saver()
+      saver.export_meta_graph(filename=os.path.join(output_dir, 'export.meta'))
+      saver.save(
+          sess, os.path.join(output_dir, 'export'), write_meta_graph=False)
+
+  def format_metric_values(self, metric_values):
+    """Formats metric values - used for logging purpose."""
+
+    # Early in training, metric_values may actually be None.
+    loss_str = 'N/A'
+    accuracy_str = 'N/A'
+    try:
+      loss_str = 'loss: %.3f' % metric_values[0]
+      accuracy_str = 'accuracy: %.3f' % metric_values[1]
+    except (TypeError, IndexError):
+      pass
+
+    return '%s, %s' % (loss_str, accuracy_str)
+
+  def format_prediction_values(self, prediction):
+    """Formats prediction values - used for writing batch predictions as csv."""
+    return '%.3f' % (prediction[0])
+
+
+def loss(logits, labels):
+  """Calculates the loss from the logits and the labels.
+
+  Args:
+    logits: Logits tensor, float - [batch_size, NUM_CLASSES].
+    labels: Labels tensor, int32 - [batch_size].
+  Returns:
+    loss: Loss tensor of type float.
+  """
+  labels = tf.to_int64(labels)
+  cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(
+      logits, labels, name='xentropy')
+  return tf.reduce_mean(cross_entropy, name='xentropy_mean')
+
+
+def training(loss_op):
+  """Calculates the loss from the logits and the labels.
+
+  Args:
+    logits: Logits tensor, float - [batch_size, NUM_CLASSES].
+    labels: Labels tensor, int32 - [batch_size].
+  Returns:
+    loss: Loss tensor of type float.
+  """
+  global_step = tf.Variable(0, name='global_step', trainable=False)
+  with tf.name_scope('train'):
+    optimizer = tf.train.AdamOptimizer(epsilon=0.001)
+    train_op = optimizer.minimize(loss_op, global_step)
+    return train_op, global_step

--- a/solutionbox/inception/datalab_solutions/inception/_package.py
+++ b/solutionbox/inception/datalab_solutions/inception/_package.py
@@ -49,7 +49,7 @@ def cloud_preprocess(input_csvs, labels_file, output_dir, project, checkpoint=No
       pipeline_option)
   if (_util.is_in_IPython()):
     import IPython
-    dataflow_url = 'https://pantheon.corp.google.com/dataflow?project=%s' % project
+    dataflow_url = 'https://console.developers.google.com/dataflow?project=%s' % project
     html = 'Job submitted.'
     html += '<p>Click <a href="%s" target="_blank">here</a> to track preprocessing job. <br/>' \
         % dataflow_url

--- a/solutionbox/inception/datalab_solutions/inception/_package.py
+++ b/solutionbox/inception/datalab_solutions/inception/_package.py
@@ -1,0 +1,112 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Provides interface for Datalab. It provides:
+     local_preprocess
+     local_train
+     local_predict
+     cloud_preprocess
+     cloud_train
+     cloud_predict
+   Datalab will look for functions with the above names.
+"""
+
+import logging
+import os
+import urllib
+
+from . import _cloud
+from . import _local
+from . import _model
+from . import _preprocess
+from . import _trainer
+from . import _util
+
+
+def local_preprocess(input_csvs, labels_file, output_dir, checkpoint=None):
+  print 'Local preprocessing...'
+  # TODO: Move this to a new process to avoid pickling issues
+  _local.Local(checkpoint).preprocess(input_csvs, labels_file, output_dir)
+  print 'Done'
+
+
+def cloud_preprocess(input_csvs, labels_file, output_dir, project, checkpoint=None,
+                     pipeline_option=None):
+  # TODO: Move this to a new process to avoid pickling issues
+  _cloud.Cloud(project, checkpoint).preprocess(input_csvs, labels_file, output_dir,
+      pipeline_option)
+  if (_util.is_in_IPython()):
+    import IPython
+    dataflow_url = 'https://pantheon.corp.google.com/dataflow?project=%s' % project
+    html = 'Job submitted.'
+    html += '<p>Click <a href="%s" target="_blank">here</a> to track preprocessing job. <br/>' \
+        % dataflow_url
+    IPython.display.display_html(html, raw=True)
+
+
+def local_train(labels_file, input_dir, batch_size, max_steps, output_path, checkpoint=None):
+  logger = logging.getLogger()
+  original_level = logger.getEffectiveLevel()
+  logger.setLevel(logging.INFO)
+  print 'Local training...'
+  try:
+    _local.Local(checkpoint).train(labels_file, input_dir, batch_size, max_steps, output_path)
+  finally:
+    logger.setLevel(original_level)
+  print 'Done'
+
+
+def cloud_train(labels_file, input_dir, batch_size, max_steps, output_path,
+                project, credentials, region, scale_tier='BASIC', checkpoint=None):
+  job_info = _cloud.Cloud(project, checkpoint).train(labels_file, input_dir, batch_size,
+      max_steps, output_path, credentials, region, scale_tier)
+  if (_util.is_in_IPython()):
+    import IPython
+    log_url_query_strings = {
+      'project': project,
+      'resource': 'ml.googleapis.com/job_id/' + job_info['jobId']
+    }
+    log_url = 'https://console.developers.google.com/logs/viewer?' + \
+        urllib.urlencode(log_url_query_strings)
+    html = '<p>Click <a href="%s" target="_blank">here</a> to view cloud log. <br/>' % log_url
+    IPython.display.display_html(html, raw=True)
+
+
+def _display_predict_results(results, show_image):
+  if (_util.is_in_IPython()):
+    import IPython
+    for image_file, label_and_score in results:
+      if show_image is True:
+        IPython.display.display_html('<p style="font-size:28px">%s(%.5f)</p>' % label_and_score,
+            raw=True)
+        IPython.display.display(IPython.display.Image(filename=image_file))
+      else:
+        IPython.display.display_html(
+            '<p>%s&nbsp&nbsp%s(%.5f)</p>' % ((image_file,) + label_and_score), raw=True)
+  else:
+    print results
+
+
+def local_predict(model_dir, image_files, labels_file, show_image=True):
+  labels_and_scores = _local.Local().predict(model_dir, image_files, labels_file)
+  results = zip(image_files, labels_and_scores)
+  _display_predict_results(results, show_image)
+
+
+def cloud_predict(model_id, image_files, labels_file, project, credentials, show_image=True):
+  labels_and_scores = _cloud.Cloud(project).predict(model_id, image_files, labels_file,
+                                                    credentials)
+  results = zip(image_files, labels_and_scores)
+  _display_predict_results(results, show_image)

--- a/solutionbox/inception/datalab_solutions/inception/_preprocess.py
+++ b/solutionbox/inception/datalab_solutions/inception/_preprocess.py
@@ -1,0 +1,304 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Preprocess pipeline implementation with Cloud DataFlow.
+"""
+
+
+import apache_beam as beam
+from apache_beam.utils.options import PipelineOptions
+import cStringIO
+import csv
+import google.cloud.ml as ml
+from google.cloud.ml.io import SaveFeatures
+import logging
+import os
+from PIL import Image
+import tensorflow as tf
+
+from . import _inceptionlib
+from . import _util
+
+
+slim = tf.contrib.slim
+
+error_count = beam.Aggregator('errorCount')
+csv_rows_count = beam.Aggregator('csvRowsCount')
+labels_count = beam.Aggregator('labelsCount')
+skipped_empty_line = beam.Aggregator('skippedEmptyLine')
+embedding_good = beam.Aggregator('embedding_good')
+embedding_bad = beam.Aggregator('embedding_bad')
+incompatible_image = beam.Aggregator('incompatible_image')
+invalid_uri = beam.Aggregator('invalid_file_name')
+ignored_unlabeled_image = beam.Aggregator('ignored_unlabeled_image')
+
+
+class ExtractLabelIdsDoFn(beam.DoFn):
+  """Extracts (uri, label_ids) tuples from CSV rows.
+  """
+
+  def start_bundle(self, context, *unused_args, **unused_kwargs):
+    self.label_to_id_map = {}
+
+  def process(self, context, all_labels):
+    if not self.label_to_id_map:
+      for i, label in enumerate(all_labels):
+        label = label.strip()
+        if label:
+          self.label_to_id_map[label] = i
+
+    # Row format is:
+    # image_uri(,label_ids)*
+    row = context.element
+    if not row:
+      context.aggregate_to(skipped_empty_line, 1)
+      return
+
+    context.aggregate_to(csv_rows_count, 1)
+    uri = row[0]
+    if not uri or not uri.startswith('gs://'):
+      context.aggregate_to(invalid_uri, 1)
+      return
+
+    # In a real-world system, you may want to provide a default id for labels
+    # that were not in the dictionary.  In this sample, we will throw an error.
+    # This code already supports multi-label problems if you want to use it.
+    label_ids = [self.label_to_id_map[label.strip()] for label in row[1:]]
+    context.aggregate_to(labels_count, len(label_ids))
+
+    if not label_ids:
+      context.aggregate_to(ignored_unlabeled_image, 1)
+    yield row[0], label_ids
+
+
+class ReadImageAndConvertToJpegDoFn(beam.DoFn):
+  """Read files from GCS and convert images to JPEG format.
+
+  We do this even for JPEG images to remove variations such as different number
+  of channels.
+  """
+
+  def process(self, context):
+    uri, label_ids = context.element
+
+    try:
+      with ml.util._file.open_local_or_gcs(uri, mode='r') as f:
+        img = Image.open(f).convert('RGB')
+    # A variety of different calling libraries throw different exceptions here.
+    # They all correspond to an unreadable file so we treat them equivalently.
+    # pylint: disable broad-except
+    except Exception as e:
+      logging.exception('Error processing image %s: %s', uri, str(e))
+      context.aggregate_to(error_count, 1)
+      return
+
+    # Convert to desired format and output.
+    output = cStringIO.StringIO()
+    img.save(output, 'jpeg')
+    image_bytes = output.getvalue()
+    yield uri, label_ids, image_bytes
+
+
+class EmbeddingsGraph(object):
+  """Builds a graph and uses it to extract embeddings from images.
+  """
+
+  # These constants are set by Inception v3's expectations.
+  WIDTH = 299
+  HEIGHT = 299
+  CHANNELS = 3
+
+  def __init__(self, tf_session, checkpoint_path):
+    self.tf_session = tf_session
+    # input_jpeg is the tensor that contains raw image bytes.
+    # It is used to feed image bytes and obtain embeddings.
+    self.input_jpeg, self.embedding = self.build_graph()
+    self.tf_session.run(tf.global_variables_initializer())
+    self.restore_from_checkpoint(checkpoint_path)
+
+  def build_graph(self):
+    """Forms the core by building a wrapper around the inception graph.
+
+      Here we add the necessary input & output tensors, to decode jpegs,
+      serialize embeddings, restore from checkpoint etc.
+
+      To use other Inception models modify this file. Note that to use other
+      models beside Inception, you should make sure input_shape matches
+      their input. Resizing or other modifications may be necessary as well.
+      See tensorflow/contrib/slim/python/slim/nets/inception_v3.py for
+      details about InceptionV3.
+
+    Returns:
+      input_jpeg: A tensor containing raw image bytes as the input layer.
+      embedding: The embeddings tensor, that will be materialized later.
+    """
+
+    input_jpeg = tf.placeholder(tf.string, shape=None)
+    image = tf.image.decode_jpeg(input_jpeg, channels=self.CHANNELS)
+
+    # Note resize expects a batch_size, but we are feeding a single image.
+    # So we have to expand then squeeze.  Resize returns float32 in the
+    # range [0, uint8_max]
+    image = tf.expand_dims(image, 0)
+
+    # convert_image_dtype also scales [0, uint8_max] -> [0 ,1).
+    image = tf.image.convert_image_dtype(image, dtype=tf.float32)
+    image = tf.image.resize_bilinear(
+        image, [self.HEIGHT, self.WIDTH], align_corners=False)
+
+    # Then rescale range to [-1, 1) for Inception.
+    image = tf.sub(image, 0.5)
+    inception_input = tf.mul(image, 2.0)
+
+    # Build Inception layers, which expect a tensor of type float from [-1, 1)
+    # and shape [batch_size, height, width, channels].
+    with slim.arg_scope(_inceptionlib.inception_v3_arg_scope()):
+      _, end_points = _inceptionlib.inception_v3(inception_input, is_training=False)
+
+    embedding = end_points['PreLogits']
+    return input_jpeg, embedding
+
+  def restore_from_checkpoint(self, checkpoint_path):
+    """To restore inception model variables from the checkpoint file.
+
+       Some variables might be missing in the checkpoint file, so it only
+       loads the ones that are avialable, assuming the rest would be
+       initialized later.
+    Args:
+      checkpoint_path: Path to the checkpoint file for the Inception graph.
+    """
+    # Get all variables to restore. Exclude Logits and AuxLogits because they
+    # depend on the input data and we do not need to intialize them from
+    # checkpoint.
+    all_vars = tf.contrib.slim.get_variables_to_restore(
+        exclude=['InceptionV3/AuxLogits', 'InceptionV3/Logits', 'global_step'])
+
+    saver = tf.train.Saver(all_vars)
+    saver.restore(self.tf_session, checkpoint_path)
+
+  def calculate_embedding(self, batch_image_bytes):
+    """Get the embeddings for a given JPEG image.
+
+    Args:
+      batch_image_bytes: As if returned from [ff.read() for ff in file_list].
+
+    Returns:
+      The Inception embeddings (bottleneck layer output)
+    """
+    return self.tf_session.run(
+        self.embedding, feed_dict={self.input_jpeg: batch_image_bytes})
+
+
+class TFExampleFromImageDoFn(beam.DoFn):
+  """Embeds image bytes and labels, stores them in tensorflow.Example.
+
+  (uri, label_ids, image_bytes) -> (tensorflow.Example).
+
+  Output proto contains 'label', 'image_uri' and 'embedding'.
+  The 'embedding' is calculated by feeding image into input layer of image
+  neural network and reading output of the bottleneck layer of the network.
+
+  Attributes:
+    image_graph_uri: an uri to gcs bucket where serialized image graph is
+                     stored.
+  """
+
+  def __init__(self, checkpoint_path):
+    self.tf_session = None
+    self.graph = None
+    self.preprocess_graph = None
+    self._checkpoint_path = checkpoint_path
+
+  def start_bundle(self, context):
+    # There is one tensorflow session per instance of TFExampleFromImageDoFn.
+    # The same instance of session is re-used between bundles.
+    # Session is closed by the destructor of Session object, which is called
+    # when instance of TFExampleFromImageDoFn() is destructed.
+    if not self.graph:
+      self.graph = tf.Graph()
+      self.tf_session = tf.InteractiveSession(graph=self.graph)
+      with self.graph.as_default():
+        self.preprocess_graph = EmbeddingsGraph(self.tf_session, self._checkpoint_path)
+
+  def process(self, context):
+
+    def _bytes_feature(value):
+      return tf.train.Feature(bytes_list=tf.train.BytesList(value=value))
+
+    def _float_feature(value):
+      return tf.train.Feature(float_list=tf.train.FloatList(value=value))
+
+    uri, label_ids, image_bytes = context.element
+
+    try:
+      embedding = self.preprocess_graph.calculate_embedding(image_bytes)
+    except tf.errors.InvalidArgumentError as e:
+      context.aggregate_to(incompatible_image, 1)
+      logging.warning('Could not encode an image from %s: %s', uri, str(e))
+      return
+
+    if embedding.any():
+      context.aggregate_to(embedding_good, 1)
+    else:
+      context.aggregate_to(embedding_bad, 1)
+
+    example = tf.train.Example(features=tf.train.Features(feature={
+        'image_uri': _bytes_feature([uri]),
+        'embedding': _float_feature(embedding.ravel().tolist()),
+    }))
+
+    if label_ids:
+      label_ids.sort()
+      example.features.feature['label'].int64_list.value.extend(label_ids)
+
+    yield example
+
+
+class TrainEvalSplitPartitionFn(beam.PartitionFn):
+  """Split train and eval data."""
+  def partition_for(self, context, num_partitions):
+    import random
+    return 1 if random.random() > 0.7 else 0
+
+
+def configure_pipeline(p, checkpoint_path, input_paths, labels_file, output_dir, job_id):
+  """Specify PCollection and transformations in pipeline."""
+  output_latest_file = os.path.join(output_dir, 'latest')
+  label_source = beam.io.TextFileSource(labels_file, strip_trailing_newlines=True)
+  labels = (p | 'Read dictionary %s' >> beam.Read(label_source))
+  source_list = []
+  for ii, input_path in enumerate(input_paths):
+    input_source = beam.io.TextFileSource(
+        input_path, strip_trailing_newlines=True)
+    source_list.append(p | 'Read input %d' % ii >> beam.Read(input_source))
+  all_preprocessed = (source_list | 'Flatten Sources' >> beam.Flatten()
+       | 'Parse input' >> beam.Map(lambda line: csv.reader([line]).next())
+       | 'Extract label ids' >> beam.ParDo(ExtractLabelIdsDoFn(),
+                                           beam.pvalue.AsIter(labels))
+       | 'Read and convert to JPEG' >> beam.ParDo(ReadImageAndConvertToJpegDoFn())
+       | 'Embed and make TFExample' >> beam.ParDo(TFExampleFromImageDoFn(checkpoint_path)))
+  train_eval = (all_preprocessed |
+       'Random Partition' >> beam.Partition(TrainEvalSplitPartitionFn(), 2))
+  preprocessed_train = os.path.join(output_dir, job_id, 'train')
+  preprocessed_eval = os.path.join(output_dir, job_id, 'eval')
+  eval_save = train_eval[1] | 'Save eval to disk' >> SaveFeatures(preprocessed_eval)
+  train_save = train_eval[0] | 'Save train to disk' >> SaveFeatures(preprocessed_train)
+  # Make sure we write "latest" file after train and eval data are successfully written.
+  ([eval_save, train_save] | 'Wait for train eval saving' >> beam.Flatten() |
+      beam.transforms.combiners.Sample.FixedSizeGlobally('Fixed One', 1) |
+      beam.Map(lambda path: job_id) |
+      'WriteLatest' >> beam.io.textio.WriteToText(output_latest_file, shard_name_template=''))
+
+

--- a/solutionbox/inception/datalab_solutions/inception/_trainer.py
+++ b/solutionbox/inception/datalab_solutions/inception/_trainer.py
@@ -1,0 +1,268 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Training implementation for inception model.
+"""
+
+import logging
+import os
+import tensorflow as tf
+import time
+
+from . import _util
+
+
+def start_server(cluster, task):
+  if not task.type:
+    raise ValueError('--task_type must be specified.')
+  if task.index is None:
+    raise ValueError('--task_index must be specified.')
+
+  # Create and start a server.
+  return tf.train.Server(
+      tf.train.ClusterSpec(cluster),
+      protocol='grpc',
+      job_name=task.type,
+      task_index=task.index)
+
+class Evaluator(object):
+  """Loads variables from latest checkpoint and performs model evaluation."""
+
+  def __init__(self, model, data_paths, batch_size, output_path, dataset='eval'):
+    self.num_eval_batches = self._data_size(data_paths) // batch_size
+    self.batch_of_examples = []
+    self.checkpoint_path = os.path.join(output_path, 'train')
+    self.output_path = os.path.join(output_path, dataset)
+    self.eval_data_paths = data_paths
+    self.batch_size = batch_size
+    self.model = model
+
+
+  def _data_size(self, data_paths):
+    n = 0
+    options = tf.python_io.TFRecordOptions(
+        compression_type=tf.python_io.TFRecordCompressionType.GZIP)
+    for file in data_paths:
+      for line in tf.python_io.tf_record_iterator(file, options=options):
+        n += 1
+    return n
+
+  def evaluate(self, num_eval_batches=None):
+    """Run one round of evaluation, return loss and accuracy."""
+
+    num_eval_batches = num_eval_batches or self.num_eval_batches
+    with tf.Graph().as_default() as graph:
+      self.tensors = self.model.build_eval_graph(self.eval_data_paths,
+                                                 self.batch_size)
+      self.summary = tf.merge_all_summaries()
+      self.saver = tf.train.Saver()
+
+    self.summary_writer = tf.train.SummaryWriter(self.output_path)
+    self.sv = tf.train.Supervisor(
+        graph=graph,
+        logdir=self.output_path,
+        summary_op=None,
+        global_step=None,
+        saver=self.saver)
+
+    last_checkpoint = tf.train.latest_checkpoint(self.checkpoint_path)
+    with self.sv.managed_session(
+        master='', start_standard_services=False) as session:
+      self.sv.saver.restore(session, last_checkpoint)
+
+      if not self.batch_of_examples:
+        self.sv.start_queue_runners(session)
+        for i in range(num_eval_batches):
+          self.batch_of_examples.append(session.run(self.tensors.examples))
+
+      for i in range(num_eval_batches):
+        session.run(self.tensors.metric_updates,
+                    {self.tensors.examples: self.batch_of_examples[i]})
+
+      metric_values = session.run(self.tensors.metric_values)
+      global_step = tf.train.global_step(session, self.tensors.global_step)
+      summary = session.run(self.summary)
+      self.summary_writer.add_summary(summary, global_step)
+      self.summary_writer.flush()
+      return metric_values
+
+
+
+class Trainer(object):
+  """Performs model training and optionally evaluation."""
+
+  def __init__(self, input_dir, batch_size, max_steps, output_path, model, cluster, task):
+    train_files, eval_files = _util.get_train_eval_files(input_dir)
+    self.train_data_paths = train_files
+    self.output_path = output_path
+    self.batch_size = batch_size
+    self.model = model
+    self.max_steps = max_steps
+    self.cluster = cluster
+    self.task = task
+    self.evaluator = Evaluator(self.model, eval_files, batch_size, output_path, 'eval_set')
+    self.train_evaluator = Evaluator(self.model, train_files, batch_size, output_path, 'train_set')
+    self.min_train_eval_rate = 20
+
+  def run_training(self):
+    """Runs a Master."""
+    self.train_path = os.path.join(self.output_path, 'train')
+    self.model_path = os.path.join(self.output_path, 'model')
+    self.is_master = self.task.type != 'worker'
+    log_interval = 15
+    self.eval_interval = 30
+    if self.is_master and self.task.index > 0:
+      raise StandardError('Only one replica of master expected')
+
+    if self.cluster:
+      logging.info('Starting %s/%d', self.task.type, self.task.index)
+      server = start_server(self.cluster, self.task)
+      target = server.target
+      device_fn = tf.train.replica_device_setter(
+          ps_device='/job:ps',
+          worker_device='/job:%s/task:%d' % (self.task.type, self.task.index),
+          cluster=self.cluster)
+      # We use a device_filter to limit the communication between this job
+      # and the parameter servers, i.e., there is no need to directly
+      # communicate with the other workers; attempting to do so can result
+      # in reliability problems.
+      device_filters = [
+          '/job:ps', '/job:%s/task:%d' % (self.task.type, self.task.index)
+      ]
+      config = tf.ConfigProto(device_filters=device_filters)
+    else:
+      target = ''
+      device_fn = ''
+      config = None
+
+    with tf.Graph().as_default() as graph:
+      with tf.device(device_fn):
+        # Build the training graph.
+        self.tensors = self.model.build_train_graph(self.train_data_paths,
+                                                    self.batch_size)
+
+        # Add the variable initializer Op.
+        init_op = tf.global_variables_initializer()
+
+        # Create a saver for writing training checkpoints.
+        self.saver = tf.train.Saver()
+
+        # Build the summary operation based on the TF collection of Summaries.
+        self.summary_op = tf.merge_all_summaries()
+
+    # Create a "supervisor", which oversees the training process.
+    self.sv = tf.train.Supervisor(
+        graph,
+        is_chief=self.is_master,
+        logdir=self.train_path,
+        init_op=init_op,
+        saver=self.saver,
+        # Write summary_ops by hand.
+        summary_op=None,
+        global_step=self.tensors.global_step,
+        # No saving; we do it manually in order to easily evaluate immediately
+        # afterwards.
+        save_model_secs=0)
+
+    should_retry = True
+    to_run = [self.tensors.global_step, self.tensors.train]
+
+    while should_retry:
+      try:
+        should_retry = False
+        with self.sv.managed_session(target, config=config) as session:
+          self.start_time = start_time = time.time()
+          self.last_save = self.last_log = 0
+          self.global_step = self.last_global_step = 0
+          self.local_step = self.last_local_step = 0
+          self.last_global_time = self.last_local_time = start_time
+
+          # Loop until the supervisor shuts down or max_steps have
+          # completed.
+          max_steps = self.max_steps
+          while not self.sv.should_stop() and self.global_step < max_steps:
+            try:
+              # Run one step of the model.
+              self.global_step = session.run(to_run)[0]
+              self.local_step += 1
+
+              self.now = time.time()
+              is_time_to_eval = (self.now - self.last_save) > self.eval_interval
+              is_time_to_log = (self.now - self.last_log) > log_interval
+              should_eval = self.is_master and is_time_to_eval
+              should_log = is_time_to_log or should_eval
+
+              if should_log:
+                self.log(session)
+
+              if should_eval:
+                self.eval(session)
+            except tf.errors.AbortedError:
+              should_retry = True
+
+          if self.is_master:
+            # Take the final checkpoint and compute the final accuracy.
+            # self.saver.save(session, self.sv.save_path, self.tensors.global_step)
+            self.eval(session)
+            # Export the model for inference.
+            self.model.export(tf.train.latest_checkpoint(self.train_path), self.model_path)
+
+      except tf.errors.AbortedError:
+        should_retry = True
+
+    # Ask for all the services to stop.
+    self.sv.stop()
+
+  def log(self, session):
+    """Logs training progress."""
+    logging.info('Train [%s/%d], step %d (%.3f sec) %.1f '
+                 'global steps/s, %.1f local steps/s', self.task.type,
+                 self.task.index, self.global_step,
+                 (self.now - self.start_time),
+                 (self.global_step - self.last_global_step) /
+                 (self.now - self.last_global_time),
+                 (self.local_step - self.last_local_step) /
+                 (self.now - self.last_local_time))
+    self.last_log = self.now
+    self.last_global_step, self.last_global_time = self.global_step, self.now
+    self.last_local_step, self.last_local_time = self.local_step, self.now
+
+  def eval(self, session):
+    """Runs evaluation loop."""
+    eval_start = time.time()
+    self.saver.save(session, self.sv.save_path, self.tensors.global_step)
+    logging.info(
+        'Eval, step %d:\n- on train set %s\n-- on eval set %s',
+        self.global_step,
+        self.model.format_metric_values(self.train_evaluator.evaluate()),
+        self.model.format_metric_values(self.evaluator.evaluate()))
+    now = time.time()
+
+    # Make sure eval doesn't consume too much of total time.
+    eval_time = now - eval_start
+    train_eval_rate = self.eval_interval / eval_time
+    if train_eval_rate < self.min_train_eval_rate and self.last_save > 0:
+      logging.info('Adjusting eval interval from %.2fs to %.2fs',
+                   self.eval_interval, self.min_train_eval_rate * eval_time)
+      self.eval_interval = self.min_train_eval_rate * eval_time
+
+    self.last_save = now
+    self.last_log = now
+
+  def save_summaries(self, session):
+    self.sv.summary_computed(session,
+                             session.run(self.summary_op), self.global_step)
+    self.sv.summary_writer.flush()
+

--- a/solutionbox/inception/datalab_solutions/inception/_util.py
+++ b/solutionbox/inception/datalab_solutions/inception/_util.py
@@ -1,0 +1,133 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Reusable utility functions.
+"""
+
+import google.cloud.ml as ml
+import multiprocessing
+import os
+
+import tensorflow as tf
+from tensorflow.python.lib.io import file_io
+
+
+_PACKAGE_GS_URL = 'gs://cloud-datalab/packages/inception-0.1.tar.gz'
+_DEFAULT_CHECKPOINT_GSURL = 'gs://cloud-ml-data/img/flower_photos/inception_v3_2016_08_28.ckpt'
+
+
+def is_in_IPython():
+  try:
+    import IPython
+    return True
+  except ImportError:
+    return False
+
+
+def get_train_eval_files(input_dir):
+  latest_file = os.path.join(input_dir, 'latest')
+  with ml.util._file.open_local_or_gcs(latest_file, 'r') as f:
+    dir_name = f.read().rstrip()
+  data_dir = os.path.join(input_dir, dir_name)
+  train_pattern = os.path.join(data_dir, 'train*.tfrecord.gz')
+  eval_pattern = os.path.join(data_dir, 'eval*.tfrecord.gz')
+  train_files = ml.util._file.glob_files(train_pattern)
+  eval_files = ml.util._file.glob_files(eval_pattern)
+  return train_files, eval_files
+
+
+def get_labels(input_labels_file):
+  """Get a list of labels from labels file."""
+  with ml.util._file.open_local_or_gcs(input_labels_file, mode='r') as f:
+    labels = f.read().rstrip().split('\n')
+  return labels
+
+
+def read_examples(input_files, batch_size, shuffle, num_epochs=None):
+  """Creates readers and queues for reading example protos."""
+  files = []
+  for e in input_files:
+    for path in e.split(','):
+      files.extend(file_io.get_matching_files(path))
+  thread_count = multiprocessing.cpu_count()
+
+  # The minimum number of instances in a queue from which examples are drawn
+  # randomly. The larger this number, the more randomness at the expense of
+  # higher memory requirements.
+  min_after_dequeue = 1000
+
+  # When batching data, the queue's capacity will be larger than the batch_size
+  # by some factor. The recommended formula is (num_threads + a small safety
+  # margin). For now, we use a single thread for reading, so this can be small.
+  queue_size_multiplier = thread_count + 3
+
+  # Convert num_epochs == 0 -> num_epochs is None, if necessary
+  num_epochs = num_epochs or None
+
+  # Build a queue of the filenames to be read.
+  filename_queue = tf.train.string_input_producer(files, num_epochs, shuffle)
+
+  options = tf.python_io.TFRecordOptions(
+      compression_type=tf.python_io.TFRecordCompressionType.GZIP)
+  example_id, encoded_example = tf.TFRecordReader(options=options).read_up_to(
+      filename_queue, batch_size)
+
+  if shuffle:
+    capacity = min_after_dequeue + queue_size_multiplier * batch_size
+    return tf.train.shuffle_batch(
+        [example_id, encoded_example],
+        batch_size,
+        capacity,
+        min_after_dequeue,
+        enqueue_many=True,
+        num_threads=thread_count)
+  else:
+    capacity = queue_size_multiplier * batch_size
+    return tf.train.batch(
+        [example_id, encoded_example],
+        batch_size,
+        capacity=capacity,
+        enqueue_many=True,
+        num_threads=thread_count)
+
+
+def override_if_not_in_args(flag, argument, args):
+  """Checks if flags is in args, and if not it adds the flag to args."""
+  if flag not in args:
+    args.extend([flag, argument])
+
+
+def loss(loss_value):
+  """Calculates aggregated mean loss."""
+  total_loss = tf.Variable(0.0, False)
+  loss_count = tf.Variable(0, False)
+  total_loss_update = tf.assign_add(total_loss, loss_value)
+  loss_count_update = tf.assign_add(loss_count, 1)
+  loss_op = total_loss / tf.cast(loss_count, tf.float32)
+  return [total_loss_update, loss_count_update], loss_op
+
+
+def accuracy(logits, labels):
+  """Calculates aggregated accuracy."""
+  is_correct = tf.nn.in_top_k(logits, labels, 1)
+  correct = tf.reduce_sum(tf.cast(is_correct, tf.int32))
+  incorrect = tf.reduce_sum(tf.cast(tf.logical_not(is_correct), tf.int32))
+  correct_count = tf.Variable(0, False)
+  incorrect_count = tf.Variable(0, False)
+  correct_count_update = tf.assign_add(correct_count, correct)
+  incorrect_count_update = tf.assign_add(incorrect_count, incorrect)
+  accuracy_op = tf.cast(correct_count, tf.float32) / tf.cast(
+      correct_count + incorrect_count, tf.float32)
+  return [correct_count_update, incorrect_count_update], accuracy_op

--- a/solutionbox/inception/datalab_solutions/inception/task.py
+++ b/solutionbox/inception/datalab_solutions/inception/task.py
@@ -1,0 +1,93 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Entry point for CloudML training.
+
+   CloudML training requires a tarball package and a python module to run. This file
+   provides such a "main" method and a list of args passed with the program.
+"""
+
+import argparse
+import json
+import logging
+import os
+import tensorflow as tf
+
+from . import _model
+from . import _trainer
+from . import _util
+
+
+def main(_):
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '--train_data_paths',
+      type=str,
+      action='append',
+      help='The paths to the training data files. '
+      'Can be comma separated list of files or glob pattern.')
+  parser.add_argument(
+      '--input_dir',
+      type=str,
+      help='The input dir path for training and evaluation data.')
+  parser.add_argument(
+      '--output_path',
+      type=str,
+      help='The path to which checkpoints and other outputs '
+      'should be saved. This can be either a local or GCS '
+      'path.')
+  parser.add_argument(
+      '--max_steps',
+      type=int,)
+  parser.add_argument(
+      '--batch_size',
+      type=int,
+      help='Number of examples to be processed per mini-batch.')
+  parser.add_argument(
+      '--num_classes',
+      type=int,
+      help='Number of classification classes.')
+  parser.add_argument(
+      '--checkpoint',
+      type=str,
+      default=_util._DEFAULT_CHECKPOINT_GSURL,
+      help='Pretrained inception checkpoint path.')
+
+  args, _ = parser.parse_known_args()
+  model = _model.Model(args.num_classes, 0.5, args.checkpoint)
+
+  env = json.loads(os.environ.get('TF_CONFIG', '{}'))
+  # Print the job data as provided by the service.
+  logging.info('Original job data: %s', env.get('job', {}))
+  task_data = env.get('task', None) or {'type': 'master', 'index': 0}
+  task = type('TaskSpec', (object,), task_data)
+  trial = task_data.get('trial')
+  if trial is not None:
+    args.output_path = os.path.join(args.output_path, trial)
+
+  cluster_data = env.get('cluster', None)
+  cluster = tf.train.ClusterSpec(cluster_data) if cluster_data else None
+  if not cluster or not task or task.type == 'master' or task.type == 'worker':
+     _trainer.Trainer(args.input_dir, args.batch_size, args.max_steps,
+                      args.output_path, model, cluster, task).run_training()
+  elif task.type == 'ps':
+     server = _trainer.start_server(cluster, task)
+     server.join()
+  else:
+    raise ValueError('invalid task_type %s' % (task.type,))
+
+if __name__ == '__main__':
+  logging.basicConfig(level=logging.INFO)
+  tf.app.run()

--- a/solutionbox/inception/release.sh
+++ b/solutionbox/inception/release.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+# Build a distribution package
+python setup.py sdist --formats=gztar
+gsutil cp ./dist/inception-0.1.tar.gz gs://cloud-datalab/packages/inception-0.1.tar.gz
+
+

--- a/solutionbox/inception/setup.py
+++ b/solutionbox/inception/setup.py
@@ -1,0 +1,50 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+# To publish to PyPi use: python setup.py bdist_wheel upload -r pypi
+
+import datetime
+from setuptools import setup
+
+minor = datetime.datetime.now().strftime("%y%m%d%H%M")
+version = '0.1'
+
+setup(
+  name='inception',
+  version=version,
+  packages=[
+    'datalab_solutions',
+    'datalab_solutions.inception',
+  ],
+  description='Google Cloud Datalab Inception Package',
+  author='Google',
+  author_email='google-cloud-datalab-feedback@googlegroups.com',
+  keywords=[
+  ],
+  license="Apache Software License",
+  classifiers=[
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Development Status :: 4 - Beta",
+        "Environment :: Other Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Topic :: Software Development :: Libraries :: Python Modules"
+  ],
+  long_description="""
+  """,
+  install_requires=[
+  ],
+  package_data={
+  }
+)


### PR DESCRIPTION
To use the inception package, Datalab users run the following commands:

%%ml preprocess --package gs://cloud-datalab/packages/inception-0.1.tar.gz [--cloud] [--dumpargs]
[args]
%%ml train --package gs://cloud-datalab/packages/inception-0.1.tar.gz [--cloud] [--dumpargs]
[args]
%%ml prediction --package gs://cloud-datalab/packages/inception-0.1.tar.gz [--cloud] [--dumpargs]
[args]

The package url tells Datalab where to load the package from. --cloud indicates whether cloud run or local run. If --dumpargs is specified, instead of running actual command it dumps the required and optional parameters that users need to input in cell. For example,

Input:
%ml predict --package gs://cloud-datalab/packages/inception-0.1.tar.gz --dumpargs

Output:
=============
Local Run Command:

%ml predict --package gs://cloud-datalab/packages/inception-0.1.tar.gz
image_files: 
labels_file: 
model_dir: 
show_image: (optional)

Cloud Run Command:

%ml predict --package gs://cloud-datalab/packages/inception-0.1.tar.gz --cloud
image_files: 
labels_file: 
model_id: 
project: (optional)
show_image: (optional)

============

Notes for code reviewers:

The interface between the package and Datalab are 6 functions (cloud_preprocess, local_preprocess, cloud_train, local_train, cloud_predict, local_predict). “--dumpargs” basically dumps the arguments of these functions. The function names are part of the contract between datalab and package. There will be more packages in the future that follow the same interface.

For each command, Datalab pip-installs the package into a temp dir, and looks for the functions under “datalab_solutions.[package_name]” namespace. [package_name] is the first part of the package url file name split by ‘-’ , such as inception-0.1.tar.gz.

The preprocessing input is a list of CSV files with each line being “image_url,label”. Preprocessing combines all CSV files and split the combined set into train/eval data. For each run, the output will be saved under a unique job_id subdir, and a “latest” file will be updated with the latest dir, so users can run preprocessing with the same output dir multiple times without losing previous results.

To support cloud training, the package also exposes an “task” module which wraps training function with program args.

The package now lives under pydatalab/solutionbox dir. It will not be installed with pydatalab. To rebuild and release, run pydatalab/solutionbox/inception/release.sh.

The Datalab part (runs the package, dumps args, etc) is in a separate commit. Sample notebooks will be in another commit.