### PR TITLE
Add %bq datasource

### DIFF
--- a/google/datalab/bigquery/_api.py
+++ b/google/datalab/bigquery/_api.py
@@ -156,7 +156,7 @@ class Api(object):
           priority, more expensive).
       allow_large_results: whether to allow large results (slower with some restrictions but
           can handle big jobs).
-      table_definitions: a list of JSON external table definitions for any external tables
+      table_definitions: a dictionary of JSON external table definitions for any external tables
           referenced in the query.
       query_params: a dictionary containing query parameter types and values, passed to BigQuery.
     Returns:

--- a/google/datalab/bigquery/_external_data_source.py
+++ b/google/datalab/bigquery/_external_data_source.py
@@ -20,7 +20,6 @@ from . import _csv_options
 
 class ExternalDataSource(object):
 
-  @staticmethod
   def __init__(self, source, source_format='csv', csv_options=None, ignore_unknown_values=False,
                    max_bad_records=0, compressed=False, schema=None):
 
@@ -41,14 +40,6 @@ class ExternalDataSource(object):
           data source or to be loaded using a Table object that itself has no schema (default None).
 
   """
-    self._bq_source_format = None
-    self._source = None
-    self._source_format = None
-    self._csv_options = None
-    self._ignore_unknown_values = None
-    self._max_bad_records = None
-    self._compressed = None
-    self._schema = None
     # Do some sanity checking and concert some params from friendly form to form used by BQ.
     if source_format == 'csv':
       self._bq_source_format = 'CSV'
@@ -69,10 +60,12 @@ class ExternalDataSource(object):
     self._compressed = compressed
     self._schema = schema
 
-
   @property
   def schema(self):
     return self._schema
+
+  def __repr__(self):
+    return 'BigQuery External Datasource - paths: %s' % (','.join(self._source))
 
   def _to_query_json(self):
     """ Return the table as a dictionary to be used as JSON in a query job. """

--- a/google/datalab/bigquery/_query.py
+++ b/google/datalab/bigquery/_query.py
@@ -52,7 +52,7 @@ class Query(object):
     self._udfs = udfs
     self._subqueries = subqueries
     self._env = env or {}
-    self._data_sources = []
+    self._data_sources = {}
 
     def _validate_object(obj, obj_type):
       item = self._env.get(obj)
@@ -71,7 +71,7 @@ class Query(object):
     if data_sources:
       for ds in data_sources:
         _validate_object(ds, _external_data_source.ExternalDataSource)
-        self._data_sources = {ds: self._env[ds]._to_query_json()}
+        self._data_sources[ds] = self._env[ds]._to_query_json()
 
     if len(self._data_sources) > 1:
       raise Exception('Only one temporary external datasource is supported in queries.')

--- a/google/datalab/bigquery/_query.py
+++ b/google/datalab/bigquery/_query.py
@@ -73,6 +73,9 @@ class Query(object):
         _validate_object(ds, _external_data_source.ExternalDataSource)
         self._data_sources = {ds: self._env[ds]._to_query_json()}
 
+    if len(self._data_sources) > 1:
+      raise Exception('Only one temporary external datasource is supported in queries.')
+
   @staticmethod
   def from_view(view):
     """ Return a Query for the given View object
