### PR TITLE
Various BigQuery related fixes

### DIFF
--- a/google/datalab/bigquery/_dataset.py
+++ b/google/datalab/bigquery/_dataset.py
@@ -43,7 +43,7 @@ class Dataset(object):
     self._context = context
     self._api = _api.Api(context)
     self._name_parts = _utils.parse_dataset_name(name, self._api.project_id)
-    self._full_name = '%s:%s' % self._name_parts
+    self._full_name = '%s.%s' % self._name_parts
     self._info = None
     try:
       self._info = self._get_info()

--- a/google/datalab/bigquery/_sampling.py
+++ b/google/datalab/bigquery/_sampling.py
@@ -87,7 +87,7 @@ class Sampling(object):
       raise Exception('Hash field must be specified')
     def _hashed_sampling(sql):
       projection = Sampling._create_projection(fields)
-      sql = 'SELECT %s FROM (%s) WHERE ABS(HASH(%s)) %% 100 < %d' % \
+      sql = 'SELECT %s FROM (%s) WHERE MOD(FARM_FINGERPRINT(CAST(%s AS STRING)), 100) < %d' % \
             (projection, sql, field_name, percent)
       if count != 0:
         sql = '%s LIMIT %d' % (sql, count)

--- a/google/datalab/bigquery/_table.py
+++ b/google/datalab/bigquery/_table.py
@@ -128,7 +128,7 @@ class Table(object):
     self._context = context
     self._api = _api.Api(context)
     self._name_parts = _utils.parse_table_name(name, self._api.project_id)
-    self._full_name = '%s:%s.%s%s' % self._name_parts
+    self._full_name = '%s.%s.%s%s' % self._name_parts
     self._info = None
     self._cached_page = None
     self._cached_page_index = 0

