### PR TITLE
Remove Query.sample and Query.sampling_query

### DIFF
--- a/google/datalab/bigquery/_sampling.py
+++ b/google/datalab/bigquery/_sampling.py
@@ -69,24 +69,6 @@ class Sampling(object):
     projection = Sampling._create_projection(fields)
     return lambda sql: 'SELECT %s FROM (%s) ORDER BY %s%s LIMIT %d' % (projection, sql, field_name,
                                                                        direction, count)
-
-  @staticmethod
-  def sampling_query(sql, fields=None, count=5, sampling=None):
-    """Returns a sampling query for the SQL object.
-
-    Args:
-      sql: the SQL object to sample
-      fields: an optional list of field names to retrieve.
-      count: an optional count of rows to retrieve which is used if a specific
-          sampling is not specified.
-      sampling: an optional sampling strategy to apply to the table.
-    Returns:
-      A SQL query string for sampling the input sql.
-    """
-    if sampling is None:
-      sampling = Sampling.default(count=count, fields=fields)
-    return sampling(sql)
-
   @staticmethod
   def hashed(field_name, percent, fields=None, count=0):
     """Provides a sampling strategy based on hashing and selecting a percentage of data.

--- a/google/datalab/bigquery/_table.py
+++ b/google/datalab/bigquery/_table.py
@@ -37,6 +37,8 @@ from . import _job
 from . import _parser
 from . import _schema
 from . import _utils
+from ._query_output import QueryOutput
+from ._sampling import Sampling
 
 
 # import of Query is at end of module as we have a circular dependency of
@@ -262,11 +264,11 @@ class Table(object):
     # Do import here to avoid top-level circular dependencies.
     from . import _query
     sql = self._repr_sql_()
-    return _query.Query.sampling_query(sql, context=self._context, count=count, fields=fields,
-                                       sampling=sampling) \
-                        .execute(use_cache=use_cache,
-                                 dialect=dialect,
-                                 billing_tier=billing_tier) \
+    query = _query.Query(sql, context=self._context)
+    if sampling is None:
+      sampling = Sampling.default(fields=fields, count=count)
+    return query.execute(QueryOutput.table(use_cache=use_cache), sampling=sampling,
+                         dialect=dialect, billing_tier=billing_tier) \
                         .results
 
   @staticmethod


### PR DESCRIPTION
This PR folds the query sampling functionality into its `execute` and `execute_async` methods.

This branch is based on google-datalab-dev, which has an ongoing PR (https://github.com/googledatalab/pydatalab/pull/149), so I'll rebase it on any changes introduced there, they shouldn't affect these changes though.