### PR TITLE
Remove references to bigquery_dialect

### DIFF
--- a/google/datalab/_context.py
+++ b/google/datalab/_context.py
@@ -94,7 +94,6 @@ class Context(object):
   def _get_default_config():
     """Return a default config object"""
     return {
-      'bigquery_dialect': 'standard',
       'bigquery_billing_tier': None
     }
 

--- a/google/datalab/bigquery/_api.py
+++ b/google/datalab/bigquery/_api.py
@@ -52,11 +52,6 @@ class Api(object):
     return self._context.credentials
 
   @property
-  def bigquery_dialect(self):
-    """The BigQuery dialect associated with this API client."""
-    return self._context.config.get('bigquery_dialect', 'standard')
-
-  @property
   def bigquery_billing_tier(self):
     """The BigQuery billing tier associated with this API client."""
     return self._context.config.get('bigquery_billing_tier', None)
@@ -172,7 +167,7 @@ class Api(object):
                 'query': sql,
                 'useQueryCache': use_cache,
                 'allowLargeResults': allow_large_results,
-                'useLegacySql': self.bigquery_dialect == 'legacy'
+                'useLegacySql': False
             },
             'dryRun': dry_run,
             'priority': 'BATCH' if batch else 'INTERACTIVE',

--- a/google/datalab/bigquery/commands/_bigquery.py
+++ b/google/datalab/bigquery/commands/_bigquery.py
@@ -166,8 +166,6 @@ def _create_sample_subparser(parser):
   group.add_argument('-v', '--view', help='the name of the view object to sample')
   sample_parser.add_argument('-nc', '--nocache', help='Don\'t use previously cached results',
                               action='store_true')
-  sample_parser.add_argument('-d', '--dialect', help='BigQuery SQL dialect',
-                             choices=['legacy', 'standard'])
   sample_parser.add_argument('-b', '--billing', type=int, help='BigQuery billing tier')
   sample_parser.add_argument('-m', '--method', help='The type of sampling to use',
                              choices=['limit', 'random', 'hashed', 'sorted'], default='limit')
@@ -214,8 +212,6 @@ def _create_dryrun_subparser(parser):
       'Execute a dry run of a BigQuery query and display approximate usage statistics')
   dryrun_parser.add_argument('-q', '--query',
                               help='The name of the query to be dry run')
-  dryrun_parser.add_argument('-d', '--dialect', help='BigQuery SQL dialect',
-                             choices=['legacy', 'standard'])
   dryrun_parser.add_argument('-b', '--billing', type=int, help='BigQuery billing tier')
   dryrun_parser.add_argument('-v', '--verbose',
                               help='Show the expanded SQL that is being executed',
@@ -242,8 +238,6 @@ def _create_execute_subparser(parser):
       'The cell can optionally contain arguments for expanding variables in the query.')
   execute_parser.add_argument('-nc', '--nocache', help='Don\'t use previously cached results',
                               action='store_true')
-  execute_parser.add_argument('-d', '--dialect', help='BigQuery SQL dialect',
-                             choices=['legacy', 'standard'])
   execute_parser.add_argument('-b', '--billing', type=int, help='BigQuery billing tier')
   execute_parser.add_argument('-m', '--mode', help='The table creation mode', default='create',
                               choices=['create', 'append', 'overwrite'])
@@ -269,8 +263,6 @@ def _create_extract_subparser(parser):
                               action='store_true')
   extract_parser.add_argument('-f', '--format', choices=['csv', 'json'], default='csv',
                               help='The format to use for the export')
-  extract_parser.add_argument('-d', '--dialect', help='BigQuery SQL dialect',
-                             choices=['legacy', 'standard'])
   extract_parser.add_argument('-b', '--billing', type=int, help='BigQuery billing tier')
   extract_parser.add_argument('-c', '--compress', action='store_true',
                               help='Whether to compress the data')
@@ -324,10 +316,7 @@ def _construct_context_for_args(args):
   for key in global_default_context.config:
     config[key] = global_default_context.config[key]
 
-  dialect_arg = args.get('dialect', None)
   billing_tier_arg = args.get('billing', None)
-  if dialect_arg:
-    config['bigquery_dialect'] = dialect_arg
   if billing_tier_arg:
     config['bigquery_billing_tier'] = billing_tier_arg
 

--- a/tests/bigquery/api_tests.py
+++ b/tests/bigquery/api_tests.py
@@ -106,7 +106,6 @@ class TestCases(unittest.TestCase):
   @mock.patch('google.datalab.utils.Http.request')
   def test_jobs_insert_query(self, mock_http_request):
     context = TestCases._create_context()
-    context.config['bigquery_dialect'] = 'legacy'
     context.config['bigquery_billing_tier'] = None
     api = TestCases._create_api(context)
     api.jobs_insert_query('SQL')
@@ -117,7 +116,7 @@ class TestCases(unittest.TestCase):
           'query': 'SQL',
           'useQueryCache': True,
           'allowLargeResults': False,
-          'useLegacySql': True,
+          'useLegacySql': False,
         },
         'dryRun': False,
         'priority': 'BATCH',
@@ -126,7 +125,6 @@ class TestCases(unittest.TestCase):
     self.validate(mock_http_request, 'https://www.googleapis.com/bigquery/v2/projects/test/jobs/',
                   expected_data=expected_data)
 
-    context.config['bigquery_dialect'] = 'standard'
     context.config['bigquery_billing_tier'] = 1
     api.jobs_insert_query('SQL2',
                           table_name=google.datalab.bigquery._utils.TableName('p', 'd', 't', ''),


### PR DESCRIPTION
This removes all references for setting the bigquery dialect
from the new `google.*` library.

This is because the code in that library does not support legacy SQL