### PR TITLE
Mltoolbox

### DIFF
--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/data/analyze_data.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/data/analyze_data.py
@@ -17,10 +17,13 @@ from __future__ import division
 from __future__ import print_function
 
 import argparse
+import base64
 import collections
+import cStringIO
 import csv
 import json
 import os
+from PIL import Image
 import sys
 import pandas as pd
 import six
@@ -80,6 +83,10 @@ NUMERIC_SCHEMA = [INTEGER_SCHEMA, FLOAT_SCHEMA]
 # Inception Checkpoint
 INCEPTION_V3_CHECKPOINT = 'gs://cloud-ml-data/img/flower_photos/inception_v3_2016_08_28.ckpt'
 INCEPTION_EXCLUDED_VARIABLES = ['InceptionV3/AuxLogits', 'InceptionV3/Logits', 'global_step']
+
+_img_buf = cStringIO.StringIO()
+Image.new('RGB', (16, 16)).save(_img_buf, 'jpeg')
+IMAGE_DEFAULT_STRING = base64.urlsafe_b64encode(_img_buf.getvalue())
 
 
 def parse_arguments(argv):
@@ -379,7 +386,8 @@ def make_image_to_vec_tito(tmp_dir):
       width = 299
       channels = 3
 
-      image = tf.decode_base64(image_str_tensor)
+      image = tf.where(tf.equal(image_str_tensor, ''), IMAGE_DEFAULT_STRING, image_str_tensor)
+      image = tf.decode_base64(image)
       image = tf.image.decode_jpeg(image, channels=channels)
       image = tf.expand_dims(image, 0)
       image = tf.image.resize_bilinear(image, [height, width], align_corners=False)
@@ -550,7 +558,7 @@ def make_tft_input_schema(schema, stats_filepath):
   """
   result = {}
 
-  # stats file us used to get default values.
+  # stats file is used to get default values.
   stats = json.loads(file_io.read_file_to_string(stats_filepath).decode())
 
   for col_schema in schema:
@@ -777,6 +785,9 @@ def run_local_analysis(output_dir, csv_file_pattern, schema, features):
   for input_file in input_files:
     with file_io.FileIO(input_file, 'r') as f:
       for line in csv.reader(f):
+        if len(header) != len(line):
+          raise ValueError('Schema has %d columns but a csv line only has %d columns.' %
+                           (len(header), len(line)))
         parsed_line = dict(zip(header, line))
         num_examples += 1
 

--- a/solutionbox/code_free_ml/test_mltoolbox/test_training.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_training.py
@@ -136,6 +136,7 @@ class TestTrainer(unittest.TestCase):
         str_tfidf = ' '.join(str_tfidf)
         if with_image:
           img_url = random.choice(self._image_files)
+          _drop_out(img_url)
 
         num_id = _drop_out(num_id)
         num_scale = _drop_out(num_scale)
@@ -236,7 +237,7 @@ class TestTrainer(unittest.TestCase):
   def _run_transform(self):
     cmd = ['python %s' % os.path.join(CODE_PATH, 'transform_raw_data.py'),
            '--csv-file-pattern=' + self._csv_train_filename,
-           '--analyze-output-dir=' + self._analysis_output,
+           '--analysis-output-dir=' + self._analysis_output,
            '--output-filename-prefix=features_train',
            '--output-dir=' + self._transform_output,
            '--target',
@@ -247,7 +248,7 @@ class TestTrainer(unittest.TestCase):
 
     cmd = ['python %s' % os.path.join(CODE_PATH, 'transform_raw_data.py'),
            '--csv-file-pattern=' + self._csv_eval_filename,
-           '--analyze-output-dir=' + self._analysis_output,
+           '--analysis-output-dir=' + self._analysis_output,
            '--output-filename-prefix=features_eval',
            '--output-dir=' + self._transform_output,
            '--target']

--- a/solutionbox/code_free_ml/test_mltoolbox/test_training.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_training.py
@@ -341,6 +341,7 @@ class TestTrainer(unittest.TestCase):
           for image_file in [self._image_files[0], self._image_files[2]]:
             with file_io.FileIO(image_file, 'r') as ff:
               image_bytes.append(base64.urlsafe_b64encode(ff.read()))
+
           prediction_data.update({'image': image_bytes})
 
         # Convert the prediciton data to csv.

--- a/solutionbox/code_free_ml/test_mltoolbox/test_transform_raw_data.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_transform_raw_data.py
@@ -88,7 +88,7 @@ class TestTransformRawData(unittest.TestCase):
 
     cmd = ['python ' + os.path.join(CODE_PATH, 'transform_raw_data.py'),
            '--csv-file-pattern=' + self.csv_input_filepath,
-           '--analyze-output-dir=' + self.analysis_dir,
+           '--analysis-output-dir=' + self.analysis_dir,
            '--output-filename-prefix=features',
            '--output-dir=' + self.output_dir]
     subprocess.check_call(' '.join(cmd), shell=True)
@@ -145,7 +145,7 @@ class TestTransformRawData(unittest.TestCase):
 
     cmd = ['python ' + os.path.join(CODE_PATH, 'transform_raw_data.py'),
            '--bigquery-table=%s.%s.%s' % (project_id, dataset_name, table_name),
-           '--analyze-output-dir=' + self.analysis_dir,
+           '--analysis-output-dir=' + self.analysis_dir,
            '--output-filename-prefix=features',
            '--project-id=' + project_id,
            '--output-dir=' + self.output_dir]


### PR DESCRIPTION
Allow missing values for image columns. Change 'analyzer-output-dir' to 'analysis-output-dir' in transform script to make it consistent with trainer script.