### PR TITLE
Fix subquery order dependency in Query constructor

### DIFF
--- a/google/datalab/bigquery/_query.py
+++ b/google/datalab/bigquery/_query.py
@@ -51,7 +51,7 @@ class Query(object):
       Exception if expansion of any variables failed.
       """
     self._sql = sql
-    self._udfs = {}
+    self._udfs = []
     self._subqueries = []
     self._data_sources = []
     self._env = env or {}
@@ -130,7 +130,7 @@ class Query(object):
     #      q1 as (SELECT * FROM mytable),
     # SELECT * FROM q2
     # so when we're getting the dependencies, use recursion into a list to maintain the order
-    udfs = {}
+    udfs = []
     subqueries = []
     expanded_sql = ''
 
@@ -142,7 +142,7 @@ class Query(object):
           _recurse_subqueries(subquery[1])
         subqueries.extend([s for s in query._subqueries if s not in subqueries])
       if query._udfs:
-        udfs.update(query._udfs)
+        udfs.extend([u for u in query._udfs if u not in udfs])
 
     subqueries_sql = udfs_sql = ''
     _recurse_subqueries(self)
@@ -187,7 +187,7 @@ class Query(object):
   @property
   def udfs(self):
     """ Get a dictionary of UDFs referenced by the query."""
-    return self._udfs
+    return dict(self._udfs)
 
   @property
   def subqueries(self):

--- a/tests/bigquery/query_tests.py
+++ b/tests/bigquery/query_tests.py
@@ -31,7 +31,7 @@ class TestCases(unittest.TestCase):
     env = {'subquery': sq}
     q = TestCases._create_query(sql, env=env, subqueries=['subquery'])
     self.assertIsNotNone(q)
-    self.assertEqual(q._subqueries, {'subquery': sq})
+    self.assertEqual(q.subqueries, {'subquery': sq})
     self.assertEqual(q._sql, sql)
 
     with self.assertRaises(Exception) as error:
@@ -40,7 +40,7 @@ class TestCases(unittest.TestCase):
     env = {'testudf': udf}
     q = TestCases._create_query(sql, env=env, udfs=['testudf'])
     self.assertIsNotNone(q)
-    self.assertEqual(q._udfs, {'testudf': udf})
+    self.assertEqual(q.udfs, {'testudf': udf})
     self.assertEqual(q._sql, sql)
 
   @mock.patch('google.datalab.bigquery._api.Api.tabledata_list')
@@ -130,19 +130,66 @@ class TestCases(unittest.TestCase):
     # test direct subquery expansion
     q1 = TestCases._create_query('SELECT * FROM test_table', name='q1', env=env)
     q2 = TestCases._create_query('SELECT * FROM q1', name='q2', subqueries=['q1'], env=env)
-    self.assertEqual('WITH q1 AS (SELECT * FROM test_table)\nSELECT * FROM q1', q2.sql)
+    self.assertEqual('''\
+WITH q1 AS (
+  SELECT * FROM test_table
+)
+
+SELECT * FROM q1''', q2.sql)
 
     # test recursive, second level subquery expansion
     q3 = TestCases._create_query('SELECT * FROM q2', name='q3', subqueries=['q2'], env=env)
     # subquery listing order is random, try both possibilities
-    expected_sql1 = 'WITH q1 AS (%s),\nq2 AS (%s)\n%s' % (q1._sql, q2._sql, q3._sql)
-    expected_sql2 = 'WITH q2 AS (%s),\nq1 AS (%s)\n%s' % (q2._sql, q1._sql, q3._sql)
+    expected_sql1 = '''\
+WITH q1 AS (
+  %s
+),
+q2 AS (
+  %s
+)
+
+%s''' % (q1._sql, q2._sql, q3._sql)
+    expected_sql2 = '''\
+WITH q2 AS (
+  %s
+),
+q1 AS (
+  %s
+)
+
+%s''' % (q2._sql, q1._sql, q3._sql)
 
     self.assertTrue((expected_sql1 == q3.sql) or (expected_sql2 == q3.sql))
+
+  #@mock.patch('google.datalab.bigquery._api.Api.jobs_insert_query')
+  def test_subquery_expansion_order(self):
+    env = {}
+    snps = TestCases._create_query('SELECT * FROM test_table', name='snps', env=env)
+    windows = TestCases._create_query('SELECT * FROM snps', subqueries=['snps'], name='windows',
+                                      env=env)
+    titv = TestCases._create_query('SELECT * FROM snps, windows', subqueries=['snps', 'windows'],
+                                   env=env)
+
+    # make sure snps appears before windows in the expanded sql of titv
+    snps_pos, windows_pos = titv.sql.find('snps AS'), titv.sql.find('windows AS')
+    self.assertNotEqual(snps_pos, -1, 'Could not find snps definition in expanded sql')
+    self.assertNotEqual(windows_pos, -1, 'Could not find windows definition in expanded sql')
+    self.assertLess(snps_pos, windows_pos)
+
+    # reverse the order they're referenced in titv, and make sure snps still appears before windows
+    titv = TestCases._create_query('SELECT * FROM snps, windows', subqueries=['windows', 'snps'],
+                                   env=env)
+    snps_pos, windows_pos = titv.sql.find('snps AS'), titv.sql.find('windows AS')
+    self.assertNotEqual(snps_pos, -1, 'Could not find snps definition in expanded sql')
+    self.assertNotEqual(windows_pos, -1, 'Could not find windows definition in expanded sql')
+    self.assertLess(snps_pos, windows_pos)
+
 
   @staticmethod
   def _create_query(sql='SELECT * ...', name=None, env=None, udfs=None, data_sources=None,
                     subqueries=None):
+    if env is None:
+      env = {}
     q = google.datalab.bigquery.Query(sql, env=env, udfs=udfs, data_sources=data_sources,
                                       subqueries=subqueries)
     if name:

--- a/tests/kernel/bigquery_tests.py
+++ b/tests/kernel/bigquery_tests.py
@@ -88,7 +88,12 @@ class TestCases(unittest.TestCase):
     self.assertIsNotNone(q2)
     self.assertEqual(q2.udfs, {})
     self.assertEqual({'q1': q1}, q2.subqueries)
-    expected_sql = 'WITH q1 AS (%s)\n%s' % (q1_body, q2_body)
+    expected_sql = '''\
+WITH q1 AS (
+  %s
+)
+
+%s''' % (q1_body, q2_body)
     self.assertEqual(q2_body, q2._sql)
     self.assertEqual(expected_sql, q2.sql)
 


### PR DESCRIPTION
Fixes https://github.com/googledatalab/pydatalab/issues/282

The problem is subqueries were stored in a dictionary while traversing dependencies, which does not preserve order, so the dependency tree would get flattened in the expanded sql with the order of the hashes of subquery names. Add to this the fact that BigQuery requires a correct dependency order for subqueries, for example the following is rejected:
```
with q2 as (select * from q1),
     q1 as (select * from some_table)
select * from q2
```
This PR:
- Fixes this by using an list of tuples instead of dictionary.
- Adds nice indentation formatting for expanded queries (test modification shows this).
- Adds a regression test.