### PR TITLE
Remove context from query construction, move it to execution

### DIFF
--- a/google/datalab/bigquery/_table.py
+++ b/google/datalab/bigquery/_table.py
@@ -255,10 +255,11 @@ class Table(object):
     # Do import here to avoid top-level circular dependencies.
     from . import _query
     sql = self._repr_sql_()
-    query = _query.Query(sql, context=self._context)
+    query = _query.Query(sql)
     if sampling is None:
       sampling = Sampling.default(fields=fields, count=count)
-    return query.execute(QueryOutput.table(use_cache=use_cache), sampling=sampling).results
+    return query.execute(QueryOutput.table(use_cache=use_cache), sampling=sampling,
+                         context=self._context).results
 
   @staticmethod
   def _encode_dict_as_row(record, column_name_map):
@@ -895,5 +896,5 @@ class Table(object):
       fields = '*'
     elif isinstance(fields, list):
       fields = ','.join(fields)
-    return _query.Query('SELECT %s FROM %s' % (fields, self._repr_sql_()), context=self._context)
+    return _query.Query('SELECT %s FROM %s' % (fields, self._repr_sql_()))
 

--- a/google/datalab/bigquery/_view.py
+++ b/google/datalab/bigquery/_view.py
@@ -50,7 +50,7 @@ class View(object):
       context = google.datalab.Context.default()
     self._context = context
     self._table = _table.Table(name, context=context)
-    self._materialization = _query.Query('SELECT * FROM %s' % self._repr_sql_(), context=context)
+    self._materialization = _query.Query('SELECT * FROM %s' % self._repr_sql_())
 
   def __str__(self):
     """The full name for the view as a string."""
@@ -78,7 +78,7 @@ class View(object):
       return None
     self._table._load_info()
     if 'view' in self._table._info and 'query' in self._table._info['view']:
-      return _query.Query(self._table._info['view']['query'], context=self._context)
+      return _query.Query(self._table._info['view']['query'])
     return None
 
   def exists(self):
@@ -167,7 +167,7 @@ class View(object):
       Exception if the query could not be executed or query response was malformed.
     """
     output_options = QueryOutput.table(use_cache=use_cache)
-    return self._materialization.execute(output_options).result()
+    return self._materialization.execute(output_options, context=self._context).result()
 
   def execute_async(self, table_name=None, table_mode='create', use_cache=True, priority='high',
                     allow_large_results=False):

--- a/google/datalab/data/commands/_sql.py
+++ b/google/datalab/data/commands/_sql.py
@@ -400,8 +400,8 @@ def sql_cell(args, cell):
         context.config['bigquery_dialect'] = dialect_arg
       if billing_tier_arg:
         context.config['bigquery_billing_tier'] = billing_tier_arg
-      return google.datalab.bigquery.Query(query, context=context, values=ipy.user_ns) \
-                                    .execute().results
+      return google.datalab.bigquery.Query(query, values=ipy.user_ns) \
+                                    .execute(context=context).results
   else:
     # Add it as a module
     sys.modules[name] = module

--- a/google/datalab/kernel/__init__.py
+++ b/google/datalab/kernel/__init__.py
@@ -115,7 +115,7 @@ def load_ipython_extension(shell):
 
   def _set_bq_dialect(bq_dialect):
     context = google.datalab.Context.default()
-    context.config.['bigquery_dialect'] = bq_dialect
+    context.config['bigquery_dialect'] = bq_dialect
 
   try:
     if 'datalab_project_id' not in _IPython.get_ipython().user_ns:

--- a/tests/bigquery/external_data_source_tests.py
+++ b/tests/bigquery/external_data_source_tests.py
@@ -113,7 +113,7 @@ class TestCases(unittest.TestCase):
     sql = 'SELECT * FROM weight'
 
     weight = google.datalab.bigquery.ExternalDataSource(table_uri, schema=schema, csv_options=options)
-    q = google.datalab.bigquery.Query(sql, data_sources={'weight': weight}, context=self._create_context())
+    q = google.datalab.bigquery.Query(sql, data_sources={'weight': weight})
     q.execute_async()
 
     table_definition = self._get_table_definition(table_uri, skip_rows=1)
@@ -134,7 +134,7 @@ class TestCases(unittest.TestCase):
     sql = 'SELECT * FROM weight'
 
     weight = google.datalab.bigquery.ExternalDataSource(table_uris, schema=schema)
-    q = google.datalab.bigquery.Query(sql, data_sources={'weight': weight}, context=self._create_context())
+    q = google.datalab.bigquery.Query(sql, data_sources={'weight': weight})
     q.execute_async()
 
     table_definition = self._get_table_definition(table_uris)
@@ -159,7 +159,7 @@ class TestCases(unittest.TestCase):
     weight1 = google.datalab.bigquery.ExternalDataSource(table_uri1, schema=schema,
                                                        csv_options=options)
     weight2 = google.datalab.bigquery.ExternalDataSource(table_uri2, schema=schema)
-    q = google.datalab.bigquery.Query(sql, values={'weight1': weight1, 'weight2': weight2}, context=self._create_context())
+    q = google.datalab.bigquery.Query(sql, values={'weight1': weight1, 'weight2': weight2})
     q.execute_async()
 
     table_definition1 = self._get_table_definition(table_uri1, skip_rows=1)

--- a/tests/bigquery/query_tests.py
+++ b/tests/bigquery/query_tests.py
@@ -120,8 +120,8 @@ class TestCases(unittest.TestCase):
   @staticmethod
   def _create_query(sql='SELECT * ...', name=None, values=None, udfs=None, data_sources=None,
                     subqueries=None):
-    q = google.datalab.bigquery.Query(sql, context=TestCases._create_context(), values=values,
-                                      udfs=udfs, data_sources=data_sources, subqueries=subqueries)
+    q = google.datalab.bigquery.Query(sql, values=values, udfs=udfs, data_sources=data_sources,
+                                      subqueries=subqueries)
     if name:
       values[name] = q
     return q


### PR DESCRIPTION
The reason for the change is to separate query creation from execution, so that queries can be executed with different settings (project ids, billing tiers... etc), and reduce confusion if the user tries to execute a query that takes subqueries built with different context settings. Instead, query execution is the only context that is taken into account.

This PR also fixes another tiny bug in `google/datalab/kernel/__init__.py`.