### PR TITLE
Added missing notebook environment in Query and parameters parsing

### DIFF
--- a/google/datalab/bigquery/_query.py
+++ b/google/datalab/bigquery/_query.py
@@ -51,7 +51,9 @@ class Query(object):
     self._sql = sql
     self._udfs = udfs
     self._subqueries = subqueries
-    self._env = env or {}
+    self._env = env
+    if self._env is None:
+      self._env = google.datalab.utils.commands.notebook_environment()
     self._data_sources = {}
 
     def _validate_object(obj, obj_type):

--- a/google/datalab/bigquery/commands/_bigquery.py
+++ b/google/datalab/bigquery/commands/_bigquery.py
@@ -379,7 +379,8 @@ def _get_query_parameters(args, cell_body):
     Validated object containing query parameters
   """
 
-  config = google.datalab.utils.commands.parse_config(cell_body, env=None, as_dict=False)
+  env = google.datalab.utils.commands.notebook_environment()
+  config = google.datalab.utils.commands.parse_config(cell_body, env=env, as_dict=False)
   sql = args['query']
   if sql is None:
     raise Exception('Cannot extract query parameters in non-query cell')
@@ -686,7 +687,10 @@ def _dataset_line(args):
   """
   if args['command'] == 'list':
     filter_ = args['filter'] if args['filter'] else '*'
-    return _render_list([str(dataset) for dataset in google.datalab.bigquery.Datasets(args['project'])
+    context = google.datalab.Context.default()
+    if args['project']:
+      context = google.datalab.Context(args['project'], context.credentials)
+    return _render_list([str(dataset) for dataset in google.datalab.bigquery.Datasets(context)
                          if fnmatch.fnmatch(str(dataset), filter_)])
 
   elif args['command'] == 'create':


### PR DESCRIPTION
- If no environment is provided when building a `Query` object (such as when done explicitly by the user), use the notebook's environment.
- When parsing the query parameters, use the notebook environment to expand any variables.
- Pass a `Context` object instead of `project_id` to `Datasets`.