### PR TITLE
Update PyPI release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,20 +1,38 @@
-#!/bin/sh -e
-
-# Copyright 2016 Google Inc. All rights reserved.
+#!/bin/bash -e
+# Copyright 2017 Google Inc. All rights reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-# in compliance with the License. You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#  http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied. See the License for the specific language governing permissions and limitations under
-# the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# Build a distribution package
-tsc --module amd --noImplicitAny --outdir datalab/notebook/static datalab/notebook/static/*.ts
-python setup.py bdist_wheel
-rm datalab/notebook/static/*.js
+# Compiles the typescript sources to javascript and submits the files
+# to the pypi server specified as first parameter, defaults to testpypi
+# In order to run this script locally, make sure you have the following:
+# - Typescript installed
+# - A configured ~/.pypi.rc containing your pypi/testpypi credentials with
+#   the server names matching the name you're passing in.
+# - Make sure the package version string in the setup.py file is updated.
+#   It will get rejected by the server if it already exists
+# - If this is a new release, make sure the release notes are updated
+#   and create a new release tag
 
+tsc --module amd --noImplicitAny datalab/notebook/static/*.ts
+tsc --module amd --noImplicitAny google/datalab/notebook/static/*.ts
 
+server="${1:-testpypi}"
+echo "Submitting package to ${server}"
+
+# Build and upload a distribution package
+python setup.py sdist upload -r "${server}" -q
+
+# Clean up
+rm -f datalab/notebook/static/*.js
+rm -f google/datalab/notebook/static/*.js

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@
 
 # To publish to PyPi use: python setup.py bdist_wheel upload -r pypi
 
-import datetime
 from setuptools import setup
 
 version = '1.0.0'

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,7 @@
 import datetime
 from setuptools import setup
 
-minor = datetime.datetime.now().strftime("%y%m%d%H%M")
-version = '1.0.' + minor
+version = '1.0.0'
 
 setup(
   name='datalab',


### PR DESCRIPTION
This PR updates the package release script to compile *.ts to *.js, and actually submit them to testpypi (or pypi).

I also got rid of the timestamp on the version string, we should be uploading easy to use version strings since those are used manually by users in pip commands.