### PR TITLE
Resolve issue where the legacy bq.Query command would raise TypeError

### DIFF
--- a/datalab/data/_utils.py
+++ b/datalab/data/_utils.py
@@ -102,6 +102,9 @@ def _next_token(sql):
   def start_string(s, i):
     return s[i] == '"' or s[i] == "'"
 
+  def always_true(s, i):
+    return True
+
   while i < len(sql):
     start = i
     if start_multi_line_comment(sql, i):
@@ -119,13 +122,13 @@ def _next_token(sql):
     elif start_string(sql, i):
       # Special handling here as we need to check for escaped closing quotes.
       quote = sql[i]
-      end_checker = True
+      end_checker = always_true
       i += 1
       while i < len(sql) and sql[i] != quote:
         i += 2 if sql[i] == '\\' else 1
     else:
       # We return single characters for everything else
-      end_checker = True
+      end_checker = always_true
 
     i += 1
     while i < len(sql) and not end_checker(sql, i):


### PR DESCRIPTION
Steps to reproduce
```
df = bq.Query("SELECT * FROM ")

----> 1 df = bq.Query("SELECT * FROM ")

/usr/local/lib/python2.7/dist-packages/datalab/bigquery/_query.pyc in __init__(self, sql, context, values, udfs, data_sources, **kwargs)
    104     included_udfs = set([])
    105 
--> 106     tokens = datalab.data.tokenize(self._sql)
    107     udf_dict = {udf.name: udf for udf in udfs}
    108 

/usr/local/lib/python2.7/dist-packages/datalab/data/_utils.pyc in tokenize(sql)
    155     A list of strings corresponding to the groups above.
    156   """
--> 157   return list(_next_token(sql))

/usr/local/lib/python2.7/dist-packages/datalab/data/_utils.pyc in _next_token(sql)
    129 
    130     i += 1
--> 131     while i < len(sql) and not end_checker(sql, i):
    132       i += 1
    133 

TypeError: 'bool' object is not callable
```

This issue was a regression introduced in #315 during refactoring. 