### PR TITLE
Bigquery cleanup and fixes

### DIFF
--- a/google/datalab/_job.py
+++ b/google/datalab/_job.py
@@ -253,27 +253,3 @@ class Job(object):
         concurrent.futures.wait(futures, timeout=Job._POLL_INTERVAL_SECONDS,
                                 return_when=return_when)
 
-  @staticmethod
-  def wait_any(jobs, timeout=None):
-    """ Return when at least one of the specified jobs has completed or timeout expires.
-
-    Args:
-      jobs: a Job or list of Jobs to wait on.
-      timeout: a timeout in seconds to wait for. None (the default) means no timeout.
-    Returns:
-      A list of the jobs that have now completed or None if there were no jobs.
-
-    """
-    return Job._wait(jobs, timeout, concurrent.futures.FIRST_COMPLETED)
-
-  @staticmethod
-  def wait_all(jobs, timeout=None):
-    """ Return when at all of the specified jobs have completed or timeout expires.
-
-    Args:
-      jobs: a Job or list of Jobs to wait on.
-      timeout: a timeout in seconds to wait for. None (the default) means no timeout.
-    Returns:
-      A list of the jobs that have now completed or None if there were no jobs.
-    """
-    return Job._wait(jobs, timeout, concurrent.futures.ALL_COMPLETED)

--- a/google/datalab/bigquery/_api.py
+++ b/google/datalab/bigquery/_api.py
@@ -137,14 +137,13 @@ class Api(object):
 
     return google.datalab.utils.Http.request(url, data=data, credentials=self.credentials)
 
-  def jobs_insert_query(self, sql, code=None, table_name=None, append=False,
+  def jobs_insert_query(self, sql, table_name=None, append=False,
                         overwrite=False, dry_run=False, use_cache=True, batch=True,
                         allow_large_results=False, table_definitions=None, query_params=None):
     """Issues a request to insert a query job.
 
     Args:
       sql: the SQL string representing the query to execute.
-      code: code for Javascript UDFs, if any.
       table_name: None for an anonymous table, or a name parts tuple for a long-lived table.
       append: if True, append to the table if it is non-empty; else the request will fail if table
           is non-empty unless overwrite is True.

--- a/google/datalab/bigquery/_view.py
+++ b/google/datalab/bigquery/_view.py
@@ -110,22 +110,6 @@ class View(object):
       return self
     raise Exception("View %s could not be created as it already exists" % str(self))
 
-  def sample(self, fields=None, count=5, sampling=None, use_cache=True):
-    """Retrieves a sampling of data from the view.
-
-    Args:
-      fields: an optional list of field names to retrieve.
-      count: an optional count of rows to retrieve which is used if a specific
-          sampling is not specified.
-      sampling: an optional sampling strategy to apply to the view.
-      use_cache: whether to use cached results or not.
-    Returns:
-      A QueryResultsTable object containing the resulting data.
-    Raises:
-      Exception if the sample query could not be executed or the query response was malformed.
-    """
-    return self._table.sample(fields=fields, count=count, sampling=sampling, use_cache=use_cache)
-
   @property
   def schema(self):
     """Retrieves the schema of the table.
@@ -223,7 +207,7 @@ class View(object):
     Returns:
       A formatted table name for use within SQL statements.
     """
-    return '[' + str(self) + ']'
+    return '`' + str(self) + '`'
 
   def __repr__(self):
     """Returns a representation for the view for showing in the notebook.

--- a/tests/bigquery/api_tests.py
+++ b/tests/bigquery/api_tests.py
@@ -128,7 +128,7 @@ class TestCases(unittest.TestCase):
 
     context.config['bigquery_dialect'] = 'standard'
     context.config['bigquery_billing_tier'] = 1
-    api.jobs_insert_query('SQL2', ['CODE'],
+    api.jobs_insert_query('SQL2',
                           table_name=google.datalab.bigquery._utils.TableName('p', 'd', 't', ''),
                           append=True, dry_run=True, use_cache=False, batch=False,
                           allow_large_results=True)

--- a/tests/bigquery/table_tests.py
+++ b/tests/bigquery/table_tests.py
@@ -34,7 +34,7 @@ class TestCases(unittest.TestCase):
     self.assertEqual('requestlogs', parsed_name[1])
     self.assertEqual('today', parsed_name[2])
     self.assertEqual('', parsed_name[3])
-    self.assertEqual('[test:requestlogs.today]', table._repr_sql_())
+    self.assertEqual('`test:requestlogs.today`', table._repr_sql_())
     self.assertEqual('test:requestlogs.today', str(table))
 
   def test_api_paths(self):
@@ -662,12 +662,12 @@ class TestCases(unittest.TestCase):
 
   def test_table_to_query(self):
     tbl = google.datalab.bigquery.Table('testds.testTable0', context=TestCases._create_context())
-    q = tbl.to_query()
-    self.assertEqual('SELECT * FROM [test:testds.testTable0]', q.sql)
-    q = tbl.to_query('foo, bar')
-    self.assertEqual('SELECT foo, bar FROM [test:testds.testTable0]', q.sql)
-    q = tbl.to_query(['bar', 'foo'])
-    self.assertEqual('SELECT bar,foo FROM [test:testds.testTable0]', q.sql)
+    q = google.datalab.bigquery.Query.from_table(tbl)
+    self.assertEqual('SELECT * FROM `test:testds.testTable0`', q.sql)
+    q = google.datalab.bigquery.Query.from_table(tbl, fields='foo, bar')
+    self.assertEqual('SELECT foo, bar FROM `test:testds.testTable0`', q.sql)
+    q = google.datalab.bigquery.Query.from_table(tbl, fields=['bar', 'foo'])
+    self.assertEqual('SELECT bar,foo FROM `test:testds.testTable0`', q.sql)
 
   @staticmethod
   def _create_context():

--- a/tests/bigquery/view_tests.py
+++ b/tests/bigquery/view_tests.py
@@ -26,7 +26,7 @@ class TestCases(unittest.TestCase):
   def test_view_repr_sql(self):
     name = 'test:testds.testView0'
     view = google.datalab.bigquery.View(name, TestCases._create_context())
-    self.assertEqual('[%s]' % name, view._repr_sql_())
+    self.assertEqual('`%s`' % name, view._repr_sql_())
 
   @mock.patch('google.datalab.bigquery._api.Api.tables_insert')
   @mock.patch('google.datalab.bigquery._api.Api.tables_get')
@@ -48,7 +48,7 @@ class TestCases(unittest.TestCase):
     result = view.create(sql)
     self.assertTrue(view.exists())
     self.assertEqual(name, str(view))
-    self.assertEqual('[%s]' % name, view._repr_sql_())
+    self.assertEqual('`%s`' % name, view._repr_sql_())
     self.assertIsNotNone(result, 'Expected a view')
 
   @mock.patch('google.datalab.bigquery._api.Api.tables_insert')


### PR DESCRIPTION
- Removed `wait_all` and `wait_any`
- Fixed old reference to `_code` property in `Query`
- Added static methods `from_view` and `from_table` to create `Query` objects from them
- Removed `sample` methods from `Table` and `View` objects, since sampling should be done using `Query` object only
- Fixed table delimiter to use Standard SQL \`table\` instead of [table]
- Fixed a bug with sampling when done using a table or view