### PR TITLE
Update ipykernel dependecy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'pyyaml==3.11',
     'requests==2.9.1',
     'scikit-learn==0.17.1',
-    'ipykernel==4.4.1',
+    'ipykernel==4.5.2',
     'psutil==4.3.0',
     'jsonschema==2.6.0',
   ],


### PR DESCRIPTION
The only clear dependency is that IPython is defined. Exact match is preventing Datalab from updating `ipykernel`.