--- a/google/datalab/bigquery/_utils.py
+++ b/google/datalab/bigquery/_utils.py
@@ -39,14 +39,14 @@ TableName = collections.namedtuple('TableName',
     decorator: the optional decorator for the table (for windowing/snapshot-ing).
 """
 
-# Absolute project-qualified name pattern: <project>:<dataset>
-_ABS_DATASET_NAME_PATTERN = r'^([a-z\d\-_\.:]+)\:(\w+)$'
+# Absolute project-qualified name pattern: <project>.<dataset>
+_ABS_DATASET_NAME_PATTERN = r'^([a-z\d\-_\.]+)\.(\w+)$'
 
 # Relative name pattern: <dataset>
 _REL_DATASET_NAME_PATTERN = r'^(\w+)$'
 
-# Absolute project-qualified name pattern: <project>:<dataset>.<table>
-_ABS_TABLE_NAME_PATTERN = r'^([a-z\d\-_\.:]+)\:(\w+)\.(\w+)(@[\d\-]+)?$'
+# Absolute project-qualified name pattern: <project>.<dataset>.<table>
+_ABS_TABLE_NAME_PATTERN = r'^([a-z\d\-_\.]+)\.(\w+)\.(\w+)(@[\d\-]+)?$'
 
 # Relative name pattern: <dataset>.<table>
 _REL_TABLE_NAME_PATTERN = r'^(\w+)\.(\w+)(@[\d\-]+)?$'

--- a/google/datalab/bigquery/commands/_bigquery.py
+++ b/google/datalab/bigquery/commands/_bigquery.py
@@ -148,6 +148,11 @@ def _create_table_subparser(parser):
   delete_parser.add_argument('-n', '--name', help='The name of the table to delete.',
                                    required=True)
 
+  # %%bq tables view
+  delete_parser = sub_commands.add_parser('view', help='View a table.')
+  delete_parser.add_argument('-n', '--name', help='The name of the table to view.',
+                                   required=True)
+
   return table_parser
 
 
@@ -473,14 +478,8 @@ def _sample_cell(args, cell_body):
   context = _construct_context_for_args(args)
 
   if view:
-    view = google.datalab.utils.commands.get_notebook_item(args['view'])
-    if view is None:
-      raise Exception('Cannot find view %s.' % args['view'])
     query = google.datalab.bigquery.Query.from_view(view)
   elif table:
-    table = google.datalab.utils.commands.get_notebook_item(args['table'])
-    if table is None:
-      raise Exception('Cannot find table %s.' % args['table'])
     query = google.datalab.bigquery.Query.from_table(table)
 
   if args['profile']:
@@ -775,7 +774,7 @@ def _table_cell(args, cell_body):
    %%bq tables <command> <args>
 
   Commands:
-    {list, create, delete}
+    {list, create, delete, describe, view}
 
   Args:
     args: the optional arguments following '%%bq tables command'.
@@ -829,6 +828,12 @@ def _table_cell(args, cell_body):
     except Exception as e:
       print('Failed to delete table %s: %s' % (args['name'], e))
 
+  elif args['command'] == 'view':
+    name = args['name']
+    table = _get_table(name)
+    if not table:
+      raise Exception('Could not find table %s' % name)
+    return table
 
 def _extract_cell(args, cell_body):
   """Implements the BigQuery extract magic used to extract query or table data to GCS.

--- a/google/datalab/utils/commands/_utils.py
+++ b/google/datalab/utils/commands/_utils.py
@@ -85,13 +85,26 @@ def get_field_list(fields, schema):
       can't handle nested data.
   """
   # If the fields weren't supplied get them from the schema.
+  if schema:
+    all_fields = [f['name'] for f in schema._bq_schema if f['type'] != 'RECORD']
+
   if isinstance(fields, list):
+    if schema:
+      # validate fields exist
+      for f in fields:
+        if f not in all_fields:
+          raise Exception('Cannot find field %s in given schema' % f)
     return fields
   if isinstance(fields, basestring) and fields != '*':
-    return fields.split(',')
+    if schema:
+      # validate fields exist
+      for f in fields.split(','):
+        if f not in all_fields:
+          raise Exception('Cannot find field %s in given schema' % f)
+      return fields.split(',')
   if not schema:
     return []
-  return [f['name'] for f in schema._bq_schema if f['type'] != 'RECORD']
+  return all_fields
 
 
 def _get_cols(fields, schema):

--- a/tests/bigquery/dataset_tests.py
+++ b/tests/bigquery/dataset_tests.py
@@ -28,11 +28,11 @@ class TestCases(unittest.TestCase):
     parsed_name = dataset._name_parts
     self.assertEqual('test', parsed_name[0])
     self.assertEqual('requestlogs', parsed_name[1])
-    self.assertEqual('test:requestlogs', dataset._full_name)
-    self.assertEqual('test:requestlogs', str(dataset))
+    self.assertEqual('test.requestlogs', dataset._full_name)
+    self.assertEqual('test.requestlogs', str(dataset))
 
   def test_parse_full_name(self):
-    dataset = TestCases._create_dataset('test:requestlogs')
+    dataset = TestCases._create_dataset('test.requestlogs')
     self._check_name_parts(dataset)
 
   def test_parse_local_name(self):
@@ -74,7 +74,7 @@ class TestCases(unittest.TestCase):
   @mock.patch('google.datalab.bigquery._api.Api.datasets_get')
   def test_dataset_exists(self, mock_api_datasets_get):
     mock_api_datasets_get.return_value = ''
-    dataset = TestCases._create_dataset('test:requestlogs')
+    dataset = TestCases._create_dataset('test.requestlogs')
     self.assertTrue(dataset.exists())
     mock_api_datasets_get.side_effect = google.datalab.utils.RequestException(404, None)
     dataset._info = None
@@ -140,8 +140,8 @@ class TestCases(unittest.TestCase):
     ds = TestCases._create_dataset('requestlogs')
     tables = [table for table in ds]
     self.assertEqual(2, len(tables))
-    self.assertEqual('`p:d.t1`', tables[0]._repr_sql_())
-    self.assertEqual('`p:d.t2`', tables[1]._repr_sql_())
+    self.assertEqual('`p.d.t1`', tables[0]._repr_sql_())
+    self.assertEqual('`p.d.t2`', tables[1]._repr_sql_())
 
   @mock.patch('google.datalab.bigquery.Dataset._get_info')
   @mock.patch('google.datalab.bigquery._api.Api.datasets_list')
@@ -156,8 +156,8 @@ class TestCases(unittest.TestCase):
     datasets = [dataset for dataset in google.datalab.bigquery.Datasets('test',
                                                                  TestCases._create_context())]
     self.assertEqual(2, len(datasets))
-    self.assertEqual('p:d1', str(datasets[0]))
-    self.assertEqual('p:d2', str(datasets[1]))
+    self.assertEqual('p.d1', str(datasets[0]))
+    self.assertEqual('p.d2', str(datasets[1]))
 
   @mock.patch('google.datalab.bigquery._api.Api.tables_list')
   @mock.patch('google.datalab.bigquery._api.Api.datasets_get')

--- a/tests/bigquery/sampling_tests.py
+++ b/tests/bigquery/sampling_tests.py
@@ -37,16 +37,16 @@ class TestCases(unittest.TestCase):
     self._apply_sampling(Sampling.default(fields=[]), expected_sql)
 
   def test_hashed(self):
-    expected_sql = 'SELECT * FROM (%s) WHERE ABS(HASH(f1)) %% 100 < 5' % TestCases.BASE_SQL
+    expected_sql = 'SELECT * FROM (%s) WHERE MOD(FARM_FINGERPRINT(CAST(f1 AS STRING)), 100) < 5' % TestCases.BASE_SQL
     self._apply_sampling(Sampling.hashed('f1', 5), expected_sql)
 
   def test_hashed_and_limited(self):
-    expected_sql = 'SELECT * FROM (%s) WHERE ABS(HASH(f1)) %% 100 < 5 LIMIT 100' \
+    expected_sql = 'SELECT * FROM (%s) WHERE MOD(FARM_FINGERPRINT(CAST(f1 AS STRING)), 100) < 5 LIMIT 100' \
                    % TestCases.BASE_SQL
     self._apply_sampling(Sampling.hashed('f1', 5, count=100), expected_sql)
 
   def test_hashed_with_fields(self):
-    expected_sql = 'SELECT f1 FROM (%s) WHERE ABS(HASH(f1)) %% 100 < 5' % TestCases.BASE_SQL
+    expected_sql = 'SELECT f1 FROM (%s) WHERE MOD(FARM_FINGERPRINT(CAST(f1 AS STRING)), 100) < 5' % TestCases.BASE_SQL
     self._apply_sampling(Sampling.hashed('f1', 5, fields=['f1']), expected_sql)
 
   def test_sorted_ascending(self):

--- a/tests/bigquery/table_tests.py
+++ b/tests/bigquery/table_tests.py
@@ -34,7 +34,7 @@ class TestCases(unittest.TestCase):
     self.assertEqual('requestlogs', parsed_name[1])
     self.assertEqual('today', parsed_name[2])
     self.assertEqual('', parsed_name[3])
-    self.assertEqual('`test:requestlogs.today`', table._repr_sql_())
+    self.assertEqual('`test.requestlogs.today`', table._repr_sql_())
 
   def test_api_paths(self):
     name = google.datalab.bigquery._utils.TableName('a', 'b', 'c', 'd')
@@ -46,7 +46,7 @@ class TestCases(unittest.TestCase):
     self.assertEqual('/projects/a/datasets/b', google.datalab.bigquery._api.Api._DATASETS_PATH % name)
 
   def test_parse_full_name(self):
-    table = TestCases._create_table('test:requestlogs.today')
+    table = TestCases._create_table('test.requestlogs.today')
     self._check_name_parts(table)
 
   def test_parse_local_name(self):
@@ -89,7 +89,7 @@ class TestCases(unittest.TestCase):
 
   @mock.patch('google.datalab.bigquery._api.Api.tables_get')
   def test_table_metadata(self, mock_api_tables_get):
-    name = 'test:requestlogs.today'
+    name = 'test.requestlogs.today'
     ts = dt.datetime.utcnow()
 
     mock_api_tables_get.return_value = TestCases._create_table_info_result(ts=ts)
@@ -107,7 +107,7 @@ class TestCases(unittest.TestCase):
   def test_table_schema(self, mock_api_tables):
     mock_api_tables.return_value = TestCases._create_table_info_result()
 
-    t = TestCases._create_table('test:requestlogs.today')
+    t = TestCases._create_table('test.requestlogs.today')
     schema = t.schema
 
     self.assertEqual(2, len(schema))
@@ -117,7 +117,7 @@ class TestCases(unittest.TestCase):
   def test_table_schema_nested(self, mock_api_tables):
     mock_api_tables.return_value = TestCases._create_table_info_nested_schema_result()
 
-    t = TestCases._create_table('test:requestlogs.today')
+    t = TestCases._create_table('test.requestlogs.today')
     schema = t.schema
 
     self.assertEqual(4, len(schema))
@@ -133,7 +133,7 @@ class TestCases(unittest.TestCase):
   def test_malformed_response_raises_exception(self, mock_api_tables_get):
     mock_api_tables_get.return_value = {}
 
-    t = TestCases._create_table('test:requestlogs.today')
+    t = TestCases._create_table('test.requestlogs.today')
 
     with self.assertRaises(Exception) as error:
       _ = t.schema
@@ -151,8 +151,8 @@ class TestCases(unittest.TestCase):
     for table in ds:
       tables.append(table)
     self.assertEqual(2, len(tables))
-    self.assertEqual('`test:testds.testTable1`', tables[0]._repr_sql_())
-    self.assertEqual('`test:testds.testTable2`', tables[1]._repr_sql_())
+    self.assertEqual('`test.testds.testTable1`', tables[0]._repr_sql_())
+    self.assertEqual('`test.testds.testTable2`', tables[1]._repr_sql_())
 
   @mock.patch('google.datalab.bigquery._api.Api.tables_list')
   @mock.patch('google.datalab.bigquery._api.Api.datasets_get')
@@ -166,8 +166,8 @@ class TestCases(unittest.TestCase):
     for table in ds.tables():
       tables.append(table)
     self.assertEqual(2, len(tables))
-    self.assertEqual('`test:testds.testTable1`', tables[0]._repr_sql_())
-    self.assertEqual('`test:testds.testTable2`', tables[1]._repr_sql_())
+    self.assertEqual('`test.testds.testTable1`', tables[0]._repr_sql_())
+    self.assertEqual('`test.testds.testTable2`', tables[1]._repr_sql_())
 
   @mock.patch('google.datalab.bigquery._api.Api.tables_list')
   @mock.patch('google.datalab.bigquery._api.Api.datasets_get')
@@ -181,7 +181,7 @@ class TestCases(unittest.TestCase):
     for view in ds.views():
       views.append(view)
     self.assertEqual(1, len(views))
-    self.assertEqual('`test:testds.testView1`', views[0]._repr_sql_())
+    self.assertEqual('`test.testds.testView1`', views[0]._repr_sql_())
 
   @mock.patch('google.datalab.bigquery._api.Api.tables_list')
   @mock.patch('google.datalab.bigquery._api.Api.datasets_get')
@@ -220,7 +220,7 @@ class TestCases(unittest.TestCase):
     mock_api_tables_insert.return_value = {}
     with self.assertRaises(Exception) as error:
       _ = TestCases._create_table_with_schema(schema)
-    self.assertEqual('Table test:testds.testTable0 could not be created as it already exists',
+    self.assertEqual('Table test.testds.testTable0 could not be created as it already exists',
                      str(error.exception))
 
     mock_api_tables_insert.return_value = {'selfLink': 'http://foo'}
@@ -538,7 +538,7 @@ class TestCases(unittest.TestCase):
   def test_decorators(self):
     tbl = google.datalab.bigquery.Table('testds.testTable0', context=TestCases._create_context())
     tbl2 = tbl.snapshot(dt.timedelta(hours=-1))
-    self.assertEquals('`test:testds.testTable0@-3600000`', tbl2._repr_sql_())
+    self.assertEquals('`test.testds.testTable0@-3600000`', tbl2._repr_sql_())
 
     with self.assertRaises(Exception) as error:
       tbl2 = tbl2.snapshot(dt.timedelta(hours=-2))
@@ -563,7 +563,7 @@ class TestCases(unittest.TestCase):
         str(error.exception))
 
     tbl2 = tbl.snapshot(dt.timedelta(days=-1))
-    self.assertEquals('`test:testds.testTable0@-86400000`', tbl2._repr_sql_())
+    self.assertEquals('`test.testds.testTable0@-86400000`', tbl2._repr_sql_())
 
     with self.assertRaises(Exception) as error:
       _ = tbl.snapshot(dt.timedelta(days=1))
@@ -576,7 +576,7 @@ class TestCases(unittest.TestCase):
                      str(error.exception))
 
     _ = dt.datetime.utcnow() - dt.timedelta(1)
-    self.assertEquals('`test:testds.testTable0@-86400000`', tbl2._repr_sql_())
+    self.assertEquals('`test.testds.testTable0@-86400000`', tbl2._repr_sql_())
 
     when = dt.datetime.utcnow() + dt.timedelta(1)
     with self.assertRaises(Exception) as error:
@@ -597,7 +597,7 @@ class TestCases(unittest.TestCase):
     tbl = google.datalab.bigquery.Table('testds.testTable0', context=TestCases._create_context())
 
     tbl2 = tbl.window(dt.timedelta(hours=-1))
-    self.assertEquals('`test:testds.testTable0@-3600000-0`', tbl2._repr_sql_())
+    self.assertEquals('`test.testds.testTable0@-3600000-0`', tbl2._repr_sql_())
 
     with self.assertRaises(Exception) as error:
       tbl2 = tbl2.window(-400000, 0)
@@ -662,11 +662,11 @@ class TestCases(unittest.TestCase):
   def test_table_to_query(self):
     tbl = google.datalab.bigquery.Table('testds.testTable0', context=TestCases._create_context())
     q = google.datalab.bigquery.Query.from_table(tbl)
-    self.assertEqual('SELECT * FROM `test:testds.testTable0`', q.sql)
+    self.assertEqual('SELECT * FROM `test.testds.testTable0`', q.sql)
     q = google.datalab.bigquery.Query.from_table(tbl, fields='foo, bar')
-    self.assertEqual('SELECT foo, bar FROM `test:testds.testTable0`', q.sql)
+    self.assertEqual('SELECT foo, bar FROM `test.testds.testTable0`', q.sql)
     q = google.datalab.bigquery.Query.from_table(tbl, fields=['bar', 'foo'])
-    self.assertEqual('SELECT bar,foo FROM `test:testds.testTable0`', q.sql)
+    self.assertEqual('SELECT bar,foo FROM `test.testds.testTable0`', q.sql)
 
   @staticmethod
   def _create_context():
@@ -783,7 +783,7 @@ class TestCases(unittest.TestCase):
     return schema
 
   @staticmethod
-  def _create_table_with_schema(schema, name='test:testds.testTable0'):
+  def _create_table_with_schema(schema, name='test.testds.testTable0'):
     return google.datalab.bigquery.Table(name, TestCases._create_context()).create(schema)
 
   class _uuid(object):

--- a/tests/bigquery/udf_tests.py
+++ b/tests/bigquery/udf_tests.py
@@ -32,7 +32,7 @@ class TestCases(unittest.TestCase):
                   'bigquery.defineFunction(\'foo\', ["field1", "field2"], ' +\
                   '[{"name": "output1", "type": "integer"}, ' +\
                   '{"name": "output2", "type": "string"}], foo);'
-    self.assertEqual(query.sql, 'SELECT * FROM (SELECT output1, output2 FROM foo([test:requestlogs.today]))')
+    self.assertEqual(query.sql, 'SELECT * FROM (SELECT output1, output2 FROM foo(`test:requestlogs.today`))')
     self.assertEqual(udf._code, expected_js)
 
   def test_udf_expansion(self):

--- a/tests/bigquery/view_tests.py
+++ b/tests/bigquery/view_tests.py
@@ -24,7 +24,7 @@ import google.datalab.bigquery
 class TestCases(unittest.TestCase):
 
   def test_view_repr_sql(self):
-    name = 'test:testds.testView0'
+    name = 'test.testds.testView0'
     view = google.datalab.bigquery.View(name, TestCases._create_context())
     self.assertEqual('`%s`' % name, view._repr_sql_())
 
@@ -42,8 +42,8 @@ class TestCases(unittest.TestCase):
     mock_api_tables_get.return_value = None
     mock_api_tables_insert.return_value = TestCases._create_tables_insert_success_result()
 
-    name = 'test:testds.testView0'
-    sql = 'select * from test:testds.testTable0'
+    name = 'test.testds.testView0'
+    sql = 'select * from test.testds.testTable0'
     view = google.datalab.bigquery.View(name, TestCases._create_context())
     result = view.create(sql)
     self.assertTrue(view.exists())
@@ -66,8 +66,8 @@ class TestCases(unittest.TestCase):
     mock_api_jobs_get.return_value = {'status': {'state': 'DONE'}}
     mock_api_tabledata_list.return_value = TestCases._create_single_row_result()
 
-    name = 'test:testds.testView0'
-    sql = 'select * from test:testds.testTable0'
+    name = 'test.testds.testView0'
+    sql = 'select * from test.testds.testTable0'
     context = TestCases._create_context()
     view = google.datalab.bigquery.View(name, context)
     view.create(sql)
@@ -89,12 +89,12 @@ class TestCases(unittest.TestCase):
     mock_api_table_update.return_value = None
     friendly_name = 'casper'
     description = 'ghostly logs'
-    sql = 'select * from [test:testds.testTable0]'
+    sql = 'select * from `test.testds.testTable0`'
     info = {'friendlyName': friendly_name,
             'description': description,
             'view': {'query': sql}}
     mock_api_tables_get.return_value = info
-    name = 'test:testds.testView0'
+    name = 'test.testds.testView0'
     view = google.datalab.bigquery.View(name, TestCases._create_context())
     view.create(sql)
     self.assertEqual(friendly_name, view.friendly_name)


### PR DESCRIPTION
- Fix all remaining legacy SQL syntax to Standard SQL:
  - ([project:dataset.table] -> \`project.dataset.table\`)
  - `ABS(HASH())` -> `MOD(FARM_FINGERPRINT())`
- Added `%bq tables view` to take a quick view at a table
- When getting a list of fields from a `Schema`, validate they exist. This helps return a more user friendly error if the wrong fields are specified when charting a query/table.
- Fix tests