### PR TITLE
Fix build break because of CloudML dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ Support package for Google Cloud Datalab. This provides cell magics and Python A
 for accessing Google's Cloud Platform services such as Google BigQuery.
   """,
   install_requires=[
-    'future==0.15.2',
+    'future==0.16.0',
     'futures==3.0.5',
     'google-cloud==0.19.0',
     'google-api-python-client==1.5.1',


### PR DESCRIPTION
As of the latest release of CloudML Python SDK, that package seems to require `future==0.16.0`, so until it's fixed, we'll take it as a dependency.

Fixes https://github.com/googledatalab/datalab/issues/1160