### PR TITLE
small fixes

### DIFF
--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/data/trainer/feature_transforms.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/data/trainer/feature_transforms.py
@@ -472,10 +472,10 @@ def csv_header_and_defaults(features, schema, stats, keep_target):
     # Note that numerical key columns do not have a stats entry, hence the use
     # of get(col['name'], {})
     csv_header.append(col['name'])
-    if col['type'].lower() == 'integer':
+    if col['type'].lower() == INTEGER_SCHEMA:
       dtype = tf.int64
       default = int(stats['column_stats'].get(col['name'], {}).get('mean', 0))
-    elif col['type'].lower() == 'float':
+    elif col['type'].lower() == FLOAT_SCHEMA:
       dtype = tf.float32
       default = float(stats['column_stats'].get(col['name'], {}).get('mean', 0.0))
     else:

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/data/trainer/feature_transforms.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/data/trainer/feature_transforms.py
@@ -20,15 +20,9 @@ from tensorflow.contrib.slim.python.slim.nets.inception_v3 import inception_v3
 from tensorflow.contrib.slim.python.slim.nets.inception_v3 import inception_v3_arg_scope
 from tensorflow.python.lib.io import file_io
 
-# Files
-SCHEMA_FILE = 'schema.json'
-FEATURES_FILE = 'features.json'
-STATS_FILE = 'stats.json'
-VOCAB_ANALYSIS_FILE = 'vocab_%s.csv'
-
-TRANSFORMED_METADATA_DIR = 'transformed_metadata'
-RAW_METADATA_DIR = 'raw_metadata'
-TRANSFORM_FN_DIR = 'transform_fn'
+# ------------------------------------------------------------------------------
+# public constants. Changing these could break user's code
+# ------------------------------------------------------------------------------
 
 # Individual transforms
 IDENTITY_TRANSFORM = 'identity'
@@ -41,6 +35,16 @@ KEY_TRANSFORM = 'key'
 TARGET_TRANSFORM = 'target'
 IMAGE_TRANSFORM = 'image_to_vec'
 
+# ------------------------------------------------------------------------------
+# internal constants.
+# ------------------------------------------------------------------------------
+
+# Files
+SCHEMA_FILE = 'schema.json'
+FEATURES_FILE = 'features.json'
+STATS_FILE = 'stats.json'
+VOCAB_ANALYSIS_FILE = 'vocab_%s.csv'
+
 # Transform collections
 NUMERIC_TRANSFORMS = [IDENTITY_TRANSFORM, SCALE_TRANSFORM]
 CATEGORICAL_TRANSFORMS = [ONE_HOT_TRANSFORM, EMBEDDING_TRANSFROM]
@@ -50,7 +54,7 @@ TEXT_TRANSFORMS = [BOW_TRANSFORM, TFIDF_TRANSFORM]
 DEFAULT_NUMERIC_TRANSFORM = IDENTITY_TRANSFORM
 DEFAULT_CATEGORICAL_TRANSFORM = ONE_HOT_TRANSFORM
 
-# Schema values
+# BigQuery Schema values supported
 INTEGER_SCHEMA = 'integer'
 FLOAT_SCHEMA = 'float'
 STRING_SCHEMA = 'string'

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/data/trainer/task.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/data/trainer/task.py
@@ -22,7 +22,6 @@ import multiprocessing
 import os
 import re
 import sys
-import pandas as pd
 import six
 import tensorflow as tf
 

--- a/solutionbox/code_free_ml/test_mltoolbox/test_analyze_data.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_analyze_data.py
@@ -118,7 +118,7 @@ class TestLocalAnalyze(unittest.TestCase):
          'col2': {'transform': 'identity'}})
       stats = json.loads(
           file_io.read_file_to_string(
-              os.path.join(output_folder, analyze_data.STATS_FILE)).decode())
+              os.path.join(output_folder, analyze_data.constant.STATS_FILE)).decode())
 
       self.assertEqual(stats['num_examples'], 100)
       col = stats['column_stats']['col1']
