### PR TITLE
Fix #301: %bq query table view is broke.

### DIFF
--- a/datalab/bigquery/commands/_bigquery.py
+++ b/datalab/bigquery/commands/_bigquery.py
@@ -944,7 +944,7 @@ def _table_viewer(table, rows_per_page=25, fields=None):
                 rowNumberCell: 'gchart-table-rownumcell'
               }}
             }},
-            {{source_index: {source_index}, fields: '{fields}'}},
+            {{source_index: {source_index}, fields: '{fields}', legacy: 'true'}},
             0,
             {total_rows});
         }}

--- a/datalab/utils/commands/_chart_data.py
+++ b/datalab/utils/commands/_chart_data.py
@@ -30,7 +30,9 @@ import datalab.utils
 from . import _utils
 
 
-@IPython.core.magic.register_cell_magic
+# Disable the magic here because another one with same name is available under
+# google.datalab namespace.
+# @IPython.core.magic.register_cell_magic
 def _get_chart_data(line, cell_body=''):
 
   refresh = 0

--- a/google/datalab/bigquery/_table.py
+++ b/google/datalab/bigquery/_table.py
@@ -140,6 +140,11 @@ class Table(object):
     return self._name_parts
 
   @property
+  def full_name(self):
+    """The full name of the table in the form of project.dataset.table."""
+    return self._full_name
+
+  @property
   def job(self):
     """ For tables resulting from executing queries, the job that created the table.
 

--- a/google/datalab/bigquery/commands/_bigquery.py
+++ b/google/datalab/bigquery/commands/_bigquery.py
@@ -736,7 +736,7 @@ def _table_cell(args, cell_body):
 
     tables = []
     for dataset in datasets:
-      tables.extend([str(table) for table in dataset if fnmatch.fnmatch(str(table), filter_)])
+      tables.extend([table.full_name for table in dataset if fnmatch.fnmatch(table.full_name, filter_)])
 
     return _render_list(tables)
 
@@ -992,7 +992,7 @@ def _table_viewer(table, rows_per_page=25, fields=None):
   # TODO(gram): rework this to use google.datalab.utils.commands.chart_html
 
   if not table.exists():
-    raise Exception('Table %s does not exist' % str(table))
+    raise Exception('Table %s does not exist' % table.full_name)
 
   _HTML_TEMPLATE = u"""
     <div class="bqtv" id="{div_id}">{static_table}</div>
@@ -1047,7 +1047,7 @@ def _table_viewer(table, rows_per_page=25, fields=None):
     fields = google.datalab.utils.commands.get_field_list(fields, table.schema)
   div_id = google.datalab.utils.commands.Html.next_id()
   meta_count = ('rows: %d' % table.length) if table.length >= 0 else ''
-  meta_name = str(table) if table.job is None else ('job: %s' % table.job.id)
+  meta_name = table.full_name if table.job is None else ('job: %s' % table.job.id)
   if table.job:
     if table.job.cache_hit:
       meta_cost = 'cached'
@@ -1076,7 +1076,7 @@ def _table_viewer(table, rows_per_page=25, fields=None):
                                static_table=google.datalab.utils.commands.HtmlBuilder.render_chart_data(data),
                                meta_data=meta_data,
                                chart_style=chart,
-                               source_index=google.datalab.utils.commands.get_data_source_index(str(table)),
+                               source_index=google.datalab.utils.commands.get_data_source_index(table.full_name),
                                fields=','.join(fields),
                                total_rows=total_count,
                                rows_per_page=rows_per_page,


### PR DESCRIPTION
Fix #301. There are two issues:

- Like old library, the new library still uses "str(table)" to get table full name, but __str__() method is removed from new library's Table class.
- Old library and new library shares the same in-memory object for storing opened tables, but due to different naming convention between old table and new table full name (mainly project:dataset.table vs project.dataset.table), it no longer works. Either old or new library breaks without separating the two.

The fix takes care of both issues above to make both "%%sql" and "%%bq query" working --- the output is a paged table that can go next and previous.