### PR TITLE
Remove project_id when context is available

### DIFF
--- a/google/datalab/bigquery/_dataset.py
+++ b/google/datalab/bigquery/_dataset.py
@@ -226,12 +226,10 @@ class Dataset(object):
 class Datasets(object):
   """ Iterator class for enumerating the datasets in a project. """
 
-  def __init__(self, project_id=None, context=None):
+  def __init__(self, context=None):
     """ Initialize the Datasets object.
 
     Args:
-      project_id: the ID of the project whose datasets you want to list. If None defaults
-          to the project in the context.
       context: an optional Context object providing project_id and credentials. If a specific
           project id or credentials are unspecified, the default ones configured at the global
           level are used.
@@ -240,7 +238,7 @@ class Datasets(object):
       context = google.datalab.Context.default()
     self._context = context
     self._api = _api.Api(context)
-    self._project_id = project_id if project_id else self._api.project_id
+    self._project_id = context.project_id if context else self._api.project_id
 
   def _retrieve_datasets(self, page_token, count):
     try:

--- a/google/datalab/bigquery/commands/_bigquery.py
+++ b/google/datalab/bigquery/commands/_bigquery.py
@@ -791,7 +791,11 @@ def _table_cell(args, cell_body):
       else:
         datasets = [google.datalab.bigquery.Dataset((args['project'], args['dataset']))]
     else:
-      datasets = google.datalab.bigquery.Datasets(args['project'])
+      default_context = google.datalab.Context.default()
+      context = google.datalab.Context(default_context.project_id, default_context.credentials)
+      if args['project']:
+        context.project_id = args['project']
+      datasets = google.datalab.bigquery.Datasets(context)
 
     tables = []
     for dataset in datasets:

--- a/google/datalab/storage/_bucket.py
+++ b/google/datalab/storage/_bucket.py
@@ -164,19 +164,18 @@ class Bucket(object):
     except Exception:
       return False
 
-  def create(self, project_id=None):
+  def create(self, context=None):
     """Creates the bucket.
 
     Args:
-      project_id: the project in which to create the bucket.
+      context: the context object to use when creating the bucket.
     Returns:
       The bucket.
     Raises:
       Exception if there was an error creating the bucket.
     """
     if not self.exists():
-      if project_id is None:
-        project_id = self._api.project_id
+      project_id = context.project_id if context else self._api.project_id
       try:
         self._info = self._api.buckets_insert(self._name, project_id=project_id)
       except Exception as e:
@@ -199,12 +198,10 @@ class Bucket(object):
 class Buckets(object):
   """Represents a list of Cloud Storage buckets for a project."""
 
-  def __init__(self, project_id=None, context=None):
+  def __init__(self, context=None):
     """Initializes an instance of a BucketList.
 
     Args:
-      project_id: an optional project whose buckets we want to manipulate. If None this
-          is obtained from the api object.
       context: an optional Context object providing project_id and credentials. If a specific
           project id or credentials are unspecified, the default ones configured at the global
           level are used.
@@ -213,7 +210,7 @@ class Buckets(object):
       context = google.datalab.Context.default()
     self._context = context
     self._api = _api.Api(context)
-    self._project_id = project_id if project_id else self._api.project_id
+    self._project_id = context.project_id if context else self._api.project_id
 
   def contains(self, name):
     """Checks if the specified bucket exists.

--- a/tests/bigquery/dataset_tests.py
+++ b/tests/bigquery/dataset_tests.py
@@ -153,8 +153,7 @@ class TestCases(unittest.TestCase):
       ]
     }
     mock_dataset_get_info.return_value = {}
-    datasets = [dataset for dataset in google.datalab.bigquery.Datasets('test',
-                                                                 TestCases._create_context())]
+    datasets = [dataset for dataset in google.datalab.bigquery.Datasets(TestCases._create_context())]
     self.assertEqual(2, len(datasets))
     self.assertEqual('p:d1', str(datasets[0]))
     self.assertEqual('p:d2', str(datasets[1]))


### PR DESCRIPTION
For consistency and forward compatibility, I also replaced `project_id` with `context` in the `Bucket.create()` method.