@@ -153,13 +153,13 @@ class TestLocalAnalyze(unittest.TestCase):
 
       stats = json.loads(
           file_io.read_file_to_string(
-              os.path.join(output_folder, analyze_data.STATS_FILE)).decode())
+              os.path.join(output_folder, analyze_data.constant.STATS_FILE)).decode())
       self.assertEqual(stats['column_stats']['color']['vocab_size'], 3)
       self.assertEqual(stats['column_stats']['transport']['vocab_size'], 6)
 
       # Color column.
       vocab_str = file_io.read_file_to_string(
-        os.path.join(output_folder, analyze_data.VOCAB_ANALYSIS_FILE % 'color'))
+        os.path.join(output_folder, analyze_data.constant.VOCAB_ANALYSIS_FILE % 'color'))
       vocab = pd.read_csv(six.StringIO(vocab_str),
                           header=None,
                           names=['color', 'count'])
@@ -172,7 +172,7 @@ class TestLocalAnalyze(unittest.TestCase):
       # not known.
       vocab_str = file_io.read_file_to_string(
           os.path.join(output_folder,
-                       analyze_data.VOCAB_ANALYSIS_FILE % 'transport'))
+                       analyze_data.constant.VOCAB_ANALYSIS_FILE % 'transport'))
       vocab = pd.read_csv(six.StringIO(vocab_str),
                           header=None,
                           names=['transport', 'count'])
@@ -201,13 +201,13 @@ class TestLocalAnalyze(unittest.TestCase):
 
       stats = json.loads(
           file_io.read_file_to_string(
-              os.path.join(output_folder, analyze_data.STATS_FILE)).decode())
+              os.path.join(output_folder, analyze_data.constant.STATS_FILE)).decode())
       self.assertEqual(stats['column_stats']['col1']['vocab_size'], 5)
       self.assertEqual(stats['column_stats']['col2']['vocab_size'], 4)
 
       vocab_str = file_io.read_file_to_string(
           os.path.join(output_folder,
-                       analyze_data.VOCAB_ANALYSIS_FILE % 'col1'))
+                       analyze_data.constant.VOCAB_ANALYSIS_FILE % 'col1'))
       vocab = pd.read_csv(six.StringIO(vocab_str),
                           header=None,
                           names=['col1', 'count'])
@@ -217,7 +217,7 @@ class TestLocalAnalyze(unittest.TestCase):
 
       vocab_str = file_io.read_file_to_string(
           os.path.join(output_folder,
-                       analyze_data.VOCAB_ANALYSIS_FILE % 'col2'))
+                       analyze_data.constant.VOCAB_ANALYSIS_FILE % 'col2'))
       vocab = pd.read_csv(six.StringIO(vocab_str),
                           header=None,
                           names=['col2', 'count'])
@@ -267,7 +267,7 @@ class TestCloudAnalyzeFromBQTable(unittest.TestCase):
 
       stats = json.loads(
           file_io.read_file_to_string(
-              os.path.join(output_folder, analyze_data.STATS_FILE)).decode())
+              os.path.join(output_folder, analyze_data.constant.STATS_FILE)).decode())
 
       self.assertEqual(stats['num_examples'], 100)
       col = stats['column_stats']['col1']
@@ -316,7 +316,7 @@ class TestCloudAnalyzeFromCSVFiles(unittest.TestCase):
                   'col2': {'transform': 'identity'}})
     stats = json.loads(
         file_io.read_file_to_string(
-            os.path.join(output_folder, analyze_data.STATS_FILE)).decode())
+            os.path.join(output_folder, analyze_data.constant.STATS_FILE)).decode())
 
     self.assertEqual(stats['num_examples'], 100)
     col = stats['column_stats']['col1']
@@ -352,13 +352,13 @@ class TestCloudAnalyzeFromCSVFiles(unittest.TestCase):
 
     stats = json.loads(
         file_io.read_file_to_string(
-            os.path.join(output_folder, analyze_data.STATS_FILE)).decode())
+            os.path.join(output_folder, analyze_data.constant.STATS_FILE)).decode())
     self.assertEqual(stats['column_stats']['color']['vocab_size'], 3)
     self.assertEqual(stats['column_stats']['transport']['vocab_size'], 6)
 
     # Color column.
     vocab_str = file_io.read_file_to_string(
-      os.path.join(output_folder, analyze_data.VOCAB_ANALYSIS_FILE % 'color'))
+      os.path.join(output_folder, analyze_data.constant.VOCAB_ANALYSIS_FILE % 'color'))
     vocab = pd.read_csv(six.StringIO(vocab_str),
                         header=None,
                         names=['color', 'count'])