@@ -149,21 +152,13 @@ class Query(object):
     """
     return '(%s)' % self.sql
 
-  def __str__(self):
-    """Creates a string representation of this object.
-
-    Returns:
-      The string representation of this object (the unmodified SQL).
-    """
-    return self._sql
-
   def __repr__(self):
     """Creates a friendly representation of this object.
 
     Returns:
       The friendly representation of this object (the unmodified SQL).
     """
-    return self._sql
+    return 'BigQuery Query - %s' % self._sql
 
   @property
   def sql(self):

--- a/google/datalab/bigquery/_schema.py
+++ b/google/datalab/bigquery/_schema.py
@@ -55,11 +55,6 @@ class SchemaField(object):
     return self.name == other.name and self.type == other.type\
         and self.mode == other.mode
 
-  def __str__(self):
-    """ Returns the schema field as a string form of a dictionary. """
-    return "{ 'name': '%s', 'type': '%s', 'mode':'%s', 'description': '%s' }" % \
-           (self.name, self.type, self.mode, self.description)
-
   def __repr__(self):
     """ Returns the schema field as a string form of a dictionary. """
     return 'BigQuery Schema Field:\n%s' % pprint.pformat(vars(self), width=1)

--- a/google/datalab/bigquery/_schema.py
+++ b/google/datalab/bigquery/_schema.py
@@ -302,10 +302,6 @@ class Schema(list):
         # Recurse into the nested fields, using this field's name as a prefix.
         self._populate_fields(field_data.get('fields'), name + '.')
 
-  def __str__(self):
-    """ Returns a string representation of the non-flattened form of the schema."""
-    return str(self._bq_schema)
-
   def __repr__(self):
     """ Returns a string representation of the schema for notebooks."""
     return 'BigQuery Schema - Fields:\n%s' % pprint.pformat(self._bq_schema, width=1)

--- a/google/datalab/bigquery/_schema.py
+++ b/google/datalab/bigquery/_schema.py
@@ -20,6 +20,7 @@ from builtins import object
 
 import datetime
 import pandas
+import pprint
 
 
 class SchemaField(object):
@@ -61,7 +62,7 @@ class SchemaField(object):
 
   def __repr__(self):
     """ Returns the schema field as a string form of a dictionary. """
-    return str(self)
+    return 'BigQuery Schema Field:\n%s' % pprint.pformat(vars(self), width=1)
 
   def __getitem__(self, item):
     # TODO(gram): Currently we need this for a Schema object to work with the Parser object.
@@ -307,10 +308,12 @@ class Schema(list):
         self._populate_fields(field_data.get('fields'), name + '.')
 
   def __str__(self):
-    """ Returns a string representation of the non-flattened form of the schema. """
-    # TODO(gram): We should probably return the flattened form. There was a reason why this is
-    # not but I don't remember what it was. Figure that out and fix this.
+    """ Returns a string representation of the non-flattened form of the schema."""
     return str(self._bq_schema)
+
+  def __repr__(self):
+    """ Returns a string representation of the schema for notebooks."""
+    return 'BigQuery Schema - Fields:\n%s' % pprint.pformat(self._bq_schema, width=1)
 
   def __eq__(self, other):
     """ Compares two schema for equality. """

--- a/google/datalab/bigquery/_table.py
+++ b/google/datalab/bigquery/_table.py
@@ -695,7 +695,7 @@ class Table(object):
   def __repr__(self):
     """Returns a representation for the table for showing in the notebook.
     """
-    return 'Table %s' % self._full_name
+    return 'BigQuery Table - name: %s' % self._full_name
 
   def __str__(self):
     """Returns a string representation of the table using its specified name.

--- a/google/datalab/bigquery/_table.py
+++ b/google/datalab/bigquery/_table.py
@@ -697,14 +697,6 @@ class Table(object):
     """
     return 'BigQuery Table - name: %s' % self._full_name
 
-  def __str__(self):
-    """Returns a string representation of the table using its specified name.
-
-    Returns:
-      The string representation of this object.
-    """
-    return self._full_name
-
   @property
   def length(self):
     """ Get the length of the table (number of rows). We don't use __len__ as this may

--- a/google/datalab/bigquery/_udf.py
+++ b/google/datalab/bigquery/_udf.py
@@ -70,7 +70,7 @@ class UDF(object):
     return self._expanded_sql()
 
   def __repr__(self):
-    return self._code
+    return 'BigQuery UDF - code:\n%s' % self._code
 
   @staticmethod
   def _build_udf(name, code, return_type, params='', language='js', imports=''):

--- a/google/datalab/bigquery/_view.py
+++ b/google/datalab/bigquery/_view.py
@@ -52,10 +52,6 @@ class View(object):
     self._table = _table.Table(name, context=context)
     self._materialization = _query.Query('SELECT * FROM %s' % self._repr_sql_())
 
-  def __str__(self):
-    """The full name for the view as a string."""
-    return str(self._table)
-
   @property
   def name(self):
     """The name for the view as a named tuple."""

--- a/google/datalab/bigquery/_view.py
+++ b/google/datalab/bigquery/_view.py
@@ -149,4 +149,4 @@ class View(object):
   def __repr__(self):
     """Returns a representation for the view for showing in the notebook.
     """
-    return 'View %s\n%s' % (self._table, self.query)
+    return 'BigQuery View - table: %s, sql: %s' % (self._table, self.query)

