### PR TITLE
UDF fixes, enable tests

### DIFF
--- a/google/datalab/bigquery/_udf.py
+++ b/google/datalab/bigquery/_udf.py
@@ -51,6 +51,9 @@ class UDF(object):
       raise TypeError('Argument params should be a dictionary of parameter names and types')
     if imports and not isinstance(imports, list):
       raise TypeError('Arguments imports should be a list of GCS string paths')
+    if imports and language != 'js':
+      raise Exception('Imports are available for Javascript UDFs only')
+
     self._name = name
     self._code = code
     self._return_type = return_type
@@ -89,9 +92,6 @@ class UDF(object):
       language: see list of supported languages in the BigQuery docs
       imports: a list of GCS paths containing further support code.
       """
-
-    if imports and language != 'js':
-      raise Exception('Imports are available for Javascript UDFs only')
 
     params = ','.join(['%s %s' % named_param for named_param in params.items()])
     imports = ','.join(['library="%s"' % i for i in imports])

--- a/google/datalab/bigquery/_udf.py
+++ b/google/datalab/bigquery/_udf.py
@@ -50,7 +50,7 @@ class UDF(object):
     if params and not isinstance(params, dict):
       raise TypeError('Argument params should be a dictionary of parameter names and types')
     if imports and not isinstance(imports, list):
-      raise TypeError('Arguments imports should be a list of GCS string paths')
+      raise TypeError('Argument imports should be a list of GCS string paths')
     if imports and language != 'js':
       raise Exception('Imports are available for Javascript UDFs only')
 

--- a/google/datalab/bigquery/commands/_bigquery.py
+++ b/google/datalab/bigquery/commands/_bigquery.py
@@ -530,8 +530,8 @@ def _udf_cell(args, cell_body):
   return_type = return_type[0]
 
   # Finally build the UDF object
-  udf = google.datalab.bigquery.UDF(udf_name, cell_body, return_type, params, args['language'],
-                                    imports)
+  udf = google.datalab.bigquery.UDF(udf_name, cell_body, return_type, dict(params),
+                                    args['language'], imports)
   google.datalab.utils.commands.notebook_environment()[udf_name] = udf
 
 

--- a/tests/bigquery/udf_tests.py
+++ b/tests/bigquery/udf_tests.py
@@ -39,6 +39,13 @@ OPTIONS (
 library="gcs://mylib"
 );\
 '''
+    self.assertEqual(udf.name, 'test_udf')
+    self.assertEqual(udf.code, code)
+    self.assertEqual(udf.imports, imports)
+
+    self.assertEqual(udf._language, language)
+    self.assertEqual(udf._repr_sql_(), udf._expanded_sql())
+    self.assertEqual(udf.__repr__(), 'BigQuery UDF - code:\n%s' % udf._code)
     self.assertEqual(udf._expanded_sql(), expected_sql)
 
     # bad return type
@@ -58,6 +65,12 @@ library="gcs://mylib"
     with self.assertRaises(TypeError):
       google.datalab.bigquery.UDF('test_udf', code, return_type, params, language, imports)
     imports = ['gcs://mylib']
+
+    # imports in non-javascript
+    language = 'sql'
+    with self.assertRaisesRegexp(Exception, 'Imports are available for Javascript'):
+      google.datalab.bigquery.UDF('test_udf', code, return_type, params, language, imports)
+    language = 'js'
 
   def test_query_with_udf(self):
     code = 'console.log("test");'

--- a/tests/kernel/bigquery_tests.py
+++ b/tests/kernel/bigquery_tests.py
@@ -103,6 +103,17 @@ class TestCases(unittest.TestCase):
     self.assertEquals({'word': 'STRING', 'corpus': 'STRING'}, udf._params)
     self.assertEquals([], udf._imports)
 
+    # param types with spaces (regression for pull request 373)
+    cell_body = """
+    // @param test_param ARRAY<STRUCT<index INT64, value STRING>>
+    // @returns INTEGER
+    """
+    google.datalab.bigquery.commands._bigquery._udf_cell({'name': 'count_occurrences',
+                                                          'language': 'js'}, cell_body)
+    udf = env['count_occurrences']
+    self.assertIsNotNone(udf)
+    self.assertEquals({'test_param': 'ARRAY<STRUCT<index INT64, value STRING>>'}, udf._params)
+
   @mock.patch('google.datalab.utils.commands.notebook_environment')
   def test_datasource_cell(self, mock_notebook_env):
     env = {}

--- a/tests/kernel/bigquery_tests.py
+++ b/tests/kernel/bigquery_tests.py
@@ -100,7 +100,7 @@ class TestCases(unittest.TestCase):
     self.assertEquals('count_occurrences', udf._name)
     self.assertEquals('js', udf._language)
     self.assertEquals('INTEGER', udf._return_type)
-    self.assertEquals([('word', 'STRING'), ('corpus', 'STRING')], udf._params)
+    self.assertEquals({'word': 'STRING', 'corpus': 'STRING'}, udf._params)
     self.assertEquals([], udf._imports)
 
   @mock.patch('google.datalab.utils.commands.notebook_environment')

--- a/tests/main.py
+++ b/tests/main.py
@@ -28,7 +28,7 @@ import bigquery.query_tests
 import bigquery.sampling_tests
 import bigquery.schema_tests
 import bigquery.table_tests
-# import bigquery.udf_tests
+import bigquery.udf_tests
 import bigquery.view_tests
 import kernel.bigquery_tests
 import kernel.chart_data_tests
@@ -67,7 +67,7 @@ _TEST_MODULES = [
     bigquery.sampling_tests,
     bigquery.schema_tests,
     bigquery.table_tests,
-    # bigquery.udf_tests, # TODO: enable UDF tests once new implementation is done
+    bigquery.udf_tests,
     bigquery.view_tests,
     bigquery.sampling_tests,
     kernel.bigquery_tests,


### PR DESCRIPTION
This PR fixes the following with UDFs:
- Correct defaults for optional parameters
- Fix building UDF sql out of parameter list
- Move check for imports with non-javascript to constructor

I also fixed and enabled UDF tests, and added a few missing tests. Among these I added a regression test for https://github.com/googledatalab/pydatalab/pull/373.