### PR TITLE
Add query parameter validation unit test

### DIFF
--- a/tests/bigquery/query_tests.py
+++ b/tests/bigquery/query_tests.py
@@ -23,6 +23,24 @@ import google.datalab.bigquery
 
 class TestCases(unittest.TestCase):
 
+  def test_parameter_validation(self):
+    sql = 'SELECT * FROM table'
+    with self.assertRaises(Exception) as error:
+      q = TestCases._create_query(sql, subqueries=['subquery'])
+    env = {'subquery': TestCases._create_query()}
+    q = TestCases._create_query(sql, env=env, subqueries=['subquery'])
+    self.assertIsNotNone(q)
+    self.assertEqual(q._subqueries, ['subquery'])
+    self.assertEqual(q._sql, sql)
+
+    with self.assertRaises(Exception) as error:
+      q = TestCases._create_query(sql, udfs=['udf'])
+    env = {'udf': TestCases._create_udf('test_udf', 'code', 'TYPE')}
+    q = TestCases._create_query(sql, env=env, udfs=['udf'])
+    self.assertIsNotNone(q)
+    self.assertEqual(q._udfs, ['udf'])
+    self.assertEqual(q._sql, sql)
+
   @mock.patch('google.datalab.bigquery._api.Api.tabledata_list')
   @mock.patch('google.datalab.bigquery._api.Api.jobs_insert_query')
   @mock.patch('google.datalab.bigquery._api.Api.jobs_query_results')
@@ -125,6 +143,10 @@ class TestCases(unittest.TestCase):
     if name:
       env[name] = q
     return q
+
+  @staticmethod
+  def _create_udf(name, code, return_type):
+    return google.datalab.bigquery.UDF(name, code, return_type)
 
   @staticmethod
   def _create_context():

--- a/tests/bigquery/query_tests.py
+++ b/tests/bigquery/query_tests.py
@@ -57,7 +57,8 @@ class TestCases(unittest.TestCase):
 
     sql = 'SELECT field1 FROM [table] LIMIT 1'
     q = TestCases._create_query(sql)
-    results = q.execute().result()
+    context = TestCases._create_context()
+    results = q.execute(context=context).result()
 
     self.assertEqual(sql, results.sql)
     self.assertEqual('(%s)' % sql, q._repr_sql_())
@@ -78,7 +79,8 @@ class TestCases(unittest.TestCase):
     mock_api_insert_query.return_value = TestCases._create_insert_done_result()
 
     q = TestCases._create_query()
-    results = q.execute().result()
+    context = TestCases._create_context()
+    results = q.execute(context=context).result()
 
     self.assertEqual(0, results.length)
 
@@ -97,7 +99,8 @@ class TestCases(unittest.TestCase):
     mock_api_insert_query.return_value = TestCases._create_incomplete_result()
 
     q = TestCases._create_query()
-    results = q.execute().result()
+    context = TestCases._create_context()
+    results = q.execute(context=context).result()
 
     self.assertEqual(1, results.length)
     self.assertEqual('test_job', results.job_id)
@@ -109,7 +112,8 @@ class TestCases(unittest.TestCase):
     q = TestCases._create_query()
 
     with self.assertRaises(Exception) as error:
-      _ = q.execute().result()
+      context = TestCases._create_context()
+      _ = q.execute(context=context).result()
     self.assertEqual('Unexpected response from server', str(error.exception))
 
   def test_nested_subquery_expansion(self):


### PR DESCRIPTION
This PR also fixes some tests that break if no project has been set globally, since the test context object isn't passed to the query execution.