### PR TITLE
SchemaField/Schema related changes

### DIFF
--- a/google/datalab/bigquery/_schema.py
+++ b/google/datalab/bigquery/_schema.py
@@ -22,71 +22,68 @@ import datetime
 import pandas
 
 
+class SchemaField(object):
+  """ Represents a single field in a Table schema.
+
+  This has the properties:
+
+  - name: the flattened, full-qualified name of the field.
+  - type: the type of the field as a string ('INTEGER', 'BOOLEAN', 'FLOAT', 'STRING'
+     or 'TIMESTAMP').
+  - mode: the mode of the field; 'NULLABLE' by default.
+  - description: a description of the field, if known; empty string by default.
+
+   """
+
+  def __init__(self, name, type, mode='NULLABLE', description=''):
+    self.name = name
+    self.type = type
+    self.mode = mode
+    self.description = description
+
+  def _repr_sql_(self):
+    """Returns a representation of the field for embedding into a SQL statement.
+
+    Returns:
+      A formatted field name for use within SQL statements.
+    """
+    return self.name
+
+  def __eq__(self, other):
+    """ Compare two schema field objects for equality (ignoring description). """
+    return self.name == other.name and self.type == other.type\
+        and self.mode == other.mode
+
+  def __str__(self):
+    """ Returns the schema field as a string form of a dictionary. """
+    return "{ 'name': '%s', 'type': '%s', 'mode':'%s', 'description': '%s' }" % \
+           (self.name, self.type, self.mode, self.description)
+
+  def __repr__(self):
+    """ Returns the schema field as a string form of a dictionary. """
+    return str(self)
+
+  def __getitem__(self, item):
+    # TODO(gram): Currently we need this for a Schema object to work with the Parser object.
+    # Eventually if we change Parser to only work with Schema (and not also with the
+    # schema dictionaries in query results) we can remove this.
+
+    if item == 'name':
+      return self.name
+    if item == 'type':
+      return self.type
+    if item == 'mode':
+      return self.mode
+    if item == 'description':
+      return self.description
+
 class Schema(list):
   """Represents the schema of a BigQuery table as a flattened list of objects representing fields.
 
-   Each field object has name, data_type, mode and description properties. Nested fields
+   Each field object has name, type, mode and description properties. Nested fields
    get flattened with their full-qualified names. So a Schema that has an object A with nested
    field B will be represented as [(name: 'A', ...), (name: 'A.b', ...)].
   """
-
-  class Field(object):
-    """ Represents a single field in a Table schema.
-
-    This has the properties:
-
-    - name: the flattened, full-qualified name of the field.
-    - data_type: the type of the field as a string ('INTEGER', 'BOOLEAN', 'FLOAT', 'STRING'
-       or 'TIMESTAMP').
-    - mode: the mode of the field; 'NULLABLE' by default.
-    - description: a description of the field, if known; empty string by default.
-
-     """
-
-    # TODO(gram): consider renaming data_type member to type. Yes, it shadows top-level
-    # name but that is what we are using in __str__ and __getitem__ and is what is used in BQ.
-    # The shadowing is unlikely to cause problems.
-    def __init__(self, name, data_type, mode='NULLABLE', description=''):
-      self.name = name
-      self.data_type = data_type
-      self.mode = mode
-      self.description = description
-
-    def _repr_sql_(self):
-      """Returns a representation of the field for embedding into a SQL statement.
-
-      Returns:
-        A formatted field name for use within SQL statements.
-      """
-      return self.name
-
-    def __eq__(self, other):
-      """ Compare two schema field objects for equality (ignoring description). """
-      return self.name == other.name and self.data_type == other.data_type\
-          and self.mode == other.mode
-
-    def __str__(self):
-      """ Returns the schema field as a string form of a dictionary. """
-      return "{ 'name': '%s', 'type': '%s', 'mode':'%s', 'description': '%s' }" % \
-             (self.name, self.data_type, self.mode, self.description)
-
-    def __repr__(self):
-      """ Returns the schema field as a string form of a dictionary. """
-      return str(self)
-
-    def __getitem__(self, item):
-      # TODO(gram): Currently we need this for a Schema object to work with the Parser object.
-      # Eventually if we change Parser to only work with Schema (and not also with the
-      # schema dictionaries in query results) we can remove this.
-
-      if item == 'name':
-        return self.name
-      if item == 'type':
-        return self.data_type
-      if item == 'mode':
-        return self.mode
-      if item == 'description':
-        return self.description
 
   @staticmethod
   def _from_dataframe(dataframe, default_type='STRING'):
