### PR TITLE
Fix query_metadata tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
+  - "3.5"
 
 before_install:
   - npm install -g typescript

--- a/datalab/stackdriver/monitoring/_query_metadata.py
+++ b/datalab/stackdriver/monitoring/_query_metadata.py
@@ -64,7 +64,7 @@ class QueryMetadata(object):
       """
       max_rows = len(self._timeseries_list) if max_rows is None else max_rows
       headers = [{
-          'resource': ts.resource.__dict__, 'metric': ts.metric.__dict__}
+          'resource': ts.resource._asdict(), 'metric': ts.metric._asdict()}
           for ts in self._timeseries_list[:max_rows]]
 
       if not headers:


### PR DESCRIPTION
Tests are failing in Python3 because of using `__dict__`. It's not obvious to me why this isn't available for Python3 from the cloudml sdk, but `_asdict()` works for both.

Fixes https://github.com/googledatalab/pydatalab/issues/127.