### PR TITLE
Tokenize '@param' as an atom

### DIFF
--- a/google/datalab/notebook/static/codemirror/mode/bigquery.js
+++ b/google/datalab/notebook/static/codemirror/mode/bigquery.js
@@ -96,9 +96,9 @@ define(["require", 'codemirror/lib/codemirror'], function (require, CodeMirror) 
           stream.skipToEnd();
           return 'comment';
         }
-      } else if (ch === '$' || ch === '?') {
+      } else if (ch === '$' || ch === '?' || ch === '@') {
         stream.match(/^[\w\d]*/);
-        return 'variable-2';
+        return 'atom';
       } else if (ch === '"' || ch === '\'' || ch === '`') {
         state.tokenize = tokenLiteral(ch);
         return state.tokenize(stream, state);


### PR DESCRIPTION
Standard SQL BigQuery takes parameters that are declared as `@param`, our tokenizer should return that as an atom.