### PR TITLE
make the tests work without a project

### DIFF
--- a/solutionbox/structured_data/mltoolbox/_structured_data/_package.py
+++ b/solutionbox/structured_data/mltoolbox/_structured_data/_package.py
@@ -189,14 +189,17 @@ def _analyze(output_dir, dataset, cloud=False, project_id=None):
                                            prefix='schema')
     file_io.write_string_to_file(schema_file_path, json.dumps(dataset.schema))
 
+    #TODO(brandondutra) use project_id in the local preprocess function.
     args = ['preprocess',
             '--input-file-pattern=%s' % dataset.input_files[0],
             '--output-dir=%s' % output_dir,
             '--schema-file=%s' % schema_file_path]
 
     if cloud:
+      if not project_id:
+        project_id = _default_project()
       print('Track BigQuery status at')
-      print('https://bigquery.cloud.google.com/queries/%s' % _default_project())
+      print('https://bigquery.cloud.google.com/queries/%s' % project_id)
       preprocess.cloud_preprocess.main(args)
     else:
       preprocess.local_preprocess.main(args)

--- a/solutionbox/structured_data/mltoolbox/_structured_data/_package.py
+++ b/solutionbox/structured_data/mltoolbox/_structured_data/_package.py
@@ -189,7 +189,7 @@ def _analyze(output_dir, dataset, cloud=False, project_id=None):
                                            prefix='schema')
     file_io.write_string_to_file(schema_file_path, json.dumps(dataset.schema))
 
-    #TODO(brandondutra) use project_id in the local preprocess function.
+    # TODO(brandondutra) use project_id in the local preprocess function.
     args = ['preprocess',
             '--input-file-pattern=%s' % dataset.input_files[0],
             '--output-dir=%s' % output_dir,

--- a/solutionbox/structured_data/test_mltoolbox/test_package_functions.py
+++ b/solutionbox/structured_data/test_mltoolbox/test_package_functions.py
@@ -108,7 +108,8 @@ class TestAnalyze(unittest.TestCase):
         dlml.CsvDataSet(
             file_pattern=['gs://file1.txt'],
             schema=schema),
-        cloud=True).wait()
+        cloud=True,
+        project_id='junk_project_id').wait()
       self.assertIn('Schema contains an unsupported type %s.' % col_type,
                     job.fatal_error.message)
 


### PR DESCRIPTION
...without a project set in gcloud

analyze does not use the project_id that is passed in! This is documented in #332 This will change if we move to tensorflow_transform. 

Fixes #330 