### PR TITLE
Make the library pip-installable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
 
 before_install:
+  - sudo apt-get install -y python-setuptools
   - npm install -g typescript
   - tsc --module amd --noImplicitAny --outdir datalab/notebook/static datalab/notebook/static/*.ts
   - pip install -U pip
+  - pip install -U setuptools
   - pip install .
 
 script: python ./tests/main.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
-  - "2.7"
+  - 2.7
+  - 3.5
 
 before_install:
   - sudo apt-get install -y python-setuptools

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,9 @@
 # To publish to PyPi use: python setup.py bdist_wheel upload -r pypi
 
 import datetime
+import platform
 from setuptools import setup
+import pip
 
 minor = datetime.datetime.now().strftime("%y%m%d%H%M")
 version = '0.1.' + minor
@@ -104,3 +106,22 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
       ]
   }
 )
+
+tensorflow_path = None
+if platform.system() == 'Darwin':
+  tensorflow_path = 'https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-0.11.0-py2-none-any.whl'
+elif platform.system() == 'Linux':
+  if platform.linux_distribution()[0] == 'Ubuntu':
+    tensorflow_path = 'https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0-cp27-none-linux_x86_64.whl'
+  elif platform.linux_distribution()[0] == 'Debian':
+    tensorflow_path = 'https://storage.googleapis.com/tensorflow/linux/cpu/debian/jessie/tensorflow-0.11.0-cp27-none-linux_x86_64.whl'
+
+# install tensorflow
+if not tensorflow_path:
+  print """Warning: could not find tensorflow build for your OS.
+  Please go to https://www.tensorflow.org/get_started/os_setup to see install options"""
+else:
+  pip.main(['install', tensorflow_path])
+
+# install cloud ml sdk
+pip.main(['install', 'https://storage.googleapis.com/cloud-ml/sdk/cloudml.latest.tar.gz'])

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,12 @@
 # To publish to PyPi use: python setup.py bdist_wheel upload -r pypi
 
 import datetime
-import platform
+import sys
 from setuptools import setup
-import pip
+
+if sys.version_info[0] == 2:
+  import platform
+  import pip
 
 minor = datetime.datetime.now().strftime("%y%m%d%H%M")
 version = '0.1.' + minor
@@ -107,21 +110,23 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
   }
 )
 
-tensorflow_path = None
-if platform.system() == 'Darwin':
-  tensorflow_path = 'https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-0.11.0-py2-none-any.whl'
-elif platform.system() == 'Linux':
-  if platform.linux_distribution()[0] == 'Ubuntu':
-    tensorflow_path = 'https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0-cp27-none-linux_x86_64.whl'
-  elif platform.linux_distribution()[0] == 'Debian':
-    tensorflow_path = 'https://storage.googleapis.com/tensorflow/linux/cpu/debian/jessie/tensorflow-0.11.0-cp27-none-linux_x86_64.whl'
+# for python2 only, install tensorflow and cloudml
+if sys.version_info[0] == 2:
+  tensorflow_path = None
+  if platform.system() == 'Darwin':
+    tensorflow_path = 'https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-0.11.0-py2-none-any.whl'
+  elif platform.system() == 'Linux':
+    if platform.linux_distribution()[0] == 'Ubuntu':
+      tensorflow_path = 'https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0-cp27-none-linux_x86_64.whl'
+    elif platform.linux_distribution()[0] == 'Debian':
+      tensorflow_path = 'https://storage.googleapis.com/tensorflow/linux/cpu/debian/jessie/tensorflow-0.11.0-cp27-none-linux_x86_64.whl'
 
-# install tensorflow
-if not tensorflow_path:
-  print("""Warning: could not find tensorflow build for your OS.
-  Please go to https://www.tensorflow.org/get_started/os_setup to see install options""")
-else:
-  pip.main(['install', tensorflow_path])
+  # install tensorflow
+  if not tensorflow_path:
+    print("""Warning: could not find tensorflow build for your OS.
+    Please go to https://www.tensorflow.org/get_started/os_setup to see install options""")
+  else:
+    pip.main(['install', tensorflow_path])
 
-# install cloud ml sdk
-pip.main(['install', 'https://storage.googleapis.com/cloud-ml/sdk/cloudml.latest.tar.gz'])
+  # install cloud ml sdk
+  pip.main(['install', 'https://storage.googleapis.com/cloud-ml/sdk/cloudml.latest.tar.gz'])

--- a/setup.py
+++ b/setup.py
@@ -118,8 +118,8 @@ elif platform.system() == 'Linux':
 
 # install tensorflow
 if not tensorflow_path:
-  print """Warning: could not find tensorflow build for your OS.
-  Please go to https://www.tensorflow.org/get_started/os_setup to see install options"""
+  print("""Warning: could not find tensorflow build for your OS.
+  Please go to https://www.tensorflow.org/get_started/os_setup to see install options""")
 else:
   pip.main(['install', tensorflow_path])
 


### PR DESCRIPTION
This PR adds tensorflow and cloudml in setup.py to make the lib pip-installable. I had to install them explicitly using pip from inside the `setup.py` script, even though it's not a clean way to do it, it gets around the two issues we have at the moment with these two packags:

- Pypi has Tensorflow version 0.12, while we need 0.11 for the current version of pydatalab. According to the [Cloud ML docs](https://cloud.google.com/ml/docs/how-tos/getting-set-up#installing_the_google_api_client_for_python), that version exists as a pip package for three supported platforms.
- Cloud ML SDK exists as a pip package, but also not on Pypi, and while we could add it as a dependency link, there exists another package on Pypi called `cloudml`, and pip ends up installing that instead (see https://github.com/googledatalab/pydatalab/pull/124). I cannot find a way to force pip to install the package from the link I included.