### PR TITLE
Fix UDF parameter order

### DIFF
--- a/google/datalab/bigquery/_udf.py
+++ b/google/datalab/bigquery/_udf.py
@@ -41,14 +41,14 @@ class UDF(object):
       code: function body implementing the logic.
       return_type: BigQuery data type of the function return. See supported data types in
         the BigQuery docs
-      params: dictionary of parameter names and types
+      params: list of parameter tuples: (name, type)
       language: see list of supported languages in the BigQuery docs
       imports: a list of GCS paths containing further support code.
       """
     if not isinstance(return_type, basestring):
       raise TypeError('Argument return_type should be a string. Instead got: ', type(return_type))
-    if params and not isinstance(params, dict):
-      raise TypeError('Argument params should be a dictionary of parameter names and types')
+    if params and not isinstance(params, list):
+      raise TypeError('Argument params should be a list of parameter names and types')
     if imports and not isinstance(imports, list):
       raise TypeError('Argument imports should be a list of GCS string paths')
     if imports and language != 'js':
@@ -57,7 +57,7 @@ class UDF(object):
     self._name = name
     self._code = code
     self._return_type = return_type
-    self._params = params or {}
+    self._params = params or []
     self._language = language
     self._imports = imports or []
     self._sql = None
@@ -93,7 +93,7 @@ class UDF(object):
       imports: a list of GCS paths containing further support code.
       """
 
-    params = ','.join(['%s %s' % named_param for named_param in params.items()])
+    params = ','.join(['%s %s' % named_param for named_param in params])
     imports = ','.join(['library="%s"' % i for i in imports])
 
     udf = 'CREATE TEMPORARY FUNCTION {name} ({params})\n' +\

--- a/google/datalab/bigquery/commands/_bigquery.py
+++ b/google/datalab/bigquery/commands/_bigquery.py
@@ -530,7 +530,7 @@ def _udf_cell(args, cell_body):
   return_type = return_type[0]
 
   # Finally build the UDF object
-  udf = google.datalab.bigquery.UDF(udf_name, cell_body, return_type, dict(params),
+  udf = google.datalab.bigquery.UDF(udf_name, cell_body, return_type, params,
                                     args['language'], imports)
   google.datalab.utils.commands.notebook_environment()[udf_name] = udf
 

--- a/tests/bigquery/udf_tests.py
+++ b/tests/bigquery/udf_tests.py
@@ -23,7 +23,7 @@ class TestCases(unittest.TestCase):
   def _create_udf(self, name='test_udf', code='console.log("test");', return_type='integer',
                   params=None, language='js', imports=None):
     if params is None:
-      params = {'test_param': 'integer'}
+      params = [('test_param', 'integer')]
     if code is None:
       code = 'test code;'
     if imports is None:
@@ -60,8 +60,12 @@ library="gcs://test_lib"
       self._create_udf(return_type=['integer'])
 
   def test_udf_bad_params(self):
-    with self.assertRaisesRegexp(TypeError, 'Argument params should be a dictionary'):
-      self._create_udf(params=['param1', 'param2'])
+    with self.assertRaisesRegexp(TypeError, 'Argument params should be a list'):
+      self._create_udf(params={'param1': 'param2'})
+
+  def test_udf_params_order(self):
+    udf = self._create_udf(params=[('param1', 'int'), ('param2', 'string'), ('param3', 'array')])
+    self.assertIn('param1 int,param2 string,param3 array', udf._expanded_sql())
 
   def test_udf_bad_imports(self):
     with self.assertRaisesRegexp(TypeError, 'Argument imports should be a list'):
@@ -74,7 +78,7 @@ library="gcs://test_lib"
   def test_query_with_udf(self):
     code = 'console.log("test");'
     return_type = 'integer'
-    params = {'test_param': 'integer'}
+    params = [('test_param', 'integer')]
     language = 'js'
     imports = ''
     udf = google.datalab.bigquery.UDF('test_udf', code, return_type, params, language, imports)

--- a/tests/kernel/bigquery_tests.py
+++ b/tests/kernel/bigquery_tests.py
@@ -101,7 +101,7 @@ class TestCases(unittest.TestCase):
     self.assertEquals('count_occurrences', udf._name)
     self.assertEquals('js', udf._language)
     self.assertEquals('INTEGER', udf._return_type)
-    self.assertEquals({'word': 'STRING', 'corpus': 'STRING'}, udf._params)
+    self.assertEquals([('word', 'STRING'), ('corpus', 'STRING')], udf._params)
     self.assertEquals([], udf._imports)
 
     # param types with spaces (regression for pull request 373)
@@ -113,7 +113,7 @@ class TestCases(unittest.TestCase):
                                                           'language': 'js'}, cell_body)
     udf = env['count_occurrences']
     self.assertIsNotNone(udf)
-    self.assertEquals({'test_param': 'ARRAY<STRUCT<index INT64, value STRING>>'}, udf._params)
+    self.assertEquals([('test_param', 'ARRAY<STRUCT<index INT64, value STRING>>')], udf._params)
 
   @mock.patch('google.datalab.utils.commands.notebook_environment')
   def test_datasource_cell(self, mock_notebook_env):


### PR DESCRIPTION
This PR fixes UDFs to take an array of tuples for parameters instead of a dictionary, which did not preserve order.
Fixes #395.