### PR TITLE
Rename 'values' to 'env', and 'query_params' in Query constructor

### DIFF
--- a/google/datalab/bigquery/_query.py
+++ b/google/datalab/bigquery/_query.py
@@ -38,13 +38,7 @@ class Query(object):
     """Initializes an instance of a Query object.
 
     Args:
-      sql: the BigQuery SQL query string to execute, or a SqlStatement object. The latter will
-          have any variable references replaced before being associated with the Query (i.e.
-          once constructed the SQL associated with a Query is static).
-
-          It is possible to have variable references in a query string too provided the variables
-          are passed as keyword arguments to this constructor.
-
+      sql: the BigQuery SQL query string to execute
       env: a dictionary containing objects from the query execution context, used to get references
           to UDFs, subqueries, and external data sources referenced by the query
       query_params: a dictionary containing query parameter types and values, passed to BigQuery.

--- a/google/datalab/bigquery/commands/_bigquery.py
+++ b/google/datalab/bigquery/commands/_bigquery.py
@@ -314,7 +314,7 @@ def _get_query_argument(args, cell, env):
     # Assume we have inline SQL in the cell
     if not isinstance(cell, basestring):
       raise Exception('Expected a --query argument or inline SQL')
-    return google.datalab.bigquery.Query(cell, values=env)
+    return google.datalab.bigquery.Query(cell, env=env)
 
   item = google.datalab.utils.commands.get_notebook_item(sql_arg)
   if isinstance(item, google.datalab.bigquery.Query):  # Queries are already expanded.
@@ -325,7 +325,7 @@ def _get_query_argument(args, cell, env):
   item, env = google.datalab.data.SqlModule.get_sql_statement_with_environment(item, config)
   if cell:
     env.update(config)  # config is both a fallback and an override.
-  return google.datalab.bigquery.Query(item, values=env)
+  return google.datalab.bigquery.Query(item, env=env)
 
 
 def _sample_cell(args, cell_body):
@@ -356,7 +356,7 @@ def _sample_cell(args, cell_body):
     if not isinstance(view, google.datalab.bigquery.View):
       raise Exception('Could not find view %s' % args['view'])
   else:
-    query = google.datalab.bigquery.Query(cell_body, values=env)
+    query = google.datalab.bigquery.Query(cell_body, env=env)
 
   # parse comma-separated list of fields
   fields = args['fields'].split(',') if args['fields'] else None
@@ -467,7 +467,7 @@ def _query_cell(args, cell_body):
   subqueries = args['subqueries']
 
   # Finally build the query object
-  query = google.datalab.bigquery.Query(cell_body, values=IPython.get_ipython().user_ns,
+  query = google.datalab.bigquery.Query(cell_body, env=IPython.get_ipython().user_ns,
                                         udfs=udfs, data_sources=datasources, subqueries=subqueries)
   google.datalab.utils.commands.notebook_environment()[name] = query
 

--- a/google/datalab/data/commands/_sql.py
+++ b/google/datalab/data/commands/_sql.py
@@ -400,7 +400,7 @@ def sql_cell(args, cell):
         context.config['bigquery_dialect'] = dialect_arg
       if billing_tier_arg:
         context.config['bigquery_billing_tier'] = billing_tier_arg
-      return google.datalab.bigquery.Query(query, values=ipy.user_ns) \
+      return google.datalab.bigquery.Query(query, env=ipy.user_ns) \
                                     .execute(context=context).results
   else:
     # Add it as a module

--- a/google/datalab/utils/commands/_utils.py
+++ b/google/datalab/utils/commands/_utils.py
@@ -217,7 +217,7 @@ def get_data(source, fields='*', env=None, first_row=0, count=-1, schema=None):
       source = google.datalab.bigquery.Table(source)
 
   if isinstance(source, types.ModuleType) or isinstance(source, google.datalab.data.SqlStatement):
-    source = google.datalab.bigquery.Query(source, values=env)
+    source = google.datalab.bigquery.Query(source, env=env)
 
   if isinstance(source, list):
     if len(source) == 0:

--- a/tests/bigquery/external_data_source_tests.py
+++ b/tests/bigquery/external_data_source_tests.py
@@ -159,7 +159,7 @@ class TestCases(unittest.TestCase):
     weight1 = google.datalab.bigquery.ExternalDataSource(table_uri1, schema=schema,
                                                        csv_options=options)
     weight2 = google.datalab.bigquery.ExternalDataSource(table_uri2, schema=schema)
-    q = google.datalab.bigquery.Query(sql, values={'weight1': weight1, 'weight2': weight2})
+    q = google.datalab.bigquery.Query(sql, env={'weight1': weight1, 'weight2': weight2})
     q.execute_async()
 
     table_definition1 = self._get_table_definition(table_uri1, skip_rows=1)

--- a/tests/bigquery/query_tests.py
+++ b/tests/bigquery/query_tests.py
@@ -102,15 +102,15 @@ class TestCases(unittest.TestCase):
     with self.assertRaises(Exception) as error:
       TestCases._create_query('SELECT test_udf(field1) FROM test_table', udfs=['test_udf'])
 
-    values = {}
+    env = {}
 
     # test direct subquery expansion
-    q1 = TestCases._create_query('SELECT * FROM test_table', name='q1', values=values)
-    q2 = TestCases._create_query('SELECT * FROM q1', name='q2', subqueries=['q1'], values=values)
+    q1 = TestCases._create_query('SELECT * FROM test_table', name='q1', env=env)
+    q2 = TestCases._create_query('SELECT * FROM q1', name='q2', subqueries=['q1'], env=env)
     self.assertEqual('WITH q1 AS (SELECT * FROM test_table)\nSELECT * FROM q1', q2.sql)
 
     # test recursive, second level subquery expansion
-    q3 = TestCases._create_query('SELECT * FROM q2', name='q3', subqueries=['q2'], values=values)
+    q3 = TestCases._create_query('SELECT * FROM q2', name='q3', subqueries=['q2'], env=env)
     # subquery listing order is random, try both possibilities
     expected_sql1 = 'WITH q1 AS (%s),\nq2 AS (%s)\n%s' % (q1._sql, q2._sql, q3._sql)
     expected_sql2 = 'WITH q2 AS (%s),\nq1 AS (%s)\n%s' % (q2._sql, q1._sql, q3._sql)
@@ -118,12 +118,12 @@ class TestCases(unittest.TestCase):
     self.assertTrue((expected_sql1 == q3.sql) or (expected_sql2 == q3.sql))
 
   @staticmethod
-  def _create_query(sql='SELECT * ...', name=None, values=None, udfs=None, data_sources=None,
+  def _create_query(sql='SELECT * ...', name=None, env=None, udfs=None, data_sources=None,
                     subqueries=None):
-    q = google.datalab.bigquery.Query(sql, values=values, udfs=udfs, data_sources=data_sources,
+    q = google.datalab.bigquery.Query(sql, env=env, udfs=udfs, data_sources=data_sources,
                                       subqueries=subqueries)
     if name:
-      values[name] = q
+      env[name] = q
     return q
 
   @staticmethod

--- a/tests/kernel/sql_tests.py
+++ b/tests/kernel/sql_tests.py
@@ -113,52 +113,6 @@ class TestCases(unittest.TestCase):
     self.assertEquals('SELECT * FROM $q1', m.__dict__[TestCases._SQL_MODULE_MAIN].sql)
     self.assertEquals('SELECT * FROM $q1', m.__dict__[TestCases._SQL_MODULE_LAST].sql)
 
-  @mock.patch('google.datalab.Context.default')
-  def test_arguments(self, mock_default_context):
-    mock_default_context.return_value = TestCases._create_context()
-    m = imp.new_module('m')
-    query = google.datalab.data.commands._sql._split_cell("""
-words = ('thus', 'forsooth')
-limit = 10
-
-SELECT * FROM [publicdata:samples.shakespeare]
-WHERE word IN $words
-LIMIT $limit
-""", m)
-    sql = google.datalab.bigquery.Query(query, env={}).sql
-    self.assertEquals('SELECT * FROM [publicdata:samples.shakespeare]\n' +
-                      'WHERE word IN ("thus", "forsooth")\nLIMIT 10', sql)
-    # As above but with overrides, using list
-    sql = google.datalab.bigquery.Query(query, env={'words': 'eyeball', 'limit': 5}).sql
-    self.assertEquals('SELECT * FROM [publicdata:samples.shakespeare]\n' +
-                      'WHERE word IN "eyeball"\nLIMIT 5', sql)
-    # As above but with overrides, using tuple and env dict
-    sql = google.datalab.bigquery.Query(query, env={'limit': 3, 'words': ('thus',)}).sql
-    self.assertEquals('SELECT * FROM [publicdata:samples.shakespeare]\n' +
-                      'WHERE word IN ("thus")\nLIMIT 3', sql)
-    # As above but with list argument
-    m = imp.new_module('m')
-    query = google.datalab.data.commands._sql._split_cell("""
-words = ['thus', 'forsooth']
-limit = 10
-
-SELECT * FROM [publicdata:samples.shakespeare]
-WHERE word IN $words
-LIMIT $limit
-""", m)
-    sql = google.datalab.bigquery.Query(query, env={}).sql
-    self.assertEquals('SELECT * FROM [publicdata:samples.shakespeare]\n' +
-                      'WHERE word IN ("thus", "forsooth")\nLIMIT 10', sql)
-    # As above but with overrides, using list
-    sql = google.datalab.bigquery.Query(query, env={'limit': 2, 'words': ['forsooth']}).sql
-    self.assertEquals('SELECT * FROM [publicdata:samples.shakespeare]\n' +
-                      'WHERE word IN ("forsooth")\nLIMIT 2', sql)
-    # As above but with overrides, using tuple
-    sql = google.datalab.bigquery.Query(query, env={'words': 'eyeball'}).sql
-    self.assertEquals('SELECT * FROM [publicdata:samples.shakespeare]\n' +
-                      'WHERE word IN "eyeball"\nLIMIT 10', sql)
-    # TODO(gram): add some tests for source and datestring variables
-
   def test_date(self):
     # TODO(gram): complete this test
     pass

--- a/tests/kernel/sql_tests.py
+++ b/tests/kernel/sql_tests.py
@@ -125,15 +125,15 @@ SELECT * FROM [publicdata:samples.shakespeare]
 WHERE word IN $words
 LIMIT $limit
 """, m)
