### PR TITLE
transform beam script for the new SD package

### DIFF
--- a/solutionbox/code_free_ml/test_transform_raw_data.py
+++ b/solutionbox/code_free_ml/test_transform_raw_data.py
@@ -1,0 +1,204 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+
+import json
+
+import os
+import shutil
+import subprocess
+import tempfile
+import uuid
+import unittest
+
+import six
+import tensorflow as tf
+
+import apache_beam as beam
+import tensorflow_transform as tft
+from tensorflow_transform.beam import impl as tft_impl
+
+from tensorflow.python.lib.io import file_io
+
+
+from tensorflow_transform.tf_metadata import dataset_metadata
+from tensorflow_transform.tf_metadata import dataset_schema
+from tensorflow_transform.beam import tft_beam_io
+from tensorflow_transform.tf_metadata import metadata_io
+import base64
+
+import google.datalab as dl
+import google.datalab.bigquery as bq
+import analyze_data
+
+
+from PIL import Image
+
+
+class TestTransformRawData(unittest.TestCase):
+  """Tests for applying a saved model"""
+
+  def _create_test_data(self):
+    """Makes local test data.
+
+    The fllowing files and folders will be created in self.output_folder:
+
+    self.output_folder/
+        features.json
+        img.png
+        input.csv
+        schema.json
+        raw_metadata/
+            (tft metadata files)
+        transformed_metadata/
+            (tft metadata files)
+        transform_fn/
+            (tft saved model file)
+    """
+    self.output_folder = tempfile.mkdtemp()
+
+    # Make image file
+    self.img_filepath = os.path.join(self.output_folder, 'img.png')
+    image = Image.new('RGBA', size=(50, 50), color=(155, 0, 0))
+    image.save(self.img_filepath, 'png')
+
+    # Make csv input file
+    self.csv_input_filepath = os.path.join(self.output_folder, 'input.csv')
+    file_io.write_string_to_file(
+        self.csv_input_filepath,
+        '23.0,%s' % self.img_filepath)
+
+    # Make schema file
+    self.schema_filepath = os.path.join(self.output_folder, 'schema.json')
+    file_io.write_string_to_file(
+        self.schema_filepath,
+        json.dumps([{'name': 'num_col', 'type': 'FLOAT'},
+                    {'name': 'img_col', 'type': 'STRING'}]))
+
+    # Make features file
+    self.features_filepath = os.path.join(self.output_folder, 'features.json')
+    file_io.write_string_to_file(
+        self.features_filepath,
+        json.dumps({'num_col': {'transform': 'target'},
+                    'img_col': {'transform': 'img_url_to_vec'}}))
+
+    # Run a local beam job to make the transform_fn
+    with beam.Pipeline('DirectRunner'):
+      with tft_impl.Context(temp_dir=os.path.join(self.output_folder, 'tmp')):
+        def preprocessing_fn(inputs):
+          return {'img_col': tft.map(tf.decode_base64, inputs['img_col']),
+                  'num_col': tft.map(lambda x: tf.add(x, 1), inputs['num_col'])}
+
+        input_data = [{'img_col': base64.urlsafe_b64encode('abcd'), 'num_col': 3}]
+
+        input_metadata = dataset_metadata.DatasetMetadata(
+            schema=dataset_schema.from_feature_spec(
+                {'img_col': tf.FixedLenFeature(shape=[], dtype=tf.string),
+                 'num_col': tf.FixedLenFeature(shape=[], dtype=tf.float32)}))
+
+        (dataset, train_metadata), transform_fn = (
+            (input_data, input_metadata)
+            | 'AnalyzeAndTransform'  # noqa: W503
+            >> tft_impl.AnalyzeAndTransformDataset(preprocessing_fn))  # noqa: W503
+
+        # WriteTransformFn writes transform_fn and metadata
+        _ = (transform_fn  # noqa: F841
+             | 'WriteTransformFn'  # noqa: W503
+             >> tft_beam_io.WriteTransformFn(self.output_folder))  # noqa: W503
+
+        metadata_io.write_metadata(
+            metadata=input_metadata,
+            path=os.path.join(self.output_folder,
+                              analyze_data.RAW_METADATA_DIR))
+
+  def test_local_csv_transform(self):
+    """Test transfrom from local csv files."""
+    try:
+      self._create_test_data()
+      tfex_dir = os.path.join(self.output_folder, 'test_results')
+      cmd = ['python transform_raw_data.py',
+             '--csv-file-pattern=' + self.csv_input_filepath,
+             '--analyze-output-dir=' + self.output_folder,
+             '--output-filename-prefix=features',
+             '--output-dir=' + tfex_dir]
+      subprocess.check_call(' '.join(cmd), shell=True)
+
+      # Read the tf record file. There should only be one file.
+      record_filepath = os.path.join(tfex_dir,
+                                     'features-00000-of-00001.tfrecord.gz')
+      options = tf.python_io.TFRecordOptions(
+          compression_type=tf.python_io.TFRecordCompressionType.GZIP)
+      serialized_example = next(
+          tf.python_io.tf_record_iterator(
+              record_filepath,
+              options=options))
+      example = tf.train.Example()
+      example.ParseFromString(serialized_example)
+
+      transformed_number = example.features.feature['num_col'].float_list.value[0]
+      self.assertAlmostEqual(transformed_number, 24.0)
+
+      image_bytes = example.features.feature['img_col'].bytes_list.value[0]
+      raw_img = Image.open(self.img_filepath).convert('RGB')
+      img_file = six.BytesIO()
+      raw_img.save(img_file, 'jpeg')
+      expected_image_bytes = img_file.getvalue()
+
+      self.assertEqual(image_bytes, expected_image_bytes)
+    finally:
+      shutil.rmtree(self.output_folder)
+
+  def test_local_bigquery_transform(self):
+    """Test transfrom locally, but the data comes from bigquery."""
+    try:
+      self._create_test_data()
+
+      # Make a BQ table, and insert 1 row.
+      project_id = dl.Context.default().project_id
+      dataset_name = 'test_transform_raw_data_%s' % uuid.uuid4().hex
+      table_name = 'tmp_table'
+
+      dataset = bq.Dataset((project_id, dataset_name)).create()
+      table = bq.Table((project_id, dataset_name, table_name))
+      table.create([{'name': 'num_col', 'type': 'FLOAT'},
+                    {'name': 'img_col', 'type': 'STRING'}])
+      table.insert(data=[{'num_col': 23.0, 'img_col': self.img_filepath}])
+
+      tfex_dir = os.path.join(self.output_folder, 'test_results')
+      cmd = ['python transform_raw_data.py',
+             '--bigquery-table=%s.%s.%s' % (project_id, dataset_name, table_name),
+             '--analyze-output-dir=' + self.output_folder,
+             '--output-filename-prefix=features',
+             '--project-id=' + project_id,
+             '--output-dir=' + tfex_dir]
+      subprocess.check_call(' '.join(cmd), shell=True)
+
+      # Read the tf record file. There should only be one file.
+      record_filepath = os.path.join(tfex_dir,
+                                     'features-00000-of-00001.tfrecord.gz')
+      options = tf.python_io.TFRecordOptions(
+          compression_type=tf.python_io.TFRecordCompressionType.GZIP)
+      serialized_example = next(
+          tf.python_io.tf_record_iterator(
+              record_filepath,
+              options=options))
+      example = tf.train.Example()
+      example.ParseFromString(serialized_example)
+
+      transformed_number = example.features.feature['num_col'].float_list.value[0]
+      self.assertAlmostEqual(transformed_number, 24.0)
+
+      image_bytes = example.features.feature['img_col'].bytes_list.value[0]
+      raw_img = Image.open(self.img_filepath).convert('RGB')
+      img_file = six.BytesIO()
+      raw_img.save(img_file, 'jpeg')
+      expected_image_bytes = img_file.getvalue()
+
+      self.assertEqual(image_bytes, expected_image_bytes)
+    finally:
+      dataset.delete(delete_contents=True)
+      shutil.rmtree(self.output_folder)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/solutionbox/code_free_ml/transform_raw_data.py
+++ b/solutionbox/code_free_ml/transform_raw_data.py
@@ -1,0 +1,253 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Flake8 cannot disable a warning for the file. Flake8 does not like beam code
+# and reports many 'W503 line break before binary operator' errors. So turn off
+# flake8 for this file.
+# flake8: noqa
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import datetime
+import json
+import logging
+import os
+import random
+import sys
+import apache_beam as beam
+from apache_beam.metrics import Metrics
+from PIL import Image
+import six
+from tensorflow.python.lib.io import file_io
+from tensorflow_transform import coders
+from tensorflow_transform.beam import impl as tft
+from tensorflow_transform.beam import tft_beam_io
+from tensorflow_transform.tf_metadata import metadata_io
+
+
+img_error_count = Metrics.counter('main', 'ImgErrorCount')
+
+# Files
+SCHEMA_FILE = 'schema.json'
+FEATURES_FILE = 'features.json'
+
+TRANSFORMED_METADATA_DIR = 'transformed_metadata'
+RAW_METADATA_DIR = 'raw_metadata'
+TRANSFORM_FN_DIR = 'transform_fn'
+
+# Individual transforms
+TARGET_TRANSFORM = 'target'
+IMAGE_URL_TO_VEC_TRANSFORM = 'img_url_to_vec'
+
+
+def parse_arguments(argv):
+  """Parse command line arguments.
+  Args:
+    argv: list of command line arguments including program name.
+  Returns:
+    The parsed arguments as returned by argparse.ArgumentParser.
+  """
+  parser = argparse.ArgumentParser(
+      description='Runs Preprocessing on the Criteo model data.')
+
+  parser.add_argument(
+      '--project-id',
+      help='The project to which the job will be submitted.')
+  parser.add_argument(
+      '--cloud',
+      action='store_true',
+      help='Run preprocessing on the cloud.')
+  parser.add_argument(
+      '--job-name',
+      type=str,
+      help='Unique job name if running on the cloud.')
+
+  parser.add_argument(
+      '--csv-file-pattern',
+      required=True,
+      help='CSV data to encode as tf.example.')
+  # If using bigquery table
+  parser.add_argument(
+      '--bigquery-table',
+      type=str,
+      required=False,
+      help=('Must be in the form `project.dataset.table_name`. BigQuery '
+            'data to encode as tf.example'))
+
+  parser.add_argument(
+      '--analyze-output-dir',
+      required=True,
+      help='The output folder of analyze')
+  parser.add_argument(
+      '--output-filename-prefix',
+      required=True,
+      type=str)
+  parser.add_argument(
+      '--output-dir',
+      default=None,
+      required=True,
+      help=('Google Cloud Storage or Local directory in which '
+            'to place outputs.'))
+
+  feature_parser = parser.add_mutually_exclusive_group(required=False)
+  feature_parser.add_argument('--target', dest='target', action='store_true')
+  feature_parser.add_argument('--no-target', dest='target', action='store_false')
+  parser.set_defaults(target=True)
+
+  parser.add_argument(
+      '--shuffle',
+      action='store_true',
+      default=False)
+
+  args, _ = parser.parse_known_args(args=argv[1:])
+
+  if args.cloud and not args.project_id:
+    raise ValueError('--project-id is needed for --cloud')
+
+  if not args.job_name:
+    args.job_name = ('dataflow-job-{}'.format(
+        datetime.datetime.now().strftime('%Y%m%d%H%M%S')))
+  return args
+
+
+@beam.ptransform_fn
+def shuffle(pcoll):  # pylint: disable=invalid-name
+  return (pcoll
+          | 'PairWithRandom' >> beam.Map(lambda x: (random.random(), x))
+          | 'GroupByRandom' >> beam.GroupByKey()
+          | 'DropRandom' >> beam.FlatMap(lambda (k, vs): vs))
+
+
+def prepare_image_transforms(element, features):
+  """Replace an images url with its jpeg bytes."""
+
+  from tensorflow.python.lib.io import file_io as tf_file_io
+
+  for name, transform in six.iteritems(features):
+    if transform['transform'] == IMAGE_URL_TO_VEC_TRANSFORM:
+      uri = element[name]
+      try:
+        with tf_file_io.FileIO(uri, 'r') as f:
+          img = Image.open(f).convert('RGB')
+      # A variety of different calling libraries throw different exceptions here.
+      # They all correspond to an unreadable file so we treat them equivalently.
+      # pylint: disable broad-except
+      except Exception as e:
+        logging.exception('Error processing image %s: %s', uri, str(e))
+        img_error_count.inc()
+        return
+
+      # Convert to desired format and output.
+      output = six.StringIO()
+      img.save(output, 'jpeg')
+      image_bytes = output.getvalue()
+
+      element[name] = image_bytes
+
+  return element
+
+
+def preprocess(pipeline, args):
+  input_metadata = metadata_io.read_metadata(
+      os.path.join(args.analyze_output_dir, RAW_METADATA_DIR))
+
+  schema = json.loads(file_io.read_file_to_string(
+      os.path.join(args.analyze_output_dir, SCHEMA_FILE)).decode())
+  features = json.loads(file_io.read_file_to_string(
+      os.path.join(args.analyze_output_dir, FEATURES_FILE)).decode())
+
+  column_names = [col['name'] for col in schema]
+
+  exclude_outputs = None
+  if not args.target:
+    for name, transform in six.iteritems(features):
+      if transform['transform'] == TARGET_TRANSFORM:
+        target_name = name
+        column_names.remove(target_name)
+        exclude_outputs = [target_name]
+        del input_metadata.schema.column_schemas[target_name]
+
+  if args.csv_file_pattern:
+    coder = coders.CsvCoder(column_names, input_metadata.schema, delimiter=',')
+    raw_data = (
+        pipeline
+        | 'ReadCsvData' >> beam.io.ReadFromText(args.csv_file_pattern)
+        | 'ParseCsvData' >> beam.Map(coder.decode))
+  else:
+    columns = ', '.join(column_names)
+    query = 'SELECT {columns} FROM `{table}`'.format(columns=columns,
+                                                     table=args.bigquery_table)
+    raw_data = (
+        pipeline
+        | 'ReadBiqQueryData'
+        >> beam.io.Read(beam.io.BigQuerySource(squery=query,
+                                               use_standard_sql=True)))
+
+  raw_data = (
+      raw_data
+      | 'PreprocessTransferredLearningTransformations'
+      >> beam.Map(prepare_image_transforms, features))
+
+  if args.shuffle:
+    raw_data = raw_data | 'ShuffleData' >> shuffle()
+
+  transform_fn = (
+      pipeline
+      | 'ReadTransformFn'
+      >> tft_beam_io.ReadTransformFn(args.analyze_output_dir))
+
+  (transformed_data, transform_metadata) = (
+      ((raw_data, input_metadata), transform_fn)
+      | 'ApplyTensorflowPreprocessingGraph' 
+      >> tft.TransformDataset(exclude_outputs))
+
+  tfexample_coder = coders.ExampleProtoCoder(transform_metadata.schema)
+  _ = (transformed_data
+       | 'SerializeExamples' >> beam.Map(tfexample_coder.encode)
+       | 'WriteExamples'
+       >> beam.io.WriteToTFRecord(
+           os.path.join(args.output_dir, args.output_filename_prefix),
+           file_name_suffix='.tfrecord.gz'))
+
+
+def main(argv=None):
+  """Run Preprocessing as a Dataflow."""
+  args = parse_arguments(sys.argv if argv is None else argv)
+  if args.cloud:
+    pipeline_name = 'DataflowRunner'
+    options = {
+        'job_name': args.job_name,
+        'temp_location':
+            os.path.join(args.output_dir, 'tmp'),
+        'project':
+            args.project_id,
+    }
+
+    pipeline_options = beam.pipeline.PipelineOptions(flags=[], **options)
+  else:
+    pipeline_name = 'DirectRunner'
+    pipeline_options = None
+
+  temp_dir = os.path.join(args.output_dir, 'tmp')
+  with beam.Pipeline(pipeline_name, options=pipeline_options) as p:
+    with tft.Context(temp_dir=temp_dir):
+      preprocess(
+          pipeline=p,
+          args=args)
+
+
+if __name__ == '__main__':
+  main()

--- a/solutionbox/code_free_ml/transform_raw_data.py
+++ b/solutionbox/code_free_ml/transform_raw_data.py
@@ -87,7 +87,7 @@ def parse_arguments(argv):
 
           Running this transformation step may not have an interesting training
           performance impact if the transforms are all simple like scaling
-          numerical values.""")
+          numerical values."""))
 
   parser.add_argument(
       '--project-id',


### PR DESCRIPTION
Beam script to read data from csv or bigquery, and apply the tft transformation graph. Output is always tf.example files.

Supports image columns. For images, the file is read and converted to web safe base64 string before passing it to tft.

Also includes local test file. The test file is not part of pydatalab's automatic test framework.