### PR TITLE
List all objects in storage when using gs:// prefix

### DIFF
--- a/google/datalab/storage/commands/_storage.py
+++ b/google/datalab/storage/commands/_storage.py
@@ -309,10 +309,11 @@ def _gcs_list(args, _):
   if bucket_name is None:
     raise Exception('Cannot list %s; not a valid bucket name' % target)
 
-  if key:
+  # If a target was specified, list keys inside it
+  if target:
     if not re.search('\?|\*|\[', target):
       # If no wild characters are present in the key string, append a '/*' suffix to show all keys
-      key = key.strip('/') + '/*'
+      key = key.strip('/') + '/*' if key else '*'
 
     if project:
       # Only list if the bucket is in the project


### PR DESCRIPTION
This makes the `%gcs list` command behave more like the `gsutil` tool in that it can list GCS paths with a given prefix if that prefix is a valid path. This does not change its flexible capabilities, so it can still use wild characters to list objects.