-    sql = google.datalab.bigquery.Query(query, values={}).sql
+    sql = google.datalab.bigquery.Query(query, env={}).sql
     self.assertEquals('SELECT * FROM [publicdata:samples.shakespeare]\n' +
                       'WHERE word IN ("thus", "forsooth")\nLIMIT 10', sql)
     # As above but with overrides, using list
-    sql = google.datalab.bigquery.Query(query, values={'words': 'eyeball', 'limit': 5}).sql
+    sql = google.datalab.bigquery.Query(query, env={'words': 'eyeball', 'limit': 5}).sql
     self.assertEquals('SELECT * FROM [publicdata:samples.shakespeare]\n' +
                       'WHERE word IN "eyeball"\nLIMIT 5', sql)
-    # As above but with overrides, using tuple and values dict
-    sql = google.datalab.bigquery.Query(query, values={'limit': 3, 'words': ('thus',)}).sql
+    # As above but with overrides, using tuple and env dict
+    sql = google.datalab.bigquery.Query(query, env={'limit': 3, 'words': ('thus',)}).sql
     self.assertEquals('SELECT * FROM [publicdata:samples.shakespeare]\n' +
                       'WHERE word IN ("thus")\nLIMIT 3', sql)
     # As above but with list argument
@@ -146,15 +146,15 @@ SELECT * FROM [publicdata:samples.shakespeare]
 WHERE word IN $words
 LIMIT $limit
 """, m)
-    sql = google.datalab.bigquery.Query(query, values={}).sql
+    sql = google.datalab.bigquery.Query(query, env={}).sql
     self.assertEquals('SELECT * FROM [publicdata:samples.shakespeare]\n' +
                       'WHERE word IN ("thus", "forsooth")\nLIMIT 10', sql)
     # As above but with overrides, using list
-    sql = google.datalab.bigquery.Query(query, values={'limit': 2, 'words': ['forsooth']}).sql
+    sql = google.datalab.bigquery.Query(query, env={'limit': 2, 'words': ['forsooth']}).sql
     self.assertEquals('SELECT * FROM [publicdata:samples.shakespeare]\n' +
                       'WHERE word IN ("forsooth")\nLIMIT 2', sql)
     # As above but with overrides, using tuple
-    sql = google.datalab.bigquery.Query(query, values={'words': 'eyeball'}).sql
+    sql = google.datalab.bigquery.Query(query, env={'words': 'eyeball'}).sql
     self.assertEquals('SELECT * FROM [publicdata:samples.shakespeare]\n' +
                       'WHERE word IN "eyeball"\nLIMIT 10', sql)
     # TODO(gram): add some tests for source and datestring variables


### PR DESCRIPTION
In preparation for adding BigQuery parameterization, we'll need to maintain two dictionaries in `Query`, one for resolving references to other objects (UDFs, datasources...), and one for query parameters the user can pass.