@@ -370,7 +370,7 @@ class TestCloudAnalyzeFromCSVFiles(unittest.TestCase):
     # transport column.
     vocab_str = file_io.read_file_to_string(
         os.path.join(output_folder,
-                     analyze_data.VOCAB_ANALYSIS_FILE % 'transport'))
+                     analyze_data.constant.VOCAB_ANALYSIS_FILE % 'transport'))
     vocab = pd.read_csv(six.StringIO(vocab_str),
                         header=None,
                         names=['transport', 'count'])
@@ -401,13 +401,13 @@ class TestCloudAnalyzeFromCSVFiles(unittest.TestCase):
 
     stats = json.loads(
         file_io.read_file_to_string(
-            os.path.join(output_folder, analyze_data.STATS_FILE)).decode())
+            os.path.join(output_folder, analyze_data.constant.STATS_FILE)).decode())
     self.assertEqual(stats['column_stats']['col1']['vocab_size'], 5)
     self.assertEqual(stats['column_stats']['col2']['vocab_size'], 4)
 
     vocab_str = file_io.read_file_to_string(
         os.path.join(output_folder,
-                     analyze_data.VOCAB_ANALYSIS_FILE % 'col1'))
+                     analyze_data.constant.VOCAB_ANALYSIS_FILE % 'col1'))
     vocab = pd.read_csv(six.StringIO(vocab_str),
                         header=None,
                         names=['col1', 'count'])
@@ -417,7 +417,7 @@ class TestCloudAnalyzeFromCSVFiles(unittest.TestCase):
 
     vocab_str = file_io.read_file_to_string(
         os.path.join(output_folder,
-                     analyze_data.VOCAB_ANALYSIS_FILE % 'col2'))
+                     analyze_data.constant.VOCAB_ANALYSIS_FILE % 'col2'))
     vocab = pd.read_csv(six.StringIO(vocab_str),
                         header=None,
                         names=['col2', 'count'])

--- a/solutionbox/code_free_ml/test_mltoolbox/test_feature_transforms.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_feature_transforms.py
@@ -34,10 +34,6 @@ class TestGraphBuilding(unittest.TestCase):
           folders raw_metadata and transform_fn.
       predict_data: list of csv strings
     """
-    # Cannot call
-    # bundle_shim.load_session_bundle_or_saved_model_bundle_from_path directly
-    # as tft changes the in/output tensor names.
-
     with tf.Graph().as_default():
       with tf.Session().as_default() as session:
         outputs, labels, inputs = feature_transforms.build_csv_serving_tensors(

--- a/solutionbox/code_free_ml/test_mltoolbox/test_training.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_training.py
@@ -56,6 +56,7 @@ class TestOptionalKeys(unittest.TestCase):
              '--train-batch-size=4',
              '--eval-batch-size=4',
              '--max-steps=2000',
+             '--learning-rate=0.1',
              '--run-transforms']
 
       subprocess.check_call(' '.join(cmd), shell=True)
@@ -77,6 +78,7 @@ class TestOptionalKeys(unittest.TestCase):
         _, csv_tensor_name = input_alias_map.items()[0]
         result = sess.run(fetches=output_alias_map,
                           feed_dict={csv_tensor_name: ['20']})
+        print('result', result)
         self.assertTrue(abs(40 - result['predicted']) < 5)
     finally:
       shutil.rmtree(output_dir)


### PR DESCRIPTION
* move all constants to the feature_transforms file
* exported graph in /model has a schema file with target column removed
* numerical defaults use the stats file
* linear models now use an optimizer that has L1/L2 terms. I did not use the SDCA optimizer because
  1. I think it is only for (binary) classification problems
  1. requires the target column to be a string, not an int
  1. is in tf.contrib, so one less thing that will break in the future
* For linear models, I use the tf.train.FtrlOptimizer optimizer, which is tf's default.

