### PR TITLE
Fix backwards-compatibility issue with the new `Context` class.

### DIFF
--- a/datalab/bigquery/_dialect.py
+++ b/datalab/bigquery/_dialect.py
@@ -36,6 +36,12 @@ class Dialect(object):
     """ Set the default BigQuery SQL dialect"""
     if bq_dialect in ['legacy', 'standard']:
       self._global_dialect = bq_dialect
+      try:
+        from google.datalab import Context as new_context
+        new_context.default().config['bigquery_dialect'] = bq_dialect
+      except ImportError:
+        # If the new library is not loaded, then we have nothing to do.
+        pass
 
   @staticmethod
   def default():

--- a/datalab/bigquery/_dialect.py
+++ b/datalab/bigquery/_dialect.py
@@ -36,12 +36,6 @@ class Dialect(object):
     """ Set the default BigQuery SQL dialect"""
     if bq_dialect in ['legacy', 'standard']:
       self._global_dialect = bq_dialect
-      try:
-        from google.datalab import Context as new_context
-        new_context.default().config['bigquery_dialect'] = bq_dialect
-      except ImportError:
-        # If the new library is not loaded, then we have nothing to do.
-        pass
 
   @staticmethod
   def default():

--- a/datalab/context/_context.py
+++ b/datalab/context/_context.py
@@ -64,6 +64,13 @@ class Context(object):
   def set_project_id(self, project_id):
     """ Set the project_id for the context. """
     self._project_id = project_id
+    if self == Context._global_context:
+      try:
+        from google.datalab import Context as new_context
+        new_context.default().set_project_id(project_id)
+      except ImportError:
+        # If the new library is not loaded, then we have nothing to do.
+        pass
 
   @staticmethod
   def is_signed_in():

--- a/datalab/kernel/__init__.py
+++ b/datalab/kernel/__init__.py
@@ -130,6 +130,7 @@ def load_ipython_extension(shell):
     if 'datalab_project_id' not in _IPython.get_ipython().user_ns:
       _IPython.get_ipython().user_ns['datalab_project_id'] = _get_project_id
       _IPython.get_ipython().user_ns['set_datalab_project_id'] = _set_project_id
+    if 'datalab_bq_dialect' not in _IPython.get_ipython().user_ns:
       _IPython.get_ipython().user_ns['datalab_bq_dialect'] = _get_bq_dialect
       _IPython.get_ipython().user_ns['set_datalab_bq_dialect'] = _set_bq_dialect
   except TypeError:

--- a/google/datalab/kernel/__init__.py
+++ b/google/datalab/kernel/__init__.py
@@ -125,26 +125,10 @@ def load_ipython_extension(shell):
       # If the old library is not loaded, then we don't have to do anything
       pass
 
-  def _get_bq_dialect():
-    context = google.datalab.Context.default()
-    return context.config.get('bigquery_dialect', 'standard')
-
-  def _set_bq_dialect(bq_dialect):
-    context = google.datalab.Context.default()
-    context.config['bigquery_dialect'] = bq_dialect
-    try:
-      from datalab.bigquery import Dialect
-      Dialect.default().set_bq_dialect(bq_dialect)
-    except ImportError:
-      # If the old library is not loaded, then we don't have to do anything
-      pass
-
   try:
     if 'datalab_project_id' not in _IPython.get_ipython().user_ns:
       _IPython.get_ipython().user_ns['datalab_project_id'] = _get_project_id
       _IPython.get_ipython().user_ns['set_datalab_project_id'] = _set_project_id
-      _IPython.get_ipython().user_ns['datalab_bq_dialect'] = _get_bq_dialect
-      _IPython.get_ipython().user_ns['set_datalab_bq_dialect'] = _set_bq_dialect
   except TypeError:
     pass
 

--- a/google/datalab/kernel/__init__.py
+++ b/google/datalab/kernel/__init__.py
@@ -118,6 +118,12 @@ def load_ipython_extension(shell):
   def _set_project_id(project_id):
     context = google.datalab.Context.default()
     context.set_project_id(project_id)
+    try:
+      from datalab.context import Context as _old_context
+      _old_context.default().set_project_id(project_id)
+    except ImportError:
+      # If the old library is not loaded, then we don't have to do anything
+      pass
 
   def _get_bq_dialect():
     context = google.datalab.Context.default()
@@ -126,6 +132,12 @@ def load_ipython_extension(shell):
   def _set_bq_dialect(bq_dialect):
     context = google.datalab.Context.default()
     context.config['bigquery_dialect'] = bq_dialect
+    try:
+      from datalab.bigquery import Dialect
+      Dialect.default().set_bq_dialect(bq_dialect)
+    except ImportError:
+      # If the old library is not loaded, then we don't have to do anything
+      pass
 
   try:
     if 'datalab_project_id' not in _IPython.get_ipython().user_ns:


### PR DESCRIPTION
This change fixes a backwards-incompatibility that was recently
introduced regarding the `datalab_project_id`, `datalab_bq_dialect`,
`set_datalab_project_id`, and `set_datalab_bq_dialect` helper methods,
and the old `datalab.context.Context` and `datalab.bigquery.Dialect`
classes.

Previously, those helper methods set and get the default instance
of the corresponding classes. However, with the new `google.*` modules,
those methods instead get and set the default instance of the
`google.datalab.Context` class.

That would be a breaking change for existing notebooks, so we
have to make sure that those helper methods *also* set and get the
older classes.

For example, if your project ID is initially 'a', then the
following code cell:

```python
from google.datalab import Context as ctx
from datalab.context import Context as old_ctx

default_ctx = ctx.default()
default_old_ctx = old_ctx.default()

print datalab_project_id()
print default_ctx.project_id
print default_old_ctx.project_id

set_datalab_project_id('b')

print datalab_project_id()
print default_ctx.project_id
print default_old_ctx.project_id
```

... will now output:

```
a
a
a
b
b
b
```

... whereas, without the fix, it would have output:

```
a
a
a
b
b
a
```

Similarly, the following cell:

```python
default_old_ctx.set_project_id('a')
print datalab_project_id()
```

... will output `a`, as expected.

There is one strange behavior that this introduces:

Calling `datalab.context.Context.default().set_project_id` will
also change the project ID in the `google.datalab.Context.default()`
object. However, calling `google.datalab.Context.default().set_project_id`
will *not* update the project ID in the `datalab.context.Context.default()`
object.

That design has been adopted because the behavior of the old class
was rather static (the stored values only changed if explicitly changed),
but the behavior of the new class is more dynamic (e.g. the project
ID is changed if you run `gcloud config set project ...`).

Since we did not want to change the static nature of the old class,
there has to be some place where the connection between the two
versions of Context is broken, and that is the place picked to do that.