### PR TITLE
Run and export test coverage numbers to coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+# .coveragerc to control coverage.py
+[run]
+
+[report]
+include = */site-packages/google/datalab/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
     env: TOX_ENV=py35
   - python: 2.7
     env: TOX_ENV=flake8
+  - python: 2.7
+    env: TOX_ENV=coveralls
 
 before_install:
   - npm install -g typescript
@@ -20,5 +22,4 @@ before_install:
 script:
   # tox reads its configuration from tox.ini.
   - tox -e $TOX_ENV
-
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # By default, we want to run tests for Python 2.7, Python 3.5, and run our
 # flake8 checks.
-envlist = py27,py35,flake8
+envlist = py27,py35,flake8,coveralls
 # If an interpreter is missing locally, skip it.
 skip_missing_interpreters = true
 
@@ -29,3 +29,12 @@ deps = {[testenv]deps}
 [testenv:flake8]
 commands = flake8 --exclude=.tox,.git,./*.egg,build,.cache,env,__pycache__,docs
 deps = flake8
+
+[testenv:coveralls]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+deps = {[testenv]deps}
+       google-cloud-dataflow==0.5.5
+       coveralls 
+commands =
+  coverage run tests/main.py
+  coveralls --rcfile=.coveragerc

--- a/tox.ini
+++ b/tox.ini
@@ -37,4 +37,4 @@ deps = {[testenv]deps}
        coveralls 
 commands =
   coverage run tests/main.py
-  coveralls --rcfile=.coveragerc
+  - coveralls --rcfile=.coveragerc


### PR DESCRIPTION
The export is working fine, and the numbers show up on coveralls.io, but clicking a file to see its coverage details isn't working, giving the following error:

> **SOURCE NOT AVAILABLE**
> The file ".tox/coveralls/lib/python2.7/site-packages/google/datalab/ml/_summary.py" isn't available on github. Either it's been removed, or the repo root directory needs to be updated.
> 

It looks like it can't resolve the file path from inside the tox environment scope, but I'm not sure how to fix this. So for now, we can just run coverage locally to see the details.