### PR TITLE
Allow colons in table names.

### DIFF
--- a/google/datalab/bigquery/_utils.py
+++ b/google/datalab/bigquery/_utils.py
@@ -40,13 +40,13 @@ TableName = collections.namedtuple('TableName',
 """
 
 # Absolute project-qualified name pattern: <project>.<dataset>
-_ABS_DATASET_NAME_PATTERN = r'^([a-z\d\-_\.]+)\.(\w+)$'
+_ABS_DATASET_NAME_PATTERN = r'^([a-z\d\-_\.:]+)\.(\w+)$'
 
 # Relative name pattern: <dataset>
 _REL_DATASET_NAME_PATTERN = r'^(\w+)$'
 
 # Absolute project-qualified name pattern: <project>.<dataset>.<table>
-_ABS_TABLE_NAME_PATTERN = r'^([a-z\d\-_\.]+)\.(\w+)\.(\w+)(@[\d\-]+)?$'
+_ABS_TABLE_NAME_PATTERN = r'^([a-z\d\-_\.:]+)\.(\w+)\.(\w+)(@[\d\-]+)?$'
 
 # Relative name pattern: <dataset>.<table>
 _REL_TABLE_NAME_PATTERN = r'^(\w+)\.(\w+)(@[\d\-]+)?$'


### PR DESCRIPTION
With Standard SQL, the separator between project name and dataset
name was changed from a colon to a period. As such, we changed our
regex to replace periods with colons. However, colons are still
allowed within a project name, so the regex needs to still allow
colons in the project name.