### PR TITLE
Fix two issues in mltoolbox.

### DIFF
--- a/google/datalab/ml/_summary.py
+++ b/google/datalab/ml/_summary.py
@@ -38,9 +38,9 @@ class Summary(object):
     """
 
     if sys.version_info.major > 2:
-      basestring = (str, bytes)  # for python 3 compatibility
-
-    self._paths = [paths] if isinstance(paths, basestring) else paths
+      self._paths = [paths] if isinstance(paths, str) else paths
+    else:
+      self._paths = [paths] if isinstance(paths, basestring) else paths
 
   def _glob_events_files(self, paths):
     event_files = []

--- a/solutionbox/image_classification/mltoolbox/image/classification/_predictor.py
+++ b/solutionbox/image_classification/mltoolbox/image/classification/_predictor.py
@@ -212,7 +212,7 @@ def configure_pipeline(p, dataset, model_dir, output_csv, output_bq_table):
                     'Write Csv Results' >> beam.io.textio.WriteToText(output_csv,
                                                                       shard_name_template=''))
     (results_save |
-     beam.transforms.combiners.Sample.FixedSizeGlobally('Sample One', 1) |
+     'Sample One' >> beam.transforms.combiners.Sample.FixedSizeGlobally(1) |
      'Serialize Schema' >> beam.Map(lambda path: json.dumps(output_schema)) |
      'Write Schema' >> beam.io.textio.WriteToText(schema_file, shard_name_template=''))
 

--- a/solutionbox/image_classification/mltoolbox/image/classification/_preprocess.py
+++ b/solutionbox/image_classification/mltoolbox/image/classification/_preprocess.py
@@ -354,6 +354,6 @@ def configure_pipeline(p, dataset_train, dataset_eval, checkpoint_path, output_d
   # Make sure we write "latest" file after train and eval data are successfully written.
   output_latest_file = os.path.join(output_dir, 'latest')
   ([eval_save, train_save, labels_save] | 'Wait for train eval saving' >> beam.Flatten() |
-      beam.transforms.combiners.Sample.FixedSizeGlobally('Fixed One', 1) |
+      'Fixed One' >> beam.transforms.combiners.Sample.FixedSizeGlobally(1) |
       beam.Map(lambda path: job_id) |
       'WriteLatest' >> beam.io.textio.WriteToText(output_latest_file, shard_name_template=''))


### PR DESCRIPTION
- Beam's transform op name needs to be moved out of the transform constructor so it works well with latest version of Beam.
- Seems "basestring" cannot be assigned in a class. Otherwise if the assignment is not run, "basestring" will become "unassigned" regular variable.