### PR TITLE
Fix a bug in `%bq query` expansion with UDFs.

### DIFF
--- a/google/datalab/bigquery/_query.py
+++ b/google/datalab/bigquery/_query.py
@@ -65,7 +65,7 @@ class Query(object):
           if value is None:
             raise Exception('Cannot find object %s' % item)
 
-        # for a dictionary of objects, each pair must be a string an object of the expected type
+        # for a dictionary of objects, each pair must be a string and object of the expected type
         elif isinstance(obj_container, dict):
           value = obj_container[item]
           if not isinstance(value, obj_type):
@@ -142,12 +142,13 @@ class Query(object):
           _recurse_subqueries(subquery[1])
         subqueries.extend([s for s in query._subqueries if s not in subqueries])
       if query._udfs:
-        udfs.extend([u for u in query._udfs if u not in udfs])
+        # query._udfs is a list of (name, UDF) tuples; we just want the UDF.
+        udfs.extend([u[1] for u in query._udfs if u[1] not in udfs])
 
     _recurse_subqueries(self)
 
     if udfs:
-      expanded_sql += '\n'.join([udfs[udf]._expanded_sql() for udf in udfs])
+      expanded_sql += '\n'.join([udf._expanded_sql() for udf in udfs])
       expanded_sql += '\n'
 
     def _indent_query(subquery):

--- a/tests/bigquery/query_tests.py
+++ b/tests/bigquery/query_tests.py
@@ -52,6 +52,11 @@ class TestCases(unittest.TestCase):
     self.assertEqual(q.data_sources, {'test_datasource': test_datasource})
     self.assertEqual(q._sql, sql)
 
+  def test_query_with_udf_object(self):
+    udf = TestCases._create_udf('test_udf', 'udf body', 'TYPE')
+    q = TestCases._create_query('SELECT * FROM table', udfs={'test_udf': udf})
+    self.assertIn('udf body', q.sql)
+
   @mock.patch('google.datalab.bigquery._api.Api.tabledata_list')
   @mock.patch('google.datalab.bigquery._api.Api.jobs_insert_query')
   @mock.patch('google.datalab.bigquery._api.Api.jobs_query_results')


### PR DESCRIPTION
Currently, attempting to call `%bq query --udfs <some udf object>` will fail
with a stack trace like

```
TypeErrorTraceback (most recent call last)
<ipython-input-27-0f9364e227db> in <module>()
----> 1 extract_params_query.sql()

/tmp/tmpZ1tEW3/dist-packages/google/datalab/bigquery/_query.pyc in sql(self)
    183   def sql(self):
    184     """ Get the SQL for the query. """
--> 185     return self._expanded_sql()
    186
    187   @property

/tmp/tmpZ1tEW3/dist-packages/google/datalab/bigquery/_query.pyc in _expanded_sql(self, sampling)
    148
    149     if udfs:
--> 150       expanded_sql += '\n'.join([udfs[udf]._expanded_sql() for udf in udfs])
    151       expanded_sql += '\n'
    152

TypeError: list indices must be integers, not tuple
```

The issue here is a mismatch between use of `query._udfs`, which is a list of
`(name, udf)` tuples, and `query.udfs`, which is `dict(query._udfs)`.

This occurs in the [tutorials](https://github.com/googledatalab/notebooks/blob/master/tutorials/BigQuery/UDFs%20in%20BigQuery.ipynb).

Switching to tuples everywhere fixes this, as verified by the test.