### PR TITLE
Fold Query extract(), to_file(), and to_dataframe() into execute()

### DIFF
--- a/google/datalab/bigquery/__init__.py
+++ b/google/datalab/bigquery/__init__.py
@@ -19,6 +19,7 @@ from ._dialect import Dialect
 from ._federated_table import FederatedTable
 from ._job import Job
 from ._query import Query
+from ._query_output import QueryOutput
 from ._query_job import QueryJob
 from ._query_results_table import QueryResultsTable
 from ._query_stats import QueryStats

--- a/google/datalab/bigquery/_query_output.py
+++ b/google/datalab/bigquery/_query_output.py
@@ -14,13 +14,13 @@
 
 class QueryOutput(object):
 
-  @classmethod
-  def table(output, name=None, mode='create', use_cache=True, priority='interactive',
+  @staticmethod
+  def table(name=None, mode='create', use_cache=True, priority='interactive',
             allow_large_results=False):
     """ Construct a query output object where the result is a table
 
     Args:
-      table_name: the result table name as a string or TableName; if None (the default), then a
+      name: the result table name as a string or TableName; if None (the default), then a
           temporary table will be used.
       table_mode: one of 'create', 'overwrite' or 'append'. If 'create' (the default), the request
           will fail if the table exists.
@@ -30,18 +30,19 @@ class QueryOutput(object):
           to run quickly but are subject to rate limits; 'batch' jobs could be delayed by as much
           as three hours but are not rate-limited.
       allow_large_results: whether to allow large results; i.e. compressed data over 100MB. This is
-          slower and requires a table_name to be specified) (default False).
+          slower and requires a name to be specified) (default False).
     """
+    output = QueryOutput()
     output._output_type = 'table'
     output._table_name = name
     output._table_mode = mode
     output._use_cache = use_cache
     output._priority = priority
     output._allow_large_results = allow_large_results
-    return result
+    return output
 
-  @classmethod
-  def file(output, path, format='csv', csv_delimiter=',', csv_header=True, compress=False,
+  @staticmethod
+  def file(path, format='csv', csv_delimiter=',', csv_header=True, compress=False,
            use_cache=True):
     """ Construct a query output object where the result is either a local file or a GCS path
 
@@ -49,9 +50,7 @@ class QueryOutput(object):
     and the second to extract the resulting table. These are wrapped by a single outer Job.
 
     If the query has already been executed and you would prefer to get a Job just for the
-    extract, you can can call extract_async on the QueryResultsTable instead; i.e.:
-
-        query.execute().results.extract_async(...)
+    extract, you can can call extract[_async] on the QueryResultsTable returned by the query
 
     Args:
       path: the destination path. Can either be a local or GCS URI (starting with gs://)
@@ -63,16 +62,17 @@ class QueryOutput(object):
           AVRO format (default False). Applies only to GCS URIs.
       use_cache: whether to use cached results or not (default True).
     """
+    output = QueryOutput()
     output._output_type = 'file'
     output._file_path = path
     output._file_format = format
     output._csv_delimiter = csv_delimiter
     output._csv_header = csv_header
     output._compress_file = compress
-    return result
+    return output
 
-  @classmethod
-  def dataframe(output, start_row=0, max_rows=None, use_cache=True):
+  @staticmethod
+  def dataframe(start_row=0, max_rows=None, use_cache=True):
     """ Construct a query output object where the result is a dataframe
 
     Args:
@@ -80,11 +80,12 @@ class QueryOutput(object):
       max_rows: an upper limit on the number of rows to export (default None).
       use_cache: whether to use cached results or not (default True).
     """
+    output = QueryOutput()
     output._output_type = 'dataframe'
     output._dataframe_start_row = start_row
     output._dataframe_max_rows = max_rows
-    output._dataframe_use_cache = use_cache
-    return result
+    output._use_cache = use_cache
+    return output
 
   def __init__(self):
     """ Create a BigQuery output type object. Do not call this directly; use factory methods. """
@@ -101,7 +102,6 @@ class QueryOutput(object):
     self._compress_file = None
     self._dataframe_start_row = None
     self._dataframe_max_rows = None
-    self._dataframe_use_cache = None
 
   @property
   def type(self):
@@ -155,6 +155,3 @@ class QueryOutput(object):
   def dataframe_max_rows(self):
     return self._dataframe_max_rows
 
-  @property
-  def dataframe_use_cache(self):
-    return self._dataframe_use_cache

--- a/google/datalab/bigquery/_query_output.py
+++ b/google/datalab/bigquery/_query_output.py
@@ -1,0 +1,161 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+"""Implements BigQuery output type functionality."""
+
+class QueryOutput(object):
+
+  @staticmethod
+  def table(table_name=None, table_mode='create', use_cache=True, priority='interactive',
+            allow_large_results=False):
+    """ Construct a query output object where the result is a table
+
+    Args:
+      table_name: the result table name as a string or TableName; if None (the default), then a
+          temporary table will be used.
+      table_mode: one of 'create', 'overwrite' or 'append'. If 'create' (the default), the request
+          will fail if the table exists.
+      use_cache: whether to use past query results or ignore cache. Has no effect if destination is
+          specified (default True).
+      priority:one of 'batch' or 'interactive' (default). 'interactive' jobs should be scheduled
+          to run quickly but are subject to rate limits; 'batch' jobs could be delayed by as much
+          as three hours but are not rate-limited.
+      allow_large_results: whether to allow large results; i.e. compressed data over 100MB. This is
+          slower and requires a table_name to be specified) (default False).
+    """
+    result = QueryOutput()
+    result._output_type = 'table'
+    result._table_name = table_name
+    result._table_mode = table_mode
+    result._use_cache = use_cache
+    result._priority = priority
+    result._allow_large_results = allow_large_results
+
+  @staticmethod
+  def file(paths, format='csv', csv_delimiter=',', csv_header=True, compress=False,
+           use_cache=True):
+    """ Construct a query output object where the result is either a local file or a GCS path
+
+    Note that there are two jobs that may need to be run sequentially, one to run the query,
+    and the second to extract the resulting table. These are wrapped by a single outer Job.
+
+    If the query has already been executed and you would prefer to get a Job just for the
+    extract, you can can call extract_async on the QueryResultsTable instead; i.e.:
+
+        query.execute().results.extract_async(...)
+
+    Args:
+      paths: the destination path(s). Can be a single path or a list, each path can either be
+          local or a GCS URI (starting with gs://)
+      format: the format to use for the exported data; one of 'csv', 'json', or 'avro'
+          (default 'csv').
+      csv_delimiter: for CSV exports, the field delimiter to use (default ',').
+      csv_header: for CSV exports, whether to include an initial header line (default True).
+      compress: whether to compress the data on export. Compression is not supported for
+          AVRO format (default False). Applies only to GCS URIs.
+      use_cache: whether to use cached results or not (default True).
+    """
+    result = QueryOutput()
+    result._output_type = 'file'
+    result._file_paths = paths
+    result._file_format = format
+    result._csv_delimiter = csv_delimiter
+    result._csv_header = csv_header
+    result._compress_file = compress
+
+  @staticmethod
+  def dataframe(self, start_row=0, max_rows=None, use_cache=True):
+    """ Construct a query output object where the result is a dataframe
+
+    Args:
+      start_row: the row of the table at which to start the export (default 0).
+      max_rows: an upper limit on the number of rows to export (default None).
+      use_cache: whether to use cached results or not (default True).
+    """
+    result = QueryOutput()
+    result._output_type = 'dataframe'
+    result._dataframe_start_row = start_row
+    result._dataframe_max_rows = max_rows
+    result._dataframe_use_cache = use_cache
+
+  def __init__(self):
+    """ Create a BigQuery output type object. Do not call this directly; use factory methods. """
+    self._output_type = None
+    self._table_name = None
+    self._table_mode = None
+    self._use_cache = None
+    self._priority = None
+    self._allow_large_results = None
+    self._file_paths = None
+    self._file_format = None
+    self._csv_delimiter = None
+    self._csv_header = None
+    self._compress_file = None
+    self._dataframe_start_row = None
+    self._dataframe_max_rows = None
+    self._dataframe_use_cache = None
+
+  @property
+  def type(self):
+    return self._output_type
+
+  @property
+  def table_name(self):
+    return self._table_name
+
+  @property
+  def table_mode(self):
+    return self._table_mode
+
+  @property
+  def use_cache(self):
+    return self._use_cache
+
+  @property
+  def priority(self):
+    return self._priority
+
+  @property
+  def allow_large_results(self):
+    return self._allow_large_results
+
+  @property
+  def file_paths(self):
+    return self._file_paths
+
+  @property
+  def file_format(self):
+    return self._file_format
+
+  @property
+  def csv_delimiter(self):
+    return self._csv_delimiter
+
+  @property
+  def csv_header(self):
+    return self._csv_header
+
+  @property
+  def compress_file(self):
+    return self._compress_file
+
+  @property
+  def dataframe_start_row(self):
+    return self._dataframe_start_row
+
+  @property
+  def dataframe_max_rows(self):
+    return self._dataframe_max_rows
+
+  @property
+  def dataframe_use_cache(self):
+    return self._dataframe_use_cache

--- a/google/datalab/bigquery/_query_output.py
+++ b/google/datalab/bigquery/_query_output.py
@@ -14,8 +14,8 @@
 
 class QueryOutput(object):
 
-  @staticmethod
-  def table(table_name=None, table_mode='create', use_cache=True, priority='interactive',
+  @classmethod
+  def table(output, name=None, mode='create', use_cache=True, priority='interactive',
             allow_large_results=False):
     """ Construct a query output object where the result is a table
 
@@ -32,16 +32,16 @@ class QueryOutput(object):
       allow_large_results: whether to allow large results; i.e. compressed data over 100MB. This is
           slower and requires a table_name to be specified) (default False).
     """
-    result = QueryOutput()
-    result._output_type = 'table'
-    result._table_name = table_name
-    result._table_mode = table_mode
-    result._use_cache = use_cache
-    result._priority = priority
-    result._allow_large_results = allow_large_results
+    output._output_type = 'table'
+    output._table_name = name
+    output._table_mode = mode
+    output._use_cache = use_cache
+    output._priority = priority
+    output._allow_large_results = allow_large_results
+    return result
 
-  @staticmethod
-  def file(paths, format='csv', csv_delimiter=',', csv_header=True, compress=False,
+  @classmethod
+  def file(output, path, format='csv', csv_delimiter=',', csv_header=True, compress=False,
            use_cache=True):
     """ Construct a query output object where the result is either a local file or a GCS path
 
@@ -54,8 +54,7 @@ class QueryOutput(object):
         query.execute().results.extract_async(...)
 
     Args:
-      paths: the destination path(s). Can be a single path or a list, each path can either be
-          local or a GCS URI (starting with gs://)
+      path: the destination path. Can either be a local or GCS URI (starting with gs://)
       format: the format to use for the exported data; one of 'csv', 'json', or 'avro'
           (default 'csv').
       csv_delimiter: for CSV exports, the field delimiter to use (default ',').
@@ -64,16 +63,16 @@ class QueryOutput(object):
           AVRO format (default False). Applies only to GCS URIs.
       use_cache: whether to use cached results or not (default True).
     """
-    result = QueryOutput()
-    result._output_type = 'file'
-    result._file_paths = paths
-    result._file_format = format
-    result._csv_delimiter = csv_delimiter
-    result._csv_header = csv_header
-    result._compress_file = compress
+    output._output_type = 'file'
+    output._file_path = path
+    output._file_format = format
+    output._csv_delimiter = csv_delimiter
+    output._csv_header = csv_header
+    output._compress_file = compress
+    return result
 
-  @staticmethod
-  def dataframe(self, start_row=0, max_rows=None, use_cache=True):
+  @classmethod
+  def dataframe(output, start_row=0, max_rows=None, use_cache=True):
     """ Construct a query output object where the result is a dataframe
 
     Args:
@@ -81,11 +80,11 @@ class QueryOutput(object):
       max_rows: an upper limit on the number of rows to export (default None).
       use_cache: whether to use cached results or not (default True).
     """
-    result = QueryOutput()
-    result._output_type = 'dataframe'
-    result._dataframe_start_row = start_row
-    result._dataframe_max_rows = max_rows
-    result._dataframe_use_cache = use_cache
+    output._output_type = 'dataframe'
+    output._dataframe_start_row = start_row
+    output._dataframe_max_rows = max_rows
+    output._dataframe_use_cache = use_cache
+    return result
 
   def __init__(self):
     """ Create a BigQuery output type object. Do not call this directly; use factory methods. """
@@ -95,7 +94,7 @@ class QueryOutput(object):
     self._use_cache = None
     self._priority = None
     self._allow_large_results = None
-    self._file_paths = None
+    self._file_path = None
     self._file_format = None
     self._csv_delimiter = None
     self._csv_header = None
@@ -129,8 +128,8 @@ class QueryOutput(object):
     return self._allow_large_results
 
   @property
-  def file_paths(self):
-    return self._file_paths
+  def file_path(self):
+    return self._file_path
 
   @property
   def file_format(self):

--- a/google/datalab/bigquery/_sampling.py
+++ b/google/datalab/bigquery/_sampling.py
@@ -69,24 +69,6 @@ class Sampling(object):
     projection = Sampling._create_projection(fields)
     return lambda sql: 'SELECT %s FROM (%s) ORDER BY %s%s LIMIT %d' % (projection, sql, field_name,
                                                                        direction, count)
-
-  @staticmethod
-  def sampling_query(sql, fields=None, count=5, sampling=None):
-    """Returns a sampling query for the SQL object.
-
-    Args:
-      sql: the SQL object to sample
-      fields: an optional list of field names to retrieve.
-      count: an optional count of rows to retrieve which is used if a specific
-          sampling is not specified.
-      sampling: an optional sampling strategy to apply to the table.
-    Returns:
-      A SQL query string for sampling the input sql.
-    """
-    if sampling is None:
-      sampling = Sampling.default(count=count, fields=fields)
-    return sampling(sql)
-
   @staticmethod
   def hashed(field_name, percent, fields=None, count=0):
     """Provides a sampling strategy based on hashing and selecting a percentage of data.

--- a/google/datalab/bigquery/_table.py
+++ b/google/datalab/bigquery/_table.py
@@ -37,6 +37,8 @@ from . import _job
 from . import _parser
 from . import _schema
 from . import _utils
+from ._query_output import QueryOutput
+from ._sampling import Sampling
 
 
 # import of Query is at end of module as we have a circular dependency of
@@ -262,11 +264,11 @@ class Table(object):
     # Do import here to avoid top-level circular dependencies.
     from . import _query
     sql = self._repr_sql_()
-    return _query.Query.sampling_query(sql, context=self._context, count=count, fields=fields,
-                                       sampling=sampling) \
-                        .execute(use_cache=use_cache,
-                                 dialect=dialect,
-                                 billing_tier=billing_tier) \
+    query = _query.Query(sql, context=self._context)
+    if sampling is None:
+      sampling = Sampling.default(fields=fields, count=count)
+    return query.execute(QueryOutput.table(use_cache=use_cache), sampling=sampling,
+                         dialect=dialect, billing_tier=billing_tier) \
                         .results
 
   @staticmethod

--- a/google/datalab/bigquery/_view.py
+++ b/google/datalab/bigquery/_view.py
@@ -20,6 +20,7 @@ import google.datalab.context
 
 from . import _query
 from . import _table
+from ._query_output import QueryOutput
 
 # Query import is at end to avoid issues with circular dependencies.
 
@@ -183,9 +184,9 @@ class View(object):
     Raises:
       Exception if the query could not be executed or query response was malformed.
     """
-    return self._materialization.execute(use_cache=use_cache, dialect=dialect,
-                                         billing_tier=billing_tier) \
-                                .results
+    output_options = QueryOutput.table(use_cache=use_cache)
+    return self._materialization.execute(output_options, dialect=dialect,
+                                               billing_tier=billing_tier).results
 
   def execute_async(self, table_name=None, table_mode='create', use_cache=True, priority='high',
                     allow_large_results=False, dialect=None, billing_tier=None):
@@ -214,10 +215,10 @@ class View(object):
     Raises:
       Exception (KeyError) if View could not be materialized.
     """
-    return self._materialization.execute_async(table_name=table_name, table_mode=table_mode,
-                                               use_cache=use_cache, priority=priority,
-                                               allow_large_results=allow_large_results,
-                                               dialect=dialect, billing_tier=billing_tier)
+    output_options = QueryOutput.table(name=table_name, mode=table_mode,
+                                                     use_cache=use_cache, priority=priority,
+                                                     allow_large_results=allow_large_results)
+    return self._materialization.execute_async(output_options, dialect=dialect, billing_tier=billing_tier)
 
   def execute(self, table_name=None, table_mode='create', use_cache=True, priority='high',
               allow_large_results=False, dialect=None, billing_tier=None):
@@ -246,10 +247,10 @@ class View(object):
     Raises:
       Exception (KeyError) if View could not be materialized.
     """
-    return self._materialization.execute(table_name=table_name, table_mode=table_mode,
-                                         use_cache=use_cache, priority=priority,
-                                         allow_large_results=allow_large_results,
-                                         dialect=dialect, billing_tier=billing_tier)
+    output_options = QueryOutput.table(name=table_name, mode=table_mode,
+                                                     use_cache=use_cache, priority=priority,
+                                                     allow_large_results=allow_large_results)
+    return self._materialization.execute_async(output_options, dialect=dialect, billing_tier=billing_tier)
 
   def _repr_sql_(self):
     """Returns a representation of the view for embedding into a SQL statement.

--- a/google/datalab/mlalpha/commands/_mlalpha.py
+++ b/google/datalab/mlalpha/commands/_mlalpha.py
@@ -276,7 +276,7 @@ def _train(args, cell):
     all_messages = []
     log_dir = os.getcwd()
     if google.datalab.context._utils._in_datalab_docker():
-      log_dir = '/google.datalab/nocachecontent'
+      log_dir = '/datalab/nocachecontent'
       if not os.path.exists(log_dir):
         os.makedirs(log_dir)
     program_args = config.get('args', None)

--- a/google/datalab/notebook/static/charting.ts
+++ b/google/datalab/notebook/static/charting.ts
@@ -16,7 +16,7 @@
 
 module Charting {
   declare var IPython:any;
-  declare var google.datalab:any;
+  declare var datalab:any;
 
 // Wrappers for Plotly.js and Google Charts
 
@@ -638,7 +638,7 @@ module Charting {
         this.cellElement.classList.remove('completed');
       }
       var _this = this;
-      google.datalab.session.execute(code, function (error:string, response:any) {
+      datalab.session.execute(code, function (error:string, response:any) {
         _this.handleNewData(env, error, response);
       });
     }
@@ -897,7 +897,7 @@ module Charting {
                    refreshInterval:number,
                    totalRows:number):void {
     require(["base/js/namespace"], function(Jupyter: any) {
-      var url = "google.datalab/";
+      var url = "datalab/";
       require(driver.requires(url, chartStyle), function (/* ... */) {
         // chart module should be last dependency in require() call...
         var chartModule = arguments[arguments.length - 1];  // See if it needs to be a member.
@@ -952,7 +952,7 @@ module Charting {
       data = this.convertListToDataTable(data);
     }
 
-    // If we have a google.datalab session, we can go ahead and draw the chart; if not, add code to do the
+    // If we have a datalab session, we can go ahead and draw the chart; if not, add code to do the
     // drawing to an event handler for when the kernel is ready.
     if (IPython.notebook.kernel.is_connected()) {
       _render(driver, dom, chartStyle, controlIds, data, options, refreshData, refreshInterval,

--- a/google/datalab/notebook/static/job.ts
+++ b/google/datalab/notebook/static/job.ts
@@ -14,7 +14,7 @@
 
 /// <reference path="../../../externs/ts/require/require.d.ts" />
 
-declare var google.datalab: any;
+declare var datalab: any;
 declare var IPython: any;
 
 module Job {
@@ -22,7 +22,7 @@ module Job {
   function refresh(dom: any, job_name: any, job_type: any, interval: any,
       html_on_running: string, html_on_success: string): any {
     var code = '%_get_job_status ' + job_name + ' ' + job_type;
-    google.datalab.session.execute(code, function (error: any, newData: any) {
+    datalab.session.execute(code, function (error: any, newData: any) {
       error = error || newData.error;
       if (error) {
         dom.innerHTML = '<p class="jobfail">Job failed with error: ' + error

--- a/google/datalab/utils/commands/_job.py
+++ b/google/datalab/utils/commands/_job.py
@@ -45,8 +45,8 @@ def html_job_status(job_name, job_type, refresh_interval, html_on_running, html_
     <div class="jobstatus" id="%s">
     </div>
     <script>
-      require(['google.datalab/job', 'google.datalab/element!%s', 'base/js/events',
-          'google.datalab/style!/nbextensions/google.datalab/job.css'],
+      require(['datalab/job', 'datalab/element!%s', 'base/js/events',
+          'datalab/style!/nbextensions/datalab/job.css'],
         function(job, dom, events) {
           job.render(dom, events, '%s', '%s', %s, '%s', '%s');
         }

--- a/google/datalab/utils/commands/_utils.py
+++ b/google/datalab/utils/commands/_utils.py
@@ -608,7 +608,7 @@ def chart_html(driver_name, chart_type, source, chart_options=None, fields='*', 
         }},
         map: {{
           '*': {{
-            google.datalab: 'nbextensions/gcpdatalab'
+            datalab: 'nbextensions/gcpdatalab'
           }}
         }},
         shim: {{
@@ -619,10 +619,10 @@ def chart_html(driver_name, chart_type, source, chart_options=None, fields='*', 
         }}
       }});
 
-      require(['google.datalab/charting',
-               'google.datalab/element!{id}',
+      require(['datalab/charting',
+               'datalab/element!{id}',
                'base/js/events',
-               'google.datalab/style!/nbextensions/gcpdatalab/charting.css'
+               'datalab/style!/nbextensions/gcpdatalab/charting.css'
               ],
         function(charts, dom, events) {{
           charts.render(

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,22 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'ipykernel==4.4.1',
   ],
   package_data={
+    'google.datalab.notebook': [
+        'static/bigquery.css',
+        'static/bigquery.js',
+        'static/charting.css',
+        'static/charting.js',
+        'static/job.css',
+        'static/job.js',
+        'static/element.js',
+        'static/style.js',
+        'static/visualization.js',
+        'static/codemirror/mode/sql.js',
+        'static/parcoords.js',
+        'static/extern/d3.parcoords.js',
+        'static/extern/d3.parcoords.css',
+        'static/extern/sylvester.js',
+      ],
     'datalab.notebook': [
         'static/bigquery.css',
         'static/bigquery.js',


### PR DESCRIPTION
- Added a new `QueryOutput` type that can be built using one of three factory methods: table, file (gcs or local), or dataframe
- Removed `Query.extract/to_file/to_dataframe` and their async counterparts, and kept only `execute` and `execute_async`, which now take a `QueryOutput` object to tell it what to do. The `async` method uses the `google.datalab.utils.async_function` decorator to spawn a thread in order to wrap the query job as well as the export job (local file, gcs, or dataframe) in a `Job` object so it runs in the background. The synchronous `execute` just calls `.wait()` on its async sister.
- Fixed several references to `google.datalab` that were added by mistake by my sed command. There might be more of these, but things aren't breaking apart so I'll scrub them in a later PR.