### PR TITLE
Storage object deletion waits for consistency.

### DIFF
--- a/google/datalab/storage/_object.py
+++ b/google/datalab/storage/_object.py
@@ -16,6 +16,7 @@ from __future__ import unicode_literals
 from builtins import object
 
 import dateutil.parser
+import time
 
 import google.datalab
 import google.datalab.utils
@@ -24,6 +25,10 @@ from . import _api
 
 # TODO(nikhilko): Read/write operations don't account for larger files, or non-textual content.
 #                 Use streaming reads into a buffer or StringIO or into a file handle.
+
+# In some polling operations, we sleep between API calls to avoid hammering the
+# server. This argument controls how long we sleep between API calls.
+_POLLING_SLEEP = 1
 
 
 class ObjectMetadata(object):
@@ -136,8 +141,12 @@ class Object(object):
     except Exception as e:
       raise e
 
-  def delete(self):
+  def delete(self, wait_for_deletion=True):
     """Deletes this object from its bucket.
+
+    Args:
+      wait_for_deletion: If True, we poll until this object no longer appears in
+          objects.list operations for this bucket before returning.
 
     Raises:
       Exception if there was an error deleting the object.
@@ -147,6 +156,14 @@ class Object(object):
         self._api.objects_delete(self._bucket, self._key)
       except Exception as e:
         raise e
+      if wait_for_deletion:
+        while True:
+          objects = Objects(self._bucket, prefix=self.key, delimiter='/',
+                            context=self._context)
+          if any(o.key == self.key for o in objects):
+            time.sleep(_POLLING_SLEEP)
+            continue
+          break
 
   @property
   def metadata(self):

--- a/google/datalab/storage/_object.py
+++ b/google/datalab/storage/_object.py
@@ -160,7 +160,7 @@ class Object(object):
       except Exception as e:
         raise e
       if wait_for_deletion:
-        for _ in xrange(_MAX_POLL_ATTEMPTS):
+        for _ in range(_MAX_POLL_ATTEMPTS):
           objects = Objects(self._bucket, prefix=self.key, delimiter='/',
                             context=self._context)
           if any(o.key == self.key for o in objects):

--- a/tests/integration/storage_test.py
+++ b/tests/integration/storage_test.py
@@ -5,7 +5,6 @@ from __future__ import division
 from __future__ import print_function
 
 import logging
-import os
 import random
 import string
 import unittest

--- a/tests/integration/storage_test.py
+++ b/tests/integration/storage_test.py
@@ -1,0 +1,49 @@
+"""Integration tests for google.datalab.storage."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+import os
+import random
+import string
+import subprocess
+import unittest
+
+import google.datalab
+from google.datalab import storage
+
+
+class StorageTest(unittest.TestCase):
+
+  def setUp(self):
+    project_id = os.environ.get('PROJECT_ID', '')
+    if not project_id:
+      # If there's no project ID set, we try asking gcloud. We need to send
+      # stderr to /dev/null, otherwise we get some spurious output.
+      gcloud_output = subprocess.check_output([
+          'gcloud', 'config', 'get-value', 'project'], stderr=subprocess.PIPE)
+      project_id = gcloud_output.strip()
+    logging.info('Using project ID: %s', project_id)
+
+    context = google.datalab.Context.default()
+    context.set_project_id(project_id)
+    self._context = context
+
+    suffix = ''.join(random.choice(string.letters) for _ in range(8))
+    self._test_bucket_name = '-'.join((project_id, suffix)).lower()
+    logging.info('test bucket: %s', self._test_bucket_name)
+
+  def test_object_deletion_consistency(self):
+    b = storage.Bucket(self._test_bucket_name, context=self._context)
+    b.create()
+    o = b.object('sample')
+    o.write_stream('contents', 'text/plain')
+    o.delete()
+    b.delete()
+
+
+if __name__ == '__main__':
+  logging.basicConfig(level=logging.INFO)
+  unittest.main()

--- a/tests/integration/storage_test.py
+++ b/tests/integration/storage_test.py
@@ -8,7 +8,6 @@ import logging
 import os
 import random
 import string
-import subprocess
 import unittest
 
 import google.datalab
@@ -18,17 +17,8 @@ from google.datalab import storage
 class StorageTest(unittest.TestCase):
 
   def setUp(self):
-    project_id = os.environ.get('PROJECT_ID', '')
-    if not project_id:
-      # If there's no project ID set, we try asking gcloud. We need to send
-      # stderr to /dev/null, otherwise we get some spurious output.
-      gcloud_output = subprocess.check_output([
-          'gcloud', 'config', 'get-value', 'project'], stderr=subprocess.PIPE)
-      project_id = gcloud_output.strip()
-    logging.info('Using project ID: %s', project_id)
-
     context = google.datalab.Context.default()
-    context.set_project_id(project_id)
+    logging.info('Using project: %s', context.project_id)
     self._context = context
 
     suffix = ''.join(random.choice(string.letters) for _ in range(8))

--- a/tests/integration/storage_test.py
+++ b/tests/integration/storage_test.py
@@ -17,12 +17,11 @@ from google.datalab import storage
 class StorageTest(unittest.TestCase):
 
   def setUp(self):
