### PR TITLE
bigquery.Table: Increase default maxResults 1024 -> 100000

### DIFF
--- a/datalab/bigquery/_table.py
+++ b/datalab/bigquery/_table.py
@@ -107,7 +107,7 @@ class Table(object):
   _VALID_COLUMN_NAME_CHARACTERS = '_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
 
   # When fetching table contents, the max number of rows to fetch per HTTP request
-  _DEFAULT_PAGE_SIZE = 1024
+  _DEFAULT_PAGE_SIZE = 100000
 
   # Milliseconds per week
   _MSEC_PER_WEEK = 7 * 24 * 3600 * 1000
@@ -553,7 +553,7 @@ class Table(object):
       start_row: the row to start fetching from; default 0.
       max_rows: the maximum number of rows to fetch (across all calls, not per-call). Default
           is None which means no limit.
-      page_size: the maximum number of results to fetch per page; default 1024.
+      page_size: the maximum number of results to fetch per page; default 100000.
     Returns:
       A function that can be called repeatedly with a page token and running count, and that
       will return an array of rows and a next page token; when the returned page token is None


### PR DESCRIPTION
- Setting too low is slow (too many http reqs)
- Setting too high is safe (api enforces a max)
- Docs indicate that 100000 is the max allowed:
  - https://cloud.google.com/bigquery/docs/data

Test plan:
- Run a query that downloads a nontrivial amount of results
```
len(datalab.bigquery.Query('''
    select * from `bigquery-public-data`.noaa_gsod.gsod2016 limit 100000
''').to_dataframe(dialect='standard', use_cache=False))
```
- Before:
  - 86s
  - Log of http reqs: https://gist.github.com/jdanbrown/d979fa3b088b98a7070e0babac95eeae
- After:
  - 47s
  - Log of http reqs: https://gist.github.com/jdanbrown/a9a1b8373dc8dc3131d776eda2094b27