### PR TITLE
Support datetime.date and datetime.time in schema

### DIFF
--- a/google/datalab/bigquery/_schema.py
+++ b/google/datalab/bigquery/_schema.py
@@ -120,6 +120,10 @@ class Schema(list):
     entry = {'name': name}
     if isinstance(value, datetime.datetime):
       _type = 'TIMESTAMP'
+    elif isinstance(value, datetime.date):
+      _type = 'DATE'
+    elif isinstance(value, datetime.time):
+      _type = 'TIME'
     elif isinstance(value, bool):
       _type = 'BOOLEAN'
     elif isinstance(value, float):

--- a/google/datalab/bigquery/_table.py
+++ b/google/datalab/bigquery/_table.py
@@ -253,7 +253,7 @@ class Table(object):
     for k in list(record.keys()):
       v = record[k]
       # If the column is a date, convert to ISO string.
-      if isinstance(v, pandas.Timestamp) or isinstance(v, datetime.datetime):
+      if isinstance(v, (pandas.Timestamp, datetime.datetime, datetime.date, datetime.time)):
         v = record[k] = record[k].isoformat()
 
       # If k has invalid characters clean it up

--- a/tests/bigquery/table_tests.py
+++ b/tests/bigquery/table_tests.py
@@ -530,10 +530,20 @@ class TestCases(unittest.TestCase):
     self.assertEquals(3.1415, df['headers'][0])
     self.assertEquals(0.5, df['headers'][1])
 
-  def test_encode_dict_as_row(self):
+  def test_encode_dict_as_row_datetime(self):
     when = dt.datetime(2001, 2, 3, 4, 5, 6, 7)
     row = google.datalab.bigquery.Table._encode_dict_as_row({'fo@o': 'b@r', 'b+ar': when}, {})
     self.assertEqual({'foo': 'b@r', 'bar': '2001-02-03T04:05:06.000007'}, row)
+
+  def test_encode_dict_as_row_date(self):
+    when = dt.date(2001, 2, 3)
+    row = google.datalab.bigquery.Table._encode_dict_as_row({'fo@o': 'b@r', 'b+ar': when}, {})
+    self.assertEqual({'foo': 'b@r', 'bar': '2001-02-03'}, row)
+
+  def test_encode_dict_as_row_time(self):
+    when = dt.time(1,2,3,4)
+    row = google.datalab.bigquery.Table._encode_dict_as_row({'fo@o': 'b@r', 'b+ar': when}, {})
+    self.assertEqual({'foo': 'b@r', 'bar': '01:02:03.000004'}, row)
 
   def test_decorators(self):
     tbl = google.datalab.bigquery.Table('testds.testTable0', context=TestCases._create_context())


### PR DESCRIPTION
Fixes https://github.com/googledatalab/datalab/issues/1199

Add `datetime.date` and `datetime.time` in the list of types serialized to ISO format string. These are now first class types in Standard SQL BigQuery.