--- a/google/datalab/bigquery/_view.py
+++ b/google/datalab/bigquery/_view.py
@@ -140,7 +140,7 @@ class View(object):
     Returns:
       A formatted table name for use within SQL statements.
     """
-    return '`' + str(self) + '`'
+    return self._table._repr_sql_()
 
   def __repr__(self):
     """Returns a representation for the view for showing in the notebook.

--- a/google/datalab/bigquery/commands/_bigquery.py
+++ b/google/datalab/bigquery/commands/_bigquery.py
@@ -574,11 +574,7 @@ def _datasource_cell(args, cell_body):
     cell_body: the datasource's schema in json/yaml
   """
   name = args['name']
-  if not name:
-    raise Exception('External data source declaration must include name')
   paths = args['paths']
-  if not paths:
-    raise Exception('External data source declaration must include paths')
   data_format = (args['format'] or 'CSV').lower()
   compressed = args['compressed'] or False
 
@@ -586,8 +582,8 @@ def _datasource_cell(args, cell_body):
   record = google.datalab.utils.commands.parse_config(cell_body,
                                    google.datalab.utils.commands.notebook_environment(),
                                    as_dict=False)
-  if 'schema' not in record:
-    raise Exception('\'schema\' key is missing from the magic cell')
+
+  jsonschema.validate(record, table_schema_schema)
   schema = google.datalab.bigquery.Schema(record['schema'])
 
   # Finally build the datasource object

--- a/google/datalab/bigquery/commands/_bigquery.py
+++ b/google/datalab/bigquery/commands/_bigquery.py
@@ -195,7 +195,7 @@ def _create_datasource_subparser(parser):
   datasource_parser.add_argument('-n', '--name', help='The name for this data source',
                                  required=True)
   datasource_parser.add_argument('-p', '--paths', help='URL(s) of the data objects, can include ' + \
-                                 'a whilecard "*" at the end', required=True, nargs='+')
+                                 'a wildcard "*" at the end', required=True, nargs='+')
   datasource_parser.add_argument('-f', '--format', help='The format of the table\'s data. ' + \
                                  'CSV or JSON, default CSV', default='CSV')
   datasource_parser.add_argument('-c', '--compressed', help='Whether the data is compressed',

--- a/google/datalab/bigquery/commands/_bigquery.py
+++ b/google/datalab/bigquery/commands/_bigquery.py
@@ -190,6 +190,19 @@ def _create_udf_subparser(parser):
   return udf_parser
 
 
+def _create_datasource_subparser(parser):
+  datasource_parser = parser.subcommand('datasource', 'Create a named Javascript BigQuery external data source')
+  datasource_parser.add_argument('-n', '--name', help='The name for this data source',
+                                 required=True)
+  datasource_parser.add_argument('-p', '--paths', help='URL(s) of the data objects, can include ' + \
+                                 'a whilecard "*" at the end', required=True, nargs='+')
+  datasource_parser.add_argument('-f', '--format', help='The format of the table\'s data. ' + \
+                                 'CSV or JSON, default CSV', default='CSV')
+  datasource_parser.add_argument('-c', '--compressed', help='Whether the data is compressed',
+                                 action='store_true')
+  return datasource_parser
+
+
 def _create_dryrun_subparser(parser):
   dryrun_parser = parser.subcommand('dryrun',
       'Execute a dry run of a BigQuery query and display approximate usage statistics')
@@ -549,6 +562,40 @@ def _udf_cell(args, cell_body):
   google.datalab.utils.commands.notebook_environment()[udf_name] = udf
 
 
+def _datasource_cell(args, cell_body):
+  """Implements the BigQuery datasource cell magic for ipython notebooks.
+
+  The supported syntax is
+  %%bq datasource --name <var> --paths <url> [--format <CSV|JSON>]
+  <schema>
+
+  Args:
+    args: the optional arguments following '%%bq datasource'
+    cell_body: the datasource's schema in json/yaml
+  """
+  name = args['name']
+  if not name:
+    raise Exception('External data source declaration must include name')
+  paths = args['paths']
+  if not paths:
+    raise Exception('External data source declaration must include paths')
+  data_format = (args['format'] or 'CSV').lower()
+  compressed = args['compressed'] or False
+
+  # Get the source schema from the cell body
+  record = google.datalab.utils.commands.parse_config(cell_body,
+                                   google.datalab.utils.commands.notebook_environment(),
+                                   as_dict=False)
+  if 'schema' not in record:
+    raise Exception('\'schema\' key is missing from the magic cell')
+  schema = google.datalab.bigquery.Schema(record['schema'])
+
+  # Finally build the datasource object
+  datasource = google.datalab.bigquery.ExternalDataSource(source=paths, source_format=data_format,
+                                                          compressed=compressed, schema=schema)
+  google.datalab.utils.commands.notebook_environment()[name] = datasource
+
+
 def _query_cell(args, cell_body):
   """Implements the BigQuery cell magic for used to build SQL objects.
 
