### PR TITLE
Add cloud ml dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,9 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'scikit-learn==0.17.1',
     'ipykernel==4.4.1',
   ],
+  dependency_links=[
+     "https://storage.googleapis.com/cloud-ml/sdk/cloudml.latest.tar.gz",
+    ],
   package_data={
     'datalab.notebook': [
         'static/bigquery.css',


### PR DESCRIPTION
- cloud ml is being used in this package. This will make pydatalab works fine and pip installable.

- without this package if you try to %load_ext datalab.kernel, you will get an error message saying that google.cloud.ml does not exist. So you won't be able to use cell magic things.

 