### PR TITLE
Remove tensorflow and CloudML SDK from setup.py

### DIFF
--- a/datalab/kernel/__init__.py
+++ b/datalab/kernel/__init__.py
@@ -31,13 +31,20 @@ import datalab.context as _context
 import datalab.bigquery.commands
 import datalab.context.commands
 import datalab.data.commands
+import datalab.stackdriver.commands
+import datalab.storage.commands
+import datalab.utils.commands
+
+# mlalpha modules require TensorFlow, CloudML SDK, and DataFlow (installed with CloudML SDK).
+# These are big dependencies and users who want to use Bigquery/Storage features may not
+# want to install them.
+# This __init__.py file is called when Jupyter/Datalab loads magics on startup. We don't want
+# Jupyter+pydatalab fail to start because of missing TensorFlow/DataFlow. So we ignore import
+# errors on mlalpha commands.
 try:
   import datalab.mlalpha.commands
 except:
   print('TensorFlow and CloudML SDK are required.')
-import datalab.stackdriver.commands
-import datalab.storage.commands
-import datalab.utils.commands
 
 
 _orig_request = _httplib2.Http.request

--- a/datalab/kernel/__init__.py
+++ b/datalab/kernel/__init__.py
@@ -31,7 +31,10 @@ import datalab.context as _context
 import datalab.bigquery.commands
 import datalab.context.commands
 import datalab.data.commands
-import datalab.mlalpha.commands
+try:
+  import datalab.mlalpha.commands
+except:
+  print('TensorFlow and CloudML SDK are required.')
 import datalab.stackdriver.commands
 import datalab.storage.commands
 import datalab.utils.commands

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'pyyaml==3.11',
     'requests==2.9.1',
     'ipykernel==4.4.1',
-    'tensorflow==0.12.1',
   ],
   package_data={
     'datalab.notebook': [
@@ -110,8 +109,3 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
       ]
   }
 )
-
-# for python2 only, install cloudml
-if sys.version_info[0] == 2:
-  # install cloud ml sdk
-  pip.main(['install', 'https://storage.googleapis.com/cloud-ml/sdk/cloudml.latest.tar.gz'])

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'pyyaml==3.11',
     'requests==2.9.1',
     'ipykernel==4.4.1',
+    'tensorflow==0.12.1',
   ],
   package_data={
     'datalab.notebook': [
@@ -110,23 +111,7 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
   }
 )
 
-# for python2 only, install tensorflow and cloudml
+# for python2 only, install cloudml
 if sys.version_info[0] == 2:
-  tensorflow_path = None
-  if platform.system() == 'Darwin':
-    tensorflow_path = 'https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-0.11.0-py2-none-any.whl'
-  elif platform.system() == 'Linux':
-    if platform.linux_distribution()[0] == 'Ubuntu':
-      tensorflow_path = 'https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0-cp27-none-linux_x86_64.whl'
-    elif platform.linux_distribution()[0] == 'Debian':
-      tensorflow_path = 'https://storage.googleapis.com/tensorflow/linux/cpu/debian/jessie/tensorflow-0.11.0-cp27-none-linux_x86_64.whl'
-
-  # install tensorflow
-  if not tensorflow_path:
-    print("""Warning: could not find tensorflow build for your OS.
-    Please go to https://www.tensorflow.org/get_started/os_setup to see install options""")
-  else:
-    pip.main(['install', tensorflow_path])
-
   # install cloud ml sdk
   pip.main(['install', 'https://storage.googleapis.com/cloud-ml/sdk/cloudml.latest.tar.gz'])


### PR DESCRIPTION
There are cases that users want to use BigQuery APIs from pydatalab but not ML stuff, so having a hard dependency on it is not ideal.