@@ -764,7 +811,8 @@ def _table_cell(args, cell_body):
         record = google.datalab.utils.commands.parse_config(cell_body,
                                          google.datalab.utils.commands.notebook_environment(),
                                          as_dict=False)
-        schema = google.datalab.bigquery.Schema(record)
+        jsonschema.validate(record, table_schema_schema)
+        schema = google.datalab.bigquery.Schema(record['schema'])
         google.datalab.bigquery.Table(args['name']).create(schema=schema,
                                                     overwrite=args['overwrite'])
       except Exception as e:
@@ -920,6 +968,9 @@ for help on a specific command.
 
   # %%bq udf
   _add_command(parser, _create_udf_subparser, _udf_cell, cell_required=True)
+
+  # %%bq datasource
+  _add_command(parser, _create_datasource_subparser, _datasource_cell, cell_required=True)
 
   # %%bq pipeline
   _add_command(parser, _create_pipeline_subparser, _pipeline_cell)

--- a/tests/bigquery/dataset_tests.py
+++ b/tests/bigquery/dataset_tests.py
@@ -140,8 +140,8 @@ class TestCases(unittest.TestCase):
     ds = TestCases._create_dataset('requestlogs')
     tables = [table for table in ds]
     self.assertEqual(2, len(tables))
-    self.assertEqual('p:d.t1', str(tables[0]))
-    self.assertEqual('p:d.t2', str(tables[1]))
+    self.assertEqual('`p:d.t1`', tables[0]._repr_sql_())
+    self.assertEqual('`p:d.t2`', tables[1]._repr_sql_())
 
   @mock.patch('google.datalab.bigquery.Dataset._get_info')
   @mock.patch('google.datalab.bigquery._api.Api.datasets_list')

--- a/tests/bigquery/query_tests.py
+++ b/tests/bigquery/query_tests.py
@@ -62,7 +62,6 @@ class TestCases(unittest.TestCase):
 
     self.assertEqual(sql, results.sql)
     self.assertEqual('(%s)' % sql, q._repr_sql_())
-    self.assertEqual(sql, str(q))
     self.assertEqual(1, results.length)
     first_result = results[0]
     self.assertEqual('value1', first_result['field1'])

--- a/tests/bigquery/table_tests.py
+++ b/tests/bigquery/table_tests.py
@@ -35,7 +35,6 @@ class TestCases(unittest.TestCase):
     self.assertEqual('today', parsed_name[2])
     self.assertEqual('', parsed_name[3])
     self.assertEqual('`test:requestlogs.today`', table._repr_sql_())
-    self.assertEqual('test:requestlogs.today', str(table))
 
   def test_api_paths(self):
     name = google.datalab.bigquery._utils.TableName('a', 'b', 'c', 'd')
@@ -152,8 +151,8 @@ class TestCases(unittest.TestCase):
     for table in ds:
       tables.append(table)
     self.assertEqual(2, len(tables))
-    self.assertEqual('test:testds.testTable1', str(tables[0]))
-    self.assertEqual('test:testds.testTable2', str(tables[1]))
+    self.assertEqual('`test:testds.testTable1`', tables[0]._repr_sql_())
+    self.assertEqual('`test:testds.testTable2`', tables[1]._repr_sql_())
 
   @mock.patch('google.datalab.bigquery._api.Api.tables_list')
   @mock.patch('google.datalab.bigquery._api.Api.datasets_get')
@@ -167,8 +166,8 @@ class TestCases(unittest.TestCase):
     for table in ds.tables():
       tables.append(table)
     self.assertEqual(2, len(tables))
-    self.assertEqual('test:testds.testTable1', str(tables[0]))
-    self.assertEqual('test:testds.testTable2', str(tables[1]))
+    self.assertEqual('`test:testds.testTable1`', tables[0]._repr_sql_())
+    self.assertEqual('`test:testds.testTable2`', tables[1]._repr_sql_())
 
   @mock.patch('google.datalab.bigquery._api.Api.tables_list')
   @mock.patch('google.datalab.bigquery._api.Api.datasets_get')
