### PR TITLE
Table.to_dataframe optimization fixes

### DIFF
--- a/google/datalab/bigquery/_table.py
+++ b/google/datalab/bigquery/_table.py
@@ -106,7 +106,7 @@ class Table(object):
   # When fetching table contents for a range or iteration, use a small page size per request
   _DEFAULT_PAGE_SIZE = 1024
   # When fetching the entire table, use the maximum number of rows. The BigQuery service
-  # is likely to return less rows than this if their encoded JSON size is larger than 10MB
+  # will always return fewer rows than this if their encoded JSON size is larger than 10MB
   _MAX_PAGE_SIZE = 100000
 
   # Milliseconds per week

--- a/tests/bigquery/table_tests.py
+++ b/tests/bigquery/table_tests.py
@@ -671,14 +671,14 @@ class TestCases(unittest.TestCase):
     tbl._api.tabledata_list = mock.Mock(return_value=results)
 
     # using Table.to_dataframe should use large pages to reduce traffic
-    df = tbl.to_dataframe()
+    tbl.to_dataframe()
     tbl._api.tabledata_list.assert_called_with(tbl.name, max_results=100000, start_index=0)
 
     # using Table.range or iterator should use smaller pages to reduce latency
-    _ = list(tbl.range(start_row=0))
+    list(tbl.range(start_row=0))
     tbl._api.tabledata_list.assert_called_with(tbl.name, max_results=1024, start_index=0)
 
-    _ = tbl[0]
+    tbl[0]
     tbl._api.tabledata_list.assert_called_with(tbl.name, max_results=1024, start_index=0)
 
   @staticmethod


### PR DESCRIPTION
- Use large page size for downloading entire tables
- Concatenate paged dataframes instead of appending

Follow up from the discussion on https://github.com/googledatalab/pydatalab/issues/329.
Replaces https://github.com/googledatalab/pydatalab/pull/220