### PR TITLE
Do not wait for the killed process() in google.datalab.ml.Tensorboard.

### DIFF
--- a/google/datalab/ml/_tensorboard.py
+++ b/google/datalab/ml/_tensorboard.py
@@ -88,6 +88,5 @@ class TensorBoard(object):
       try:
         p = psutil.Process(pid)
         p.kill()
-        p.wait()
       except Exception:
         pass


### PR DESCRIPTION
I heard in some cases, Tensorboard.stop() hangs although I cannot reproduce the issue.