@@ -182,7 +181,7 @@ class TestCases(unittest.TestCase):
     for view in ds.views():
       views.append(view)
     self.assertEqual(1, len(views))
-    self.assertEqual('test:testds.testView1', str(views[0]))
+    self.assertEqual('`test:testds.testView1`', views[0]._repr_sql_())
 
   @mock.patch('google.datalab.bigquery._api.Api.tables_list')
   @mock.patch('google.datalab.bigquery._api.Api.datasets_get')
@@ -255,7 +254,7 @@ class TestCases(unittest.TestCase):
 
     with self.assertRaises(Exception) as error:
       table.insert(df)
-    self.assertEqual('Table %s does not exist.' % str(table), str(error.exception))
+    self.assertEqual('Table %s does not exist.' % table._full_name, str(error.exception))
 
   @mock.patch('uuid.uuid4')
   @mock.patch('time.sleep')
@@ -539,7 +538,7 @@ class TestCases(unittest.TestCase):
   def test_decorators(self):
     tbl = google.datalab.bigquery.Table('testds.testTable0', context=TestCases._create_context())
     tbl2 = tbl.snapshot(dt.timedelta(hours=-1))
-    self.assertEquals('test:testds.testTable0@-3600000', str(tbl2))
+    self.assertEquals('`test:testds.testTable0@-3600000`', tbl2._repr_sql_())
 
     with self.assertRaises(Exception) as error:
       tbl2 = tbl2.snapshot(dt.timedelta(hours=-2))
@@ -564,7 +563,7 @@ class TestCases(unittest.TestCase):
         str(error.exception))
 
     tbl2 = tbl.snapshot(dt.timedelta(days=-1))
-    self.assertEquals('test:testds.testTable0@-86400000', str(tbl2))
+    self.assertEquals('`test:testds.testTable0@-86400000`', tbl2._repr_sql_())
 
     with self.assertRaises(Exception) as error:
       _ = tbl.snapshot(dt.timedelta(days=1))
@@ -577,7 +576,7 @@ class TestCases(unittest.TestCase):
                      str(error.exception))
 
     _ = dt.datetime.utcnow() - dt.timedelta(1)
-    self.assertEquals('test:testds.testTable0@-86400000', str(tbl2))
+    self.assertEquals('`test:testds.testTable0@-86400000`', tbl2._repr_sql_())
 
     when = dt.datetime.utcnow() + dt.timedelta(1)
     with self.assertRaises(Exception) as error:
@@ -598,7 +597,7 @@ class TestCases(unittest.TestCase):
     tbl = google.datalab.bigquery.Table('testds.testTable0', context=TestCases._create_context())
 
     tbl2 = tbl.window(dt.timedelta(hours=-1))
-    self.assertEquals('test:testds.testTable0@-3600000-0', str(tbl2))
+    self.assertEquals('`test:testds.testTable0@-3600000-0`', tbl2._repr_sql_())
 
     with self.assertRaises(Exception) as error:
       tbl2 = tbl2.window(-400000, 0)

--- a/tests/bigquery/view_tests.py
+++ b/tests/bigquery/view_tests.py
@@ -47,7 +47,6 @@ class TestCases(unittest.TestCase):
     view = google.datalab.bigquery.View(name, TestCases._create_context())
     result = view.create(sql)
     self.assertTrue(view.exists())
-    self.assertEqual(name, str(view))
     self.assertEqual('`%s`' % name, view._repr_sql_())
     self.assertIsNotNone(result, 'Expected a view')
 


### PR DESCRIPTION
- Added `%bq datasource` magic that takes an external datasource schema
- `%bq query` now takes `--datasources`, which accepts at most one datasource for now, since the BigQuery API only allows only temporary datasource in the query insert API.
- Cleaned up `__str__` definitions and only kept `__repr__`, which is used by Jupyter to show string representations of objects. Calling `str()` on an object will end up calling its `__repr__`.
- When creating a Query object, references to subqueries, UDFs, and datasource are now validated by instance type as well.
- Fixed tests to use `_repr_sql_()` when printing table/view names, since they shouldn't care about our decorated string values of the objects.