### PR TITLE
cast string to int

### DIFF
--- a/datalab/bigquery/_table.py
+++ b/datalab/bigquery/_table.py
@@ -401,7 +401,7 @@ class Table(object):
       self._info = self._api.tables_get(self._name_parts)
       if 'streamingBuffer' not in self._info or \
               'estimatedRows' not in self._info['streamingBuffer'] or \
-              self._info['streamingBuffer']['estimatedRows'] > 0:
+              int(self._info['streamingBuffer']['estimatedRows']) > 0:
         break
       time.sleep(2)
 


### PR DESCRIPTION
`table.insert_data(df)` inserts data correctly but raises TypeError: unorderable types: str() > int()