### PR TITLE
Set up tox, and use it for local testing and Travis.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ build
 .coverage
 dist
 datalab.magics.rst
+
+# Test files
+.tox/
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,22 @@
-sudo: required
-
-dist: trusty
-
 language: python
+dist: trusty
+sudo: false
 
-python:
-  - 2.7
-  - 3.5
+matrix:
+  include:
+  - python: 2.7
+    env: TOX_ENV=py27
+  - python: 3.5
+    env: TOX_ENV=py35
+  - python: 2.7
+    env: TOX_ENV=flake8
 
 before_install:
-  - sudo apt-get install -y python-setuptools
   - npm install -g typescript
   - tsc --module amd --noImplicitAny --outdir datalab/notebook/static datalab/notebook/static/*.ts
-  - pip install -U pip
-  - pip install -U setuptools
-  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install -U google-cloud-dataflow==0.5.5; fi
-  - pip install .
-  - pip install solutionbox/structured_data/
-  - pip install solutionbox/image_classification/  
-  - pip install -U tensorflow==1.0.0
-  - pip install -U protobuf==3.1.0  #v3.2.0 has the "python: double free or corruption" bug.
-  - pip install flake8
-
-before_script:
-  - flake8 .
-
+  - pip install --upgrade pip setuptools tox coveralls
+  
 script:
-  - python ./tests/main.py
-  - python ./legacy_tests/main.py
+  - tox -e $TOX_ENV
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,11 @@ matrix:
 before_install:
   - npm install -g typescript
   - tsc --module amd --noImplicitAny --outdir datalab/notebook/static datalab/notebook/static/*.ts
-  - pip install --upgrade pip setuptools tox coveralls
+  # We use tox for actually running tests.
+  - pip install --upgrade pip tox
   
 script:
+  # tox reads its configuration from tox.ini.
   - tox -e $TOX_ENV
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,24 @@ frustration later on.
 All submissions, including submissions by project members, require review. We
 use Github pull requests for this purpose.
 
+### Running tests
+We use [`tox`](https://tox.readthedocs.io/) for running our tests. To run tests
+before sending out a pull request, just
+[install tox](https://http://tox.readthedocs.io/en/latest/install.html) and run
+
+```shell
+$ tox -e py27
+```
+
+to run tests under Python 2.7, or 
+
+```shell
+$ tox
+```
+
+to run tests under all supported environments. `tox -l` will provide a list of
+all supported environments.
+
 ### The small print
 Contributions made by corporations are covered by a different agreement than
 the one above, the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,17 +26,15 @@ before sending out a pull request, just
 [install tox](https://http://tox.readthedocs.io/en/latest/install.html) and run
 
 ```shell
-$ tox -e py27
-```
-
-to run tests under Python 2.7, or 
-
-```shell
 $ tox
 ```
 
-to run tests under all supported environments. `tox -l` will provide a list of
-all supported environments.
+to run tests under all supported environments. (This will skip any environments
+for which no interpreter is available.) `tox -l` will provide a list of all
+supported environments.
+
+`tox` will run all tests referenced by `tests/main.py` and
+`legacy_tests/main.py`.
 
 ### The small print
 Contributions made by corporations are covered by a different agreement than

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,10 @@ skip_missing_interpreters = true
 #
 # tox always installs the current package, so there's no need to list it here.
 deps = tensorflow==1.0.0
-       #Note: protobuf 3.2.0 has the "python: double free or corruption" bug.
-       protobuf==3.1.0 
+       # Note: protobuf 3.2.0 has the "python: double free or corruption" bug.
+       protobuf==3.1.0
+       # Dropping this seems to cause problems with conda in some cases.
+       scipy
        solutionbox/structured_data/
        solutionbox/image_classification/
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,6 @@ commands =
 deps = {[testenv]basedeps}
        google-cloud-dataflow==0.5.5
 
-[flake8]
-exclude = .tox,.git,./*.egg,build,.cache,env,__pycache__,docs
-
 [testenv:flake8]
-commands = flake8
+commands = flake8 --exclude=.tox,.git,./*.egg,build,.cache,env,__pycache__,docs
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,27 @@
 [tox]
+# By default, we want to run tests for Python 2.7, Python 3.5, and run our
+# flake8 checks.
 envlist = py27,py35,flake8
+# If an interpreter is missing locally, skip it.
+skip_missing_interpreters = true
 
 [testenv]
-basedeps = tensorflow==1.0.0
-           protobuf==3.1.0
-           solutionbox/structured_data/
-           solutionbox/image_classification/
-deps = {[testenv]basedeps}
+# pydatalab doesn't require users to have these dependencies installed, but we
+# need them to run our tests suite.
+#
+# tox always installs the current package, so there's no need to list it here.
+deps = tensorflow==1.0.0
+       #Note: protobuf 3.2.0 has the "python: double free or corruption" bug.
+       protobuf==3.1.0 
+       solutionbox/structured_data/
+       solutionbox/image_classification/
 commands =
   python ./tests/main.py
   python ./legacy_tests/main.py
 
 [testenv:py27]
-deps = {[testenv]basedeps}
+# google-cloud-dataflow only supports python2.7, so we add that here.
+deps = {[testenv]deps}
        google-cloud-dataflow==0.5.5
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+envlist = py27,py35,flake8
+
+[testenv]
+basedeps = tensorflow==1.0.0
+           protobuf==3.1.0
+           solutionbox/structured_data/
+           solutionbox/image_classification/
+deps = {[testenv]basedeps}
+commands =
+  python ./tests/main.py
+  python ./legacy_tests/main.py
+
+[testenv:py27]
+deps = {[testenv]basedeps}
+       google-cloud-dataflow==0.5.5
+
+[flake8]
+exclude = .tox,.git,./*.egg,build,.cache,env,__pycache__,docs
+
+[testenv:flake8]
+commands = flake8
+deps = flake8


### PR DESCRIPTION
[tox](https://tox.readthedocs.io/) is a Python test automation tool: it makes it easy to automate running the tests for your project in several environments. Under the hood, it just uses virtualenv to manage installed deps.

If you have python2.7 and python3.5 installed, simply running `tox` at the root of the repo will now run tests in both versions, as well as `flake8`.

This PR makes two changes:

* first, convert the existing `.travis.yml` into `tox.ini`, setting up three tox environments based on the configuration that was already there. (Relatedly, I added the `.tox` directory to `.gitignore`).

* Now that #330 is fixed (wooo @brandondutra), I switched the `.travis.yml` over to use `tox`. Now there are separate travis environments for each tox environment, which has two advantages: (1) these three all run in parallel, speeding up builds, and (2) build logs are separated, making it faster to figure out what caused a given failure.

PTAL @yebrahim @brandondutra 