### PR TITLE
Fix query constructor to take dictionaries or lists of dependencies

### DIFF
--- a/google/datalab/bigquery/_api.py
+++ b/google/datalab/bigquery/_api.py
@@ -155,7 +155,7 @@ class Api(object):
           priority, more expensive).
       allow_large_results: whether to allow large results (slower with some restrictions but
           can handle big jobs).
-      table_definitions: a dictionary of JSON external table definitions for any external tables
+      table_definitions: a dictionary of ExternalDataSource names and objects for any external tables
           referenced in the query.
       query_params: a dictionary containing query parameter types and values, passed to BigQuery.
     Returns:
@@ -182,7 +182,10 @@ class Api(object):
     query_config = data['configuration']['query']
 
     if table_definitions:
-      query_config['tableDefinitions'] = table_definitions
+      expanded_definitions = {}
+      for td in table_definitions:
+        expanded_definitions[td] = table_definitions[td]._to_query_json()
+      query_config['tableDefinitions'] = expanded_definitions
 
     if table_name:
       query_config['destinationTable'] = {

--- a/tests/bigquery/query_tests.py
+++ b/tests/bigquery/query_tests.py
@@ -27,18 +27,20 @@ class TestCases(unittest.TestCase):
     sql = 'SELECT * FROM table'
     with self.assertRaises(Exception) as error:
       q = TestCases._create_query(sql, subqueries=['subquery'])
-    env = {'subquery': TestCases._create_query()}
+    sq = TestCases._create_query()
+    env = {'subquery': sq}
     q = TestCases._create_query(sql, env=env, subqueries=['subquery'])
     self.assertIsNotNone(q)
-    self.assertEqual(q._subqueries, ['subquery'])
+    self.assertEqual(q._subqueries, {'subquery': sq})
     self.assertEqual(q._sql, sql)
 
     with self.assertRaises(Exception) as error:
       q = TestCases._create_query(sql, udfs=['udf'])
-    env = {'udf': TestCases._create_udf('test_udf', 'code', 'TYPE')}
-    q = TestCases._create_query(sql, env=env, udfs=['udf'])
+    udf = TestCases._create_udf('test_udf', 'code', 'TYPE')
+    env = {'testudf': udf}
+    q = TestCases._create_query(sql, env=env, udfs=['testudf'])
     self.assertIsNotNone(q)
-    self.assertEqual(q._udfs, ['udf'])
+    self.assertEqual(q._udfs, {'testudf': udf})
     self.assertEqual(q._sql, sql)
 
   @mock.patch('google.datalab.bigquery._api.Api.tabledata_list')

--- a/tests/kernel/bigquery_tests.py
+++ b/tests/kernel/bigquery_tests.py
@@ -75,8 +75,8 @@ class TestCases(unittest.TestCase):
                                                 'datasources': None, 'subqueries': None}, q1_body)
     q1 = env['q1']
     self.assertIsNotNone(q1)
-    self.assertIsNone(q1._udfs)
-    self.assertIsNone(q1._subqueries)
+    self.assertEqual(q1.udfs, {})
+    self.assertEqual(q1.subqueries, {})
     self.assertEqual(q1_body, q1._sql)
     self.assertEqual(q1_body, q1.sql)
 
@@ -86,8 +86,8 @@ class TestCases(unittest.TestCase):
                                                 'datasources': None, 'subqueries': ['q1']}, q2_body)
     q2 = env['q2']
     self.assertIsNotNone(q2)
-    self.assertIsNone(q2._udfs)
-    self.assertEqual(['q1'], q2._subqueries)
+    self.assertEqual(q2.udfs, {})
+    self.assertEqual({'q1': q1}, q2.subqueries)
     expected_sql = 'WITH q1 AS (%s)\n%s' % (q1_body, q2_body)
     self.assertEqual(q2_body, q2._sql)
     self.assertEqual(expected_sql, q2.sql)


### PR DESCRIPTION
This PR fixes the `Query` constructor to take dependencies (subqueries, udfs, or external datasources) in the form of either a list or dictionary. If a list is given, it should be a list of strings, where items are names of objects defined in the environment object (user can build their own object or pass the `notebook_environment()` as parameter). If a dictionary is provided, it should be a mapping between dependency names and objects.

All of the below examples now work:
```
q1 = bq.Query('sql')
q2 = bq.Query('sql', subqueries=['q1'], env={'q1': q1})
q2 = bq.Query('sql', subqueries=['q1'], env=utils.commands.notebook_environment())
q2 = bq.Query('sql', subqueries={'q1': q1})
```