### PR TITLE
Fix project_id from `gcloud config` in py3

### DIFF
--- a/datalab/context/_utils.py
+++ b/datalab/context/_utils.py
@@ -116,7 +116,7 @@ def get_project_id():
     proc = subprocess.Popen(['gcloud', 'config', 'list', '--format', 'value(core.project)'],
                             stdout=subprocess.PIPE)
     stdout, _ = proc.communicate()
-    value = stdout.strip()
+    value = stdout.decode().strip()
     if proc.poll() == 0 and value:
       return value
   except:


### PR DESCRIPTION
- `Popen.stdout` is a `bytes` in py3, needs `.decode()`

- Before:
```py
>>> %%sql -d standard
... select 3
Your active configuration is: [test]

HTTP request failed: Invalid project ID 'b'foo-bar''. Project IDs must contain 6-63 lowercase letters, digits, or dashes. IDs must start with a letter and may not end with a dash.
```
```sh
$ for p in python2 python3; do $p -c 'from datalab.context._utils import get_project_id; print(get_project_id())'; done
Your active configuration is: [test]

foo-bar
Your active configuration is: [test]

b'foo-bar'
```

- After:
```py
>>> %%sql -d standard
... select 3
Your active configuration is: [test]

QueryResultsTable job_1_bZNbAUtk8QzlK7bqWD5fz7S5o
```
```sh
$ for p in python2 python3; do $p -c 'from datalab.context._utils import get_project_id; print(get_project_id())'; done
Your active configuration is: [test]

foo-bar
Your active configuration is: [test]

foo-bar
```