-    context = google.datalab.Context.default()
-    logging.info('Using project: %s', context.project_id)
-    self._context = context
+    self._context = google.datalab.Context.default()
+    logging.info('Using project: %s', self._context.project_id)
 
-    suffix = ''.join(random.choice(string.letters) for _ in range(8))
-    self._test_bucket_name = '-'.join((project_id, suffix)).lower()
+    suffix = ''.join(random.choice(string.lowercase) for _ in range(8))
+    self._test_bucket_name = '{}-{}'.format(self._context.project_id, suffix)
     logging.info('test bucket: %s', self._test_bucket_name)
 
   def test_object_deletion_consistency(self):

--- a/tests/kernel/storage_tests.py
+++ b/tests/kernel/storage_tests.py
@@ -156,6 +156,7 @@ class TestCases(unittest.TestCase):
     self.assertEqual("Couldn't create gs://foo/bar: Invalid bucket name gs://foo/bar",
                      str(error.exception))
 
+  @mock.patch('google.datalab.storage._api.Api.objects_list', autospec=True)
   @mock.patch('google.datalab.storage._api.Api.buckets_get', autospec=True)
   @mock.patch('google.datalab.storage._api.Api.objects_get', autospec=True)
   @mock.patch('google.datalab.storage._bucket.Bucket.objects', autospec=True)
@@ -164,7 +165,7 @@ class TestCases(unittest.TestCase):
   @mock.patch('google.datalab.Context.default')
   def test_gcs_delete(self, mock_context_default, mock_api_bucket_delete,
                       mock_api_objects_delete, mock_bucket_objects, mock_api_objects_get,
-                      mock_api_buckets_get):
+                      mock_api_buckets_get, mock_api_objects_list):
     context = TestCases._create_context()
     mock_context_default.return_value = context
     # Mock API for getting objects in a bucket.
@@ -172,6 +173,8 @@ class TestCases(unittest.TestCase):
     # Mock API for getting object metadata.
     mock_api_objects_get.side_effect = TestCases._mock_api_objects_get()
     mock_api_buckets_get.side_effect = TestCases._mock_api_buckets_get()
+    # Mock API for listing objects in a bucket.
+    mock_api_objects_list.side_effect = {}
 
     with self.assertRaises(Exception) as error:
       google.datalab.storage.commands._storage._gcs_delete({

--- a/tests/storage/object_tests.py
+++ b/tests/storage/object_tests.py
@@ -79,6 +79,39 @@ class TestCases(unittest.TestCase):
     self.assertEqual(objects[0].key, 'test_object1')
     self.assertEqual(objects[1].key, 'test_object2')
 
+  @mock.patch('google.datalab.storage._api.Api.objects_list')
+  def test_object_delete_with_wait(self, mock_objects_list):
+    stable_object_name = 'testobject'
+    object_to_delete = 'temporaryobject'
+    mock_objects_list.side_effect = [
+        {'items': [{'name': stable_object_name}], 'nextPageToken': 'yes'},
+        {'items': [{'name': object_to_delete}]},
+        {'items': [{'name': stable_object_name}]},
+    ]
+
+    b = TestCases._create_bucket()
+    o = b.object(object_to_delete)
+    o._info = {'name': object_to_delete}
+
+    with mock.patch.object(google.datalab.storage._api.Api, 'objects_delete',
+                           autospec=True) as mock_objects_delete:
+      o.delete(wait_for_deletion=False)
+    self.assertEqual(1, mock_objects_delete.call_count)
+    # storage.objects.list shouldn't have been called with
+    # wait_for_deletion=False.
+    self.assertEqual(0, mock_objects_list.call_count)
+
+    with mock.patch.object(google.datalab.storage._api.Api, 'objects_delete',
+                           autospec=True) as mock_objects_delete:
+      o.delete()
+    self.assertEqual(1, mock_objects_delete.call_count)
+    # storage.objects.list should have been called three times with
+    # wait_for_deletion=True:
+    #  * twice on the first run, paging through all results, with the object
+    #    still present in the bucket, and
+    #  * once on a second run, now with no object present in the list.
+    self.assertEqual(3, mock_objects_list.call_count)
+
   @staticmethod
   def _create_bucket(name='test_bucket'):
     return google.datalab.storage.Bucket(name, context=TestCases._create_context())


### PR DESCRIPTION
Fixes #344.

GCS object deletions are eventually consistent, in that deleting an object in
a globally-available bucket may result in the object still appearing when
listing objects in the bucket:
  https://cloud.google.com/storage/docs/consistency#eventually_consistent_operations

This is a detail, but can lead to confusion for users: someone following the
examples in the tutorial notebooks may see rare-but-regular failures about an
object they just deleted continuing to exist. (We've seen this running the
notebooks as automated tests.) This PR teaches an object to poll the bucket
until it no longer appears. This is controllable by `wait_for_deletion`, and
defaults to **on**.

I've added two tests: first is a mock-based unit test, which works; the second
is intended as a first step towards integration tests. In this case, we assume
that the user running the test has ambient credentials that `google.datalab`
will discover.