### PR TITLE
More _bigquery module unit tests

### DIFF
--- a/google/datalab/bigquery/commands/_bigquery.py
+++ b/google/datalab/bigquery/commands/_bigquery.py
@@ -626,19 +626,6 @@ def _execute_cell(args, cell_body):
   return r.result()
 
 
-def _get_schema(name):
-  """ Given a variable or table name, get the Schema if it exists. """
-  item = google.datalab.utils.commands.get_notebook_item(name)
-  if not item:
-    item = _get_table(name)
-
-  if isinstance(item, google.datalab.bigquery.Schema):
-    return item
-  if hasattr(item, 'schema') and isinstance(item.schema, google.datalab.bigquery._schema.Schema):
-    return item.schema
-  return None
-
-
 # An LRU cache for Tables. This is mostly useful so that when we cross page boundaries
 # when paging through a table we don't have to re-fetch the schema.
 _table_cache = google.datalab.utils.LRUCache(10)

--- a/tests/kernel/bigquery_tests.py
+++ b/tests/kernel/bigquery_tests.py
@@ -52,11 +52,13 @@ class TestCases(unittest.TestCase):
     mock_default_context.return_value = TestCases._create_context()
     mock_notebook_environment.return_value = env
 
-    with self.assertRaises(Exception):
+    # no cell body
+    with self.assertRaisesRegexp(Exception, 'UDF return type must be defined'):
       google.datalab.bigquery.commands._bigquery._udf_cell({'name': 'test_udf', 'language': 'js'},
                                                            '')
 
-    with self.assertRaises(Exception):
+    # no name
+    with self.assertRaisesRegexp(Exception, 'Declaration must be of the form %%bq udf --name'):
       google.datalab.bigquery.commands._bigquery._udf_cell({'name': None, 'language': 'js'},
                                                            'test_cell_body')
 
@@ -67,7 +69,7 @@ class TestCases(unittest.TestCase):
     re = new RegExp(word, 'g');
     return corpus.match(re || []).length;
     """
-    with self.assertRaises(Exception):
+    with self.assertRaisesRegexp(Exception, 'UDF return type must be defined'):
       google.datalab.bigquery.commands._bigquery._udf_cell({'name': 'count_occurrences',
                                                             'language': 'js'}, cell_body)
 
@@ -80,7 +82,7 @@ class TestCases(unittest.TestCase):
     re = new RegExp(word, 'g');
     return corpus.match(re || []).length;
     """
-    with self.assertRaises(Exception):
+    with self.assertRaisesRegexp(Exception, 'Found more than one return'):
       google.datalab.bigquery.commands._bigquery._udf_cell({'name': 'count_occurrences',
                                                             'language': 'js'}, cell_body)
 

--- a/tests/kernel/bigquery_tests.py
+++ b/tests/kernel/bigquery_tests.py
@@ -119,9 +119,10 @@ class TestCases(unittest.TestCase):
     self.assertEqual(env['test_ds']._source, ['test_path'])
     self.assertEqual(env['test_ds']._source_format, 'csv')
 
+  @mock.patch('google.datalab.bigquery.Query.execute')
   @mock.patch('google.datalab.utils.commands.notebook_environment')
   @mock.patch('google.datalab.Context.default')
-  def test_query_cell(self, mock_default_context, mock_notebook_environment):
+  def test_query_cell(self, mock_default_context, mock_notebook_environment, mock_query_execute):
     env = {}
     mock_default_context.return_value = TestCases._create_context()
     mock_notebook_environment.return_value = env
@@ -130,11 +131,11 @@ class TestCases(unittest.TestCase):
     # test query creation
     q1_body = 'SELECT * FROM test_table'
 
-    # no query specified
-    with self.assertRaises(Exception):
-      google.datalab.bigquery.commands._bigquery._query_cell({'name': None, 'udfs': None,
-                                                              'datasources': None,
-                                                              'subqueries': None}, q1_body)
+    # no query name specified. should execute
+    google.datalab.bigquery.commands._bigquery._query_cell({'name': None, 'udfs': None,
+                                                            'datasources': None,
+                                                            'subqueries': None}, q1_body)
+    mock_query_execute.assert_called_with()
 
     # test query creation
     google.datalab.bigquery.commands._bigquery._query_cell({'name': 'q1', 'udfs': None,

--- a/tests/kernel/bigquery_tests.py
+++ b/tests/kernel/bigquery_tests.py
@@ -53,7 +53,12 @@ class TestCases(unittest.TestCase):
     mock_notebook_environment.return_value = env
 
     with self.assertRaises(Exception):
-      google.datalab.bigquery.commands._bigquery._udf_cell({'name': None, 'language': 'js'}, '')
+      google.datalab.bigquery.commands._bigquery._udf_cell({'name': 'test_udf', 'language': 'js'},
+                                                           '')
+
+    with self.assertRaises(Exception):
+      google.datalab.bigquery.commands._bigquery._udf_cell({'name': None, 'language': 'js'},
+                                                           'test_cell_body')
 
     # no return type
     cell_body = """


### PR DESCRIPTION
Removed one unused method, and added unit tests for udf, datasource, query execute, and query dryrun cell magics.