### PR TITLE
Fix a bug where an unbounded number of credentials wrappers got added.

### DIFF
--- a/datalab/utils/_http.py
+++ b/datalab/utils/_http.py
@@ -19,6 +19,7 @@ from builtins import str
 from past.builtins import basestring
 from builtins import object
 
+import copy
 import datetime
 import json
 import urllib.request, urllib.parse, urllib.error
@@ -119,9 +120,12 @@ class Http(object):
     if method is None:
       method = 'GET'
 
-    # Authorize with credentials if given.
     http = Http.http
+
+    # Authorize with credentials if given.
     if credentials is not None:
+      # Make a copy of the shared http instance before we modify it.
+      http = copy.copy(http)
       http = credentials.authorize(http)
     if stats is not None:
       stats['duration'] = datetime.datetime.utcnow()

--- a/google/datalab/utils/_http.py
+++ b/google/datalab/utils/_http.py
@@ -19,6 +19,7 @@ from builtins import str
 from past.builtins import basestring
 from builtins import object
 
+import copy
 import datetime
 import json
 import urllib.request, urllib.parse, urllib.error
@@ -119,8 +120,11 @@ class Http(object):
     if method is None:
       method = 'GET'
 
+    # Make a copy of the shared http instance in case we need to modify
+    # it (e.g. by adding credentials) below.
+    http = copy.copy(Http.http)
+
     # Authorize with credentials if given
-    http = Http.http
     if credentials is not None:
       http = credentials.authorize(http)
     if stats is not None:

--- a/google/datalab/utils/_http.py
+++ b/google/datalab/utils/_http.py
@@ -120,12 +120,12 @@ class Http(object):
     if method is None:
       method = 'GET'
 
-    # Make a copy of the shared http instance in case we need to modify
-    # it (e.g. by adding credentials) below.
-    http = copy.copy(Http.http)
+    http = Http.http
 
     # Authorize with credentials if given
     if credentials is not None:
+      # Make a copy of the shared http instance before we modify it.
+      http = copy.copy(http)
       http = credentials.authorize(http)
     if stats is not None:
       stats['duration'] = datetime.datetime.utcnow()


### PR DESCRIPTION
This fixes the issue where the fact that we were sharing a single
`httplib2.Http` instance caused each request to add an additional
credentials wrapper around that single instance.

That, in turn, caused a `RuntimeError: maximum recursion depth ...`
error message once too many API calls had been made.

This fixes https://github.com/googledatalab/datalab/issues/1251