### PR TITLE
Workaround a TF summary issue. Force online prediction to use TF 1.0.

### DIFF
--- a/datalab/mlalpha/_cloud_models.py
+++ b/datalab/mlalpha/_cloud_models.py
@@ -196,6 +196,7 @@ class ModelVersions(object):
     body = {
       'name': version_name,
       'deployment_uri': path,
+      'runtime_version': '1.0',
     }
     response = self._api.projects().models().versions().create(body=body,
                    parent=self._full_model_name).execute()


### PR DESCRIPTION
In summary.py, basically only two try-except blocks are added.