@@ -122,24 +119,6 @@ class Schema(list):
                      'type': type_mapping.get(dtype.kind, default_type)})
 
     return fields
-
-  @staticmethod
-  def from_dataframe(dataframe, default_type='STRING'):
-    """
-      Infer a BigQuery table schema from a Pandas dataframe. Note that if you don't explicitly set
-      the types of the columns in the dataframe, they may be of a type that forces coercion to
-      STRING, so even though the fields in the dataframe themselves may be numeric, the type in the
-      derived schema may not be. Hence it is prudent to make sure the Pandas dataframe is typed
-      correctly.
-
-    Args:
-      dataframe: The DataFrame.
-      default_type : The default big query type in case the type of the column does not exist in
-          the schema. Defaults to 'STRING'.
-    Returns:
-      A Schema.
-    """
-    return Schema(Schema._from_dataframe(dataframe, default_type=default_type))
 
   @staticmethod
   def _get_field_entry(name, value):
@@ -300,8 +279,8 @@ class Schema(list):
     # noinspection PyCallByClass
     return list.__getitem__(self, key)
 
-  def _add_field(self, name, data_type, mode='NULLABLE', description=''):
-    field = Schema.Field(name, data_type, mode, description)
+  def _add_field(self, name, type, mode='NULLABLE', description=''):
+    field = SchemaField(name, type, mode, description)
     self.append(field)
     self._map[name] = field
 
@@ -321,11 +300,11 @@ class Schema(list):
   def _populate_fields(self, data, prefix=''):
     for field_data in data:
       name = prefix + field_data['name']
-      data_type = field_data['type']
-      self._add_field(name, data_type, field_data.get('mode', None),
+      type = field_data['type']
+      self._add_field(name, type, field_data.get('mode', None),
                       field_data.get('description', None))
 
-      if data_type == 'RECORD':
+      if type == 'RECORD':
         # Recurse into the nested fields, using this field's name as a prefix.
         self._populate_fields(field_data.get('fields'), name + '.')
 

--- a/google/datalab/bigquery/_table.py
+++ b/google/datalab/bigquery/_table.py
@@ -355,8 +355,8 @@ class Table(object):
       table_field = table_schema[name]
       if table_field is None:
         raise Exception('Table does not contain field %s' % name)
-      data_type = data_field.data_type
-      table_type = table_field.data_type
+      data_type = data_field.type
+      table_type = table_field.type
       if table_type != data_type:
         raise Exception('Field %s in data has type %s but in table has type %s' %
                         (name, data_type, table_type))

--- a/google/datalab/utils/commands/_utils.py
+++ b/google/datalab/utils/commands/_utils.py
@@ -113,7 +113,7 @@ def _get_cols(fields, schema):
   for col in fields:
     if schema:
       f = schema[col]
-      t = 'string' if f.mode == 'REPEATED' else typemap.get(f.data_type, 'string')
+      t = 'string' if f.mode == 'REPEATED' else typemap.get(f.type, 'string')
       cols.append({'id': f.name, 'label': f.name, 'type': t})
     else:
       # This will only happen if we had no rows to infer a schema from, so the type


### PR DESCRIPTION
- Move `Schema.Field` to top level class `SchemaField`
- Rename `field.data_type` to `field.type`
- Schema type is inferred in the `from_data` method of `Schema`, except for the cases where the type is a list, which can either be interpreted a record or a list of records. I removed the `from_dataframe` method since it can be inferred, but kept the `from_record` method, which can be used to resolve the ambiguity.