### PR TITLE
Log http requests (silent by default)

### DIFF
--- a/datalab/utils/_http.py
+++ b/datalab/utils/_http.py
@@ -23,6 +23,10 @@ import datetime
 import json
 import urllib.request, urllib.parse, urllib.error
 import httplib2
+import logging
+
+
+log = logging.getLogger(__name__)
 
 
 # TODO(nikhilko): Start using the requests library instead.
@@ -128,6 +132,7 @@ class Http(object):
 
     response = None
     try:
+      log.debug('request: method[%(method)s], url[%(url)s], body[%(data)s]' % locals())
       response, content = http.request(url,
                                        method=method,
                                        body=data,

--- a/google/datalab/utils/_http.py
+++ b/google/datalab/utils/_http.py
@@ -23,6 +23,10 @@ import datetime
 import json
 import urllib.request, urllib.parse, urllib.error
 import httplib2
+import logging
+
+
+log = logging.getLogger(__name__)
 
 
 # TODO(nikhilko): Start using the requests library instead.
@@ -128,6 +132,7 @@ class Http(object):
 
     response = None
     try:
+      log.debug('request: method[%(method)s], url[%(url)s], body[%(data)s]' % locals())
       response, content = http.request(url,
                                        method=method,
                                        body=data,


### PR DESCRIPTION
- Critical for debugging issues like #195 and #220 (I've been using this locally)
- Silent by default, to avoid bothering users
- To enable, use standard logging idioms like `logging.basicConfig`, `logging.fileConfig`, etc.

Test plan:

- No logging, old api:
```py
>>> import datalab.bigquery as bq
>>> bq.Query("select 3").to_dataframe()
Your active configuration is: [foo]

   f0_
0    3
```

- No logging, new api:
```py
>>> import google.datalab.bigquery as bq
>>> bq.Query("select 3").execute().result().to_dataframe()
Your active configuration is: [foo]

   f0_
0    3
```

- With logging, old api:
```py
>>> import logging
>>> logging.basicConfig(level=logging.DEBUG)
>>> import datalab.bigquery as bq
>>> bq.Query("select 3").to_dataframe()
Your active configuration is: [foo]

DEBUG:datalab.utils._http:request: method[POST], url[https://www.googleapis.com/bigquery/v2/projects/dwh-v2/jobs/], body[{"kind": "bigquery#job", "configuration": {"query": {"query": "select 3", "useQueryCache": true, "allowLargeResults": false, "useLegacySql": true, "userDefinedFunctionResources": []}, "dryRun": false, "priority": "INTERACTIVE"}}]
INFO:oauth2client.client:Attempting refresh to obtain initial access_token
INFO:oauth2client.client:Refreshing access_token
DEBUG:datalab.utils._http:request: method[GET], url[https://www.googleapis.com/bigquery/v2/projects/dwh-v2/queries/job_u67WYzV6RCbO4F-C5JB7hRocdxA?maxResults=0&timeoutMs=30000&startIndex=0], body[None]
DEBUG:datalab.utils._http:request: method[GET], url[https://www.googleapis.com/bigquery/v2/projects/dwh-v2/jobs/job_u67WYzV6RCbO4F-C5JB7hRocdxA], body[None]
DEBUG:datalab.utils._http:request: method[GET], url[https://www.googleapis.com/bigquery/v2/projects/dwh-v2/datasets/_2f96775300d8858559d2bd23c05bad0392345e30/tables/anonda2cd79fe2c683f6e17ec63437a72c0e2144c829], body[None]
DEBUG:datalab.utils._http:request: method[GET], url[https://www.googleapis.com/bigquery/v2/projects/dwh-v2/datasets/_2f96775300d8858559d2bd23c05bad0392345e30/tables/anonda2cd79fe2c683f6e17ec63437a72c0e2144c829/data?maxResults=1024], body[None]
   f0_
0    3
```

- With logging, new api:
```py
>>> import logging
>>> logging.basicConfig(level=logging.DEBUG)
>>> import google.datalab.bigquery as bq
>>> bq.Query("select 3").execute().result().to_dataframe()
Your active configuration is: [foo]

DEBUG:google.datalab.utils._http:request: method[POST], url[https://www.googleapis.com/bigquery/v2/projects/dwh-v2/jobs/], body[{"kind": "bigquery#job", "configuration": {"priority": "INTERACTIVE", "query": {"query": "select 3", "allowLargeResults": false, "useLegacySql": false, "useQueryCache": true}, "dryRun": false}}]
INFO:oauth2client.client:Attempting refresh to obtain initial access_token
INFO:oauth2client.client:Refreshing access_token
DEBUG:google.datalab.utils._http:request: method[GET], url[https://www.googleapis.com/bigquery/v2/projects/dwh-v2/queries/job_5OZWn-K-SHCwFxi8B-55quDr254?timeoutMs=30000&startIndex=0&maxResults=0], body[None]
DEBUG:google.datalab.utils._http:request: method[GET], url[https://www.googleapis.com/bigquery/v2/projects/dwh-v2/jobs/job_5OZWn-K-SHCwFxi8B-55quDr254], body[None]
DEBUG:google.datalab.utils._http:request: method[GET], url[https://www.googleapis.com/bigquery/v2/projects/dwh-v2/datasets/_2f96775300d8858559d2bd23c05bad0392345e30/tables/anon921947a4e6645dc2b34411c365f9a45e0895d5a4], body[None]
DEBUG:google.datalab.utils._http:request: method[GET], url[https://www.googleapis.com/bigquery/v2/projects/dwh-v2/datasets/_2f96775300d8858559d2bd23c05bad0392345e30/tables/anon921947a4e6645dc2b34411c365f9a45e0895d5a4/data?maxResults=1024], body[None]
   f0_
0    3
```