### PR TITLE
Support for BigQuery parameterization

### DIFF
--- a/google/datalab/bigquery/_api.py
+++ b/google/datalab/bigquery/_api.py
@@ -137,15 +137,14 @@ class Api(object):
 
     return google.datalab.utils.Http.request(url, data=data, credentials=self.credentials)
 
-  def jobs_insert_query(self, sql, code=None, imports=None, table_name=None, append=False,
+  def jobs_insert_query(self, sql, code=None, table_name=None, append=False,
                         overwrite=False, dry_run=False, use_cache=True, batch=True,
-                        allow_large_results=False, table_definitions=None):
+                        allow_large_results=False, table_definitions=None, query_params=None):
     """Issues a request to insert a query job.
 
     Args:
       sql: the SQL string representing the query to execute.
       code: code for Javascript UDFs, if any.
-      imports: a list of GCS URLs containing additional Javascript UDF support code, if any.
       table_name: None for an anonymous table, or a name parts tuple for a long-lived table.
       append: if True, append to the table if it is non-empty; else the request will fail if table
           is non-empty unless overwrite is True.
@@ -160,6 +159,7 @@ class Api(object):
           can handle big jobs).
       table_definitions: a list of JSON external table definitions for any external tables
           referenced in the query.
+      query_params: a dictionary containing query parameter types and values, passed to BigQuery.
     Returns:
       A parsed result object.
     Raises:
@@ -183,15 +183,6 @@ class Api(object):
 
     query_config = data['configuration']['query']
 
-    resources = []
-    if code:
-      resources.extend([{'inlineCode': fragment} for fragment in code])
-
-    if imports:
-      resources.extend([{'resourceUri': uri} for uri in imports])
-
-    query_config['userDefinedFunctionResources'] = resources
-
     if table_definitions:
       query_config['tableDefinitions'] = table_definitions
 
@@ -208,6 +199,9 @@ class Api(object):
 
     if self.bigquery_billing_tier:
         query_config['maximumBillingTier'] = self.bigquery_billing_tier
+
+    if query_params is not None:
+      query_config['queryParameters'] = query_params
 
     return google.datalab.utils.Http.request(url, data=data, credentials=self.credentials)
 

--- a/google/datalab/bigquery/_api.py
+++ b/google/datalab/bigquery/_api.py
@@ -200,7 +200,7 @@ class Api(object):
     if self.bigquery_billing_tier:
         query_config['maximumBillingTier'] = self.bigquery_billing_tier
 
-    if query_params is not None:
+    if query_params:
       query_config['queryParameters'] = query_params
 
     return google.datalab.utils.Http.request(url, data=data, credentials=self.credentials)

--- a/google/datalab/bigquery/commands/_bigquery.py
+++ b/google/datalab/bigquery/commands/_bigquery.py
@@ -361,9 +361,10 @@ def _get_query_parameters(args, cell_body):
     raise Exception('Cannot extract query parameters in non-query cell')
 
   # Validate query_params
-  jsonschema.validate(config, query_params_schema)
+  if config:
+    jsonschema.validate(config, query_params_schema)
 
-  return config['queryParameters']
+  return config['queryParameters'] if config else {}
 
 def _sample_cell(args, cell_body):
   """Implements the BigQuery sample magic for sampling queries

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'pyyaml==3.11',
     'requests==2.9.1',
     'ipykernel==4.4.1',
+    'jsonschema==2.6.0',
   ],
   package_data={
     'google.datalab.notebook': [

--- a/tests/bigquery/api_tests.py
+++ b/tests/bigquery/api_tests.py
@@ -116,7 +116,6 @@ class TestCases(unittest.TestCase):
         'query': {
           'query': 'SQL',
           'useQueryCache': True,
-          'userDefinedFunctionResources': [],
           'allowLargeResults': False,
           'useLegacySql': True,
         },
@@ -148,11 +147,6 @@ class TestCases(unittest.TestCase):
             'tableId': 't'
           },
           'writeDisposition': 'WRITE_APPEND',
-          'userDefinedFunctionResources': [
-            {
-              'inlineCode': 'CODE'
-            }
-          ]
         },
         'dryRun': True,
         'priority': 'INTERACTIVE',

--- a/tests/kernel/bigquery_tests.py
+++ b/tests/kernel/bigquery_tests.py
@@ -72,8 +72,7 @@ class TestCases(unittest.TestCase):
     # test query creation
     q1_body = 'SELECT * FROM test_table'
     google.datalab.bigquery.commands._bigquery._query_cell({'name': 'q1', 'udfs': None,
-                                                'datasources': None, 'subqueries': None,
-                                                'parameters': None}, q1_body)
+                                                'datasources': None, 'subqueries': None}, q1_body)
     q1 = env['q1']
     self.assertIsNotNone(q1)
     self.assertIsNone(q1._udfs)
@@ -84,8 +83,7 @@ class TestCases(unittest.TestCase):
     # test subquery reference and expansion
     q2_body = 'SELECT * FROM q1'
     google.datalab.bigquery.commands._bigquery._query_cell({'name': 'q2', 'udfs': None,
-                                                'datasources': None, 'subqueries': ['q1'],
-                                                'parameters': None}, q2_body)
+                                                'datasources': None, 'subqueries': ['q1']}, q2_body)
     q2 = env['q2']
     self.assertIsNotNone(q2)
     self.assertIsNone(q2._udfs)

--- a/tests/kernel/bigquery_tests.py
+++ b/tests/kernel/bigquery_tests.py
@@ -72,7 +72,8 @@ class TestCases(unittest.TestCase):
     # test query creation
     q1_body = 'SELECT * FROM test_table'
     google.datalab.bigquery.commands._bigquery._query_cell({'name': 'q1', 'udfs': None,
-                                                'datasources': None, 'subqueries': None}, q1_body)
+                                                'datasources': None, 'subqueries': None,
+                                                'parameters': None}, q1_body)
     q1 = env['q1']
     self.assertIsNotNone(q1)
     self.assertIsNone(q1._udfs)
@@ -83,7 +84,8 @@ class TestCases(unittest.TestCase):
     # test subquery reference and expansion
     q2_body = 'SELECT * FROM q1'
     google.datalab.bigquery.commands._bigquery._query_cell({'name': 'q2', 'udfs': None,
-                                                'datasources': None, 'subqueries': ['q1']}, q2_body)
+                                                'datasources': None, 'subqueries': ['q1'],
+                                                'parameters': None}, q2_body)
     q2 = env['q2']
     self.assertIsNotNone(q2)
     self.assertIsNone(q2._udfs)


### PR DESCRIPTION
This PR adds support for query parameterization by passing a dictionary of parameters to BigQuery. parameters are inserted into execute calls, and look like:
```
%%bq execute --query myquery
parameters:
- name: param1
  type: STRING
  value: myvalue
- name: param2
...
```
Note the format of the schema is simpler than the one used by BigQuery, and is parsed into that format before sending to the service. The PR adds a jsonschema schema to (superficially) validate the input format before sending it to BigQuery.

Note this only adds support for named parameters. Positional parameters aren't supported yet.