### PR TITLE
allow one source column to be used in many feature columns

### DIFF
--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/analyze.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/analyze.py
@@ -420,26 +420,27 @@ def check_schema_transforms_match(schema, inverted_features):
     col_type = col_schema['type'].lower()
 
     # Check each transform and schema are compatible
-    for transform_name in inverted_features[col_name]:
-      if transform_name == constant.TARGET_TRANSFORM:
-        num_target_transforms += 1
-        continue
+    if col_name in inverted_features:
+      for transform_name in inverted_features[col_name]:
+        if transform_name == constant.TARGET_TRANSFORM:
+          num_target_transforms += 1
+          continue
 
-      elif col_type in constant.NUMERIC_SCHEMA:
-        if transform_name not in constant.NUMERIC_TRANSFORMS:
-          raise ValueError(
-              'Transform %s not supported by schema %s' % (transform_name, col_type))
-      elif col_type == constant.STRING_SCHEMA:
-        if (transform_name not in constant.CATEGORICAL_TRANSFORMS + constant.TEXT_TRANSFORMS and
-           transform_name != constant.IMAGE_TRANSFORM):
-          raise ValueError(
-              'Transform %s not supported by schema %s' % (transform_name, col_type))
-      else:
-        raise ValueError('Unsupported schema type %s' % col_type)
+        elif col_type in constant.NUMERIC_SCHEMA:
+          if transform_name not in constant.NUMERIC_TRANSFORMS:
+            raise ValueError(
+                'Transform %s not supported by schema %s' % (transform_name, col_type))
+        elif col_type == constant.STRING_SCHEMA:
+          if (transform_name not in constant.CATEGORICAL_TRANSFORMS + constant.TEXT_TRANSFORMS and
+             transform_name != constant.IMAGE_TRANSFORM):
+            raise ValueError(
+                'Transform %s not supported by schema %s' % (transform_name, col_type))
+        else:
+          raise ValueError('Unsupported schema type %s' % col_type)
 
     # Check each transform is compatible for the same source column.
     # inverted_features[col_name] should belong to exactly 1 of the 5 groups.
-    if 1 != (
+    if col_name in inverted_features and 1 != (
       sum([inverted_features[col_name].issubset(set(constant.NUMERIC_TRANSFORMS)),
            inverted_features[col_name].issubset(set(constant.CATEGORICAL_TRANSFORMS)),
            inverted_features[col_name].issubset(set(constant.TEXT_TRANSFORMS)),
@@ -532,7 +533,7 @@ def expand_defaults(schema, features):
 def invert_features(features):
   """Make a dict in the form source column : set of transforms.
 
-  Note that key transforms are removed from the set.
+  Note that the key transform is removed.
   """
   inverted_features = collections.defaultdict(set)
   for transform in six.itervalues(features):
@@ -542,7 +543,7 @@ def invert_features(features):
       continue
     inverted_features[source_column].add(transform_name)
 
-  return inverted_features
+  return dict(inverted_features)  # convert from defaultdict to dict
 
 
 def main(argv=None):

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/analyze.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/analyze.py
@@ -157,6 +157,7 @@ def parse_arguments(argv):
 
   return args
 
+
 def make_analysis_plan(schema, features):
   """Records what analysis sets needs to be performed on which input columns.
 
@@ -166,11 +167,12 @@ def make_analysis_plan(schema, features):
 
   Return:
     A dict in the form {schema_name: analysis_type}, where schema_name is an
-    input column name, and analysis_type is one of "numeric", "vocab", 
+    input column name, and analysis_type is one of "numeric", "vocab",
     "split_vocab", "image", or "key"
   """
 
   analysis_plan = {}
+
   def _insert_plan(analysis_plan, column_name, plan):
     if column_name in analysis_plan:
       if plan == 'key':
@@ -225,7 +227,6 @@ def make_analysis_plan(schema, features):
 
   return analysis_plan
 
-  
 
 def run_cloud_analysis(output_dir, csv_file_pattern, bigquery_table, schema,
                        features):
@@ -502,7 +503,7 @@ def expand_defaults(schema, features):
 
   schema_names = [x['name'] for x in schema]
 
-  # Add missing source columns 
+  # Add missing source columns
   for name, transform in six.iteritems(features):
     if 'source_column' not in transform:
       transform['source_column'] = name
@@ -512,7 +513,7 @@ def expand_defaults(schema, features):
   for name, transform in six.iteritems(features):
     if transform['source_column'] not in schema_names:
       raise ValueError('source column %s is not in the schema for transform %s'
-         % (transform['source_column'], name))
+                       % (transform['source_column'], name))
     used_schema_columns.append(transform['source_column'])
 
   # Update default transformation based on schema.

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/analyze.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/analyze.py
@@ -198,7 +198,6 @@ def make_analysis_plan(schema, features):
     else:
       analysis_plan[column_name] = plan
 
-
   for name, transform in six.iteritems(features):
     source_column = transform['source_column']
     transform_name = transform['transform']

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/analyze.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/analyze.py
@@ -79,12 +79,17 @@ def parse_arguments(argv):
                 "column_name_1": {"transform": "scale"},
                 "column_name_3": {"transform": "target"},
                 "column_name_2": {"transform": "one_hot"},
-                "column_name_4": {"transform": "key"},
+                "new_feature_name": {"transform": "key", "source_column": "column_name_4"},
              }
 
              The format of the dict is `name`: `transform-dict` where the
-             `name` must be a column name from the schema file. A list of
-             supported `transform-dict`s is below:
+             `name` is the name of the transformed feature. The `source_column`
+             value lists what column in the input data is the source for this
+             transformation. If `source_column` is missing, it is assumed the
+             `name` is a source column and the transformed feature will have
+             the same name as the input column.
+
+             A list of supported `transform-dict`s is below:
 
              {"transform": "identity"}: does nothing (for numerical columns).
              {"transform": "scale", "value": x}: scale a numerical column to

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
@@ -196,13 +196,14 @@ def build_feature_columns(features, stats, model_type):
   # we are using tf.layers.
   for name, transform in six.iteritems(features):
     transform_name = transform['transform']
+    source_column = transform['source_column']
 
     if transform_name in feature_transforms.NUMERIC_TRANSFORMS:
       new_feature = tf.contrib.layers.real_valued_column(name, dimension=1)
     elif transform_name == feature_transforms.ONE_HOT_TRANSFORM:
       sparse = tf.contrib.layers.sparse_column_with_integerized_feature(
           name,
-          bucket_size=stats['column_stats'][name]['vocab_size'])
+          bucket_size=stats['column_stats'][source_column]['vocab_size'])
       if is_dnn:
         new_feature = tf.contrib.layers.one_hot_column(sparse)
       else:
@@ -211,7 +212,7 @@ def build_feature_columns(features, stats, model_type):
       if is_dnn:
         sparse = tf.contrib.layers.sparse_column_with_integerized_feature(
             name,
-            bucket_size=stats['column_stats'][name]['vocab_size'])
+            bucket_size=stats['column_stats'][source_column]['vocab_size'])
         new_feature = tf.contrib.layers.embedding_column(
             sparse,
             dimension=transform['embedding_dim'])
@@ -223,7 +224,7 @@ def build_feature_columns(features, stats, model_type):
     elif transform_name in feature_transforms.TEXT_TRANSFORMS:
       sparse_ids = tf.contrib.layers.sparse_column_with_integerized_feature(
           name + '_ids',
-          bucket_size=stats['column_stats'][name]['vocab_size'],
+          bucket_size=stats['column_stats'][source_column]['vocab_size'],
           combiner='sum')
       sparse_weights = tf.contrib.layers.weighted_sparse_column(
           sparse_id_column=sparse_ids,
@@ -232,7 +233,7 @@ def build_feature_columns(features, stats, model_type):
       if is_dnn:
         # TODO(brandondutra): Figure out why one_hot_column does not work.
         # Use new_feature = tf.contrib.layers.one_hot_column(sparse_weights)
-        dimension = int(math.log(stats['column_stats'][name]['vocab_size'])) + 1
+        dimension = int(math.log(stats['column_stats'][source_column]['vocab_size'])) + 1
         new_feature = tf.contrib.layers.embedding_column(
             sparse_weights,
             dimension=dimension,

--- a/solutionbox/code_free_ml/test_mltoolbox/test_analyze.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_analyze.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import copy
 import json
 import os
 import shutil
@@ -448,6 +447,7 @@ class TestCloudAnalyzeFromCSVFiles(unittest.TestCase):
     self.assertEqual(vocab['col2'].tolist(), ['in', 'raining', 'kir', 'pdx'])
     self.assertEqual(vocab['count'].tolist(), [2, 2, 1, 1])
 
+
 class TestOneSourceColumnManyFeatures(unittest.TestCase):
   """Test input column can be used more than once."""
 
@@ -457,12 +457,11 @@ class TestOneSourceColumnManyFeatures(unittest.TestCase):
 
       target,number,category,text,image
       """
-      return "%d,%d,%s,%s,%s" % (i*2,
-                                 i, 
+      return "%d,%d,%s,%s,%s" % (i * 2,
+                                 i,
                                  'red' if i % 2 else 'blue',
                                  'hello world' if i % 2 else 'bye moon',
                                  '/image%d.jpeg' % i)
-
 
     output_folder = tempfile.mkdtemp()
     try:
@@ -505,8 +504,8 @@ class TestOneSourceColumnManyFeatures(unittest.TestCase):
       self.assertTrue(os.path.isfile(os.path.join(output_folder, 'vocab_text.csv')))
 
       stats = json.loads(
-           file_io.read_file_to_string(
-               os.path.join(output_folder, analyze.constant.STATS_FILE)).decode())
+          file_io.read_file_to_string(
+              os.path.join(output_folder, analyze.constant.STATS_FILE)).decode())
 
       self.assertEqual(stats['num_examples'], 100)
       col = stats['column_stats']['int']
@@ -522,7 +521,7 @@ class TestOneSourceColumnManyFeatures(unittest.TestCase):
       col = stats['column_stats']['cat']
       self.assertEqual(col['vocab_size'], 2)
     finally:
-      shutil.rmtree(output_folder)    
+      shutil.rmtree(output_folder)
 
 
 if __name__ == '__main__':

--- a/solutionbox/code_free_ml/test_mltoolbox/test_analyze.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_analyze.py
@@ -100,6 +100,28 @@ class TestConfigFiles(unittest.TestCase):
          [{'name': 'col1', 'type': 'INTEGER'}],
          {'col1': {'transform': 'xxx', 'source_column': 'col1'}})
 
+  def test_analysis_plan(self):
+    with self.assertRaises(ValueError):
+      # scale and one_hot different transform family
+      analyze.make_analysis_plan(
+         [{'name': 'col1', 'type': 'INTEGER'}],
+         {'col1': {'transform': 'scale', 'source_column': 'col1'},
+          'col2': {'transform': 'one_hot', 'source_column': 'col1'},
+          'col3': {'transform': 'key', 'source_column': 'col1'}})
+
+    with self.assertRaises(ValueError):
+      # Unknown target schema
+      analyze.make_analysis_plan(
+         [{'name': 'col1', 'type': 'x'}],
+         {'col1': {'transform': 'target', 'source_column': 'col1'}})
+
+    with self.assertRaises(ValueError):
+      # Unknown transform
+      analyze.make_analysis_plan(
+         [{'name': 'col1', 'type': 'INTEGER'}],
+         {'col1': {'transform': 'x', 'source_column': 'col1'}})
+
+
 class TestLocalAnalyze(unittest.TestCase):
   """Test local analyze functions."""
 
@@ -430,7 +452,6 @@ class TestOneSourceColumnManyFeatures(unittest.TestCase):
   """Test input column can be used more than once."""
 
   def test_multiple_usage(self):
-
     def _make_csv_row(i):
       """Makes a csv file with the following header.
 

--- a/solutionbox/code_free_ml/test_mltoolbox/test_feature_transforms.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_feature_transforms.py
@@ -59,9 +59,9 @@ class TestGraphBuilding(unittest.TestCase):
       schema = [{'name': 'num1', 'type': 'FLOAT'},
                 {'name': 'num2', 'type': 'FLOAT'},
                 {'name': 'num3', 'type': 'INTEGER'}]
-      features = {'num1': {'transform': 'identity'},
-                  'num2': {'transform': 'scale', 'value': 10},
-                  'num3': {'transform': 'scale'}}
+      features = {'num1': {'transform': 'identity', 'source_column': 'num1'},
+                  'num2': {'transform': 'scale', 'value': 10, 'source_column': 'num2'},
+                  'num3': {'transform': 'scale', 'source_column': 'num3'}}
       input_data = ['5.0,-1.0,10',
                     '10.0,1.0,5',
                     '15.0,0.5,7']
@@ -102,8 +102,8 @@ class TestGraphBuilding(unittest.TestCase):
           json.dumps(stats))
 
       schema = [{'name': 'cat1', 'type': 'STRING'}, {'name': 'cat2', 'type': 'STRING'}]
-      features = {'cat1': {'transform': 'one_hot'},
-                  'cat2': {'transform': 'embedding'}}
+      features = {'cat1': {'transform': 'one_hot', 'source_column': 'cat1'},
+                  'cat2': {'transform': 'embedding', 'source_column': 'cat2'}}
       input_data = ['red,pizza',
                     'blue,',
                     'green,extra']
@@ -146,8 +146,8 @@ class TestGraphBuilding(unittest.TestCase):
       # a key column
       schema = [{'name': 'key', 'type': 'STRING'},
                 {'name': 'cat1', 'type': 'STRING'}]
-      features = {'key': {'transform': 'key'},
-                  'cat1': {'transform': 'tfidf'}}
+      features = {'key': {'transform': 'key', 'source_column': 'key'},
+                  'cat1': {'transform': 'tfidf', 'source_column': 'cat1'}}
       input_data = ['0,red red red',    # doc 0
                     '1,red green red',  # doc 1
                     '2,blue',           # doc 2
@@ -211,8 +211,8 @@ class TestGraphBuilding(unittest.TestCase):
       # a key column
       schema = [{'name': 'key', 'type': 'STRING'},
                 {'name': 'cat1', 'type': 'STRING'}]
-      features = {'key': {'transform': 'key'},
-                  'cat1': {'transform': 'bag_of_words'}}
+      features = {'key': {'transform': 'key', 'source_column': 'key'},
+                  'cat1': {'transform': 'bag_of_words', 'source_column': 'cat1'}}
       input_data = ['0,red red red',    # doc 0
                     '1,red green red',  # doc 1
                     '2,blue',           # doc 2
@@ -270,7 +270,7 @@ class TestGraphBuilding(unittest.TestCase):
       file_io.write_string_to_file(stats_file_path, json.dumps(stats))
 
       schema = [{'name': 'img', 'type': 'STRING'}]
-      features = {'img': {'transform': 'image_to_vec'}}
+      features = {'img': {'transform': 'image_to_vec', 'source_column': 'img'}}
 
       img_string1 = _open_and_encode_image(
           'gs://cloud-ml-data/img/flower_photos/daisy/15207766_fc2f1d692c_n.jpg')

--- a/solutionbox/code_free_ml/test_mltoolbox/test_training.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_training.py
@@ -20,6 +20,10 @@ CODE_PATH = os.path.abspath(os.path.join(
     os.path.dirname(__file__), '..', 'mltoolbox', 'code_free_ml'))
 
 
+class TestMultipleFeatures(unittest.TestCase):
+  """Test one source column can be used in many features."""
+  pass
+
 class TestOptionalKeys(unittest.TestCase):
 
   def testNoKeys(self):

--- a/solutionbox/code_free_ml/test_mltoolbox/test_training.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_training.py
@@ -20,12 +20,179 @@ CODE_PATH = os.path.abspath(os.path.join(
     os.path.dirname(__file__), '..', 'mltoolbox', 'code_free_ml'))
 
 
+def run_exported_model(model_path, csv_data):
+  """Runs an exported model.
+
+  Model should have one placeholder of csv data.
+
+  Args:
+    model_path: path to the saved_model.pb
+    csv_data: list of csv strings
+
+  Return:
+    The result of session.run
+  """
+  with tf.Graph().as_default(), tf.Session() as sess:
+    meta_graph_pb = tf.saved_model.loader.load(
+        sess=sess,
+        tags=[tf.saved_model.tag_constants.SERVING],
+        export_dir=model_path)
+    signature = meta_graph_pb.signature_def['serving_default']
+
+    input_alias_map = {
+        friendly_name: tensor_info_proto.name
+        for (friendly_name, tensor_info_proto) in signature.inputs.items()}
+    output_alias_map = {
+        friendly_name: tensor_info_proto.name
+        for (friendly_name, tensor_info_proto) in signature.outputs.items()}
+
+    _, csv_tensor_name = input_alias_map.items()[0]
+    result = sess.run(fetches=output_alias_map,
+                      feed_dict={csv_tensor_name: csv_data})
+
+  return result
+
+
 class TestMultipleFeatures(unittest.TestCase):
   """Test one source column can be used in many features."""
-  pass
+
+  def testMultipleColumnsRaw(self):
+    """Test training starting from raw csv."""
+    output_dir = tempfile.mkdtemp()
+    try:
+      features = {
+          'num': {'transform': 'identity'},
+          'num2': {'transform': 'key', 'source_column': 'num'},
+          'target': {'transform': 'target'},
+          'text': {'transform': 'bag_of_words'},
+          'text2': {'transform': 'tfidf', 'source_column': 'text'},
+          'text3': {'transform': 'key', 'source_column': 'text'}}
+      schema = [
+          {'name': 'num', 'type': 'integer'},
+          {'name': 'target', 'type': 'float'},
+          {'name': 'text', 'type': 'string'}]
+      data = ['1,2,hello world\n', '4,8,bye moon\n', '5,10,hello moon\n', '11,22,moon moon\n']
+      file_io.recursive_create_dir(output_dir)
+      file_io.write_string_to_file(os.path.join(output_dir, 'schema.json'),
+                                   json.dumps(schema, indent=2))
+      file_io.write_string_to_file(os.path.join(output_dir, 'features.json'),
+                                   json.dumps(features, indent=2))
+      file_io.write_string_to_file(os.path.join(output_dir, 'data.csv'),
+                                   ''.join(data))
+
+      cmd = ['python %s' % os.path.join(CODE_PATH, 'analyze.py'),
+             '--output-dir=' + os.path.join(output_dir, 'analysis'),
+             '--csv-file-pattern=' + os.path.join(output_dir, 'data.csv'),
+             '--csv-schema-file=' + os.path.join(output_dir, 'schema.json'),
+             '--features-file=' + os.path.join(output_dir, 'features.json')]
+      subprocess.check_call(' '.join(cmd), shell=True)
+
+      cmd = ['cd %s && ' % CODE_PATH,
+             'python -m trainer.task',
+             '--train-data-paths=' + os.path.join(output_dir, 'data.csv'),
+             '--eval-data-paths=' + os.path.join(output_dir, 'data.csv'),
+             '--job-dir=' + os.path.join(output_dir, 'training'),
+             '--analysis-output-dir=' + os.path.join(output_dir, 'analysis'),
+             '--model-type=linear_regression',
+             '--train-batch-size=4',
+             '--eval-batch-size=4',
+             '--max-steps=200',
+             '--learning-rate=0.1',
+             '--run-transforms']
+
+      subprocess.check_call(' '.join(cmd), shell=True)
+
+      result = run_exported_model(
+          model_path=os.path.join(output_dir, 'training', 'model'),
+          csv_data=['20,hello moon'])
+
+      # check keys were made
+      self.assertEqual(20, result['num2'])
+      self.assertEqual('hello moon', result['text3'])
+    finally:
+      shutil.rmtree(output_dir)
+
+  def testMultipleColumnsTransformed(self):
+    """Test training starting from tf.example."""
+    output_dir = tempfile.mkdtemp()
+    try:
+      features = {
+          'num': {'transform': 'identity'},
+          'num2': {'transform': 'key', 'source_column': 'num'},
+          'target': {'transform': 'target'},
+          'text': {'transform': 'bag_of_words'},
+          'text2': {'transform': 'tfidf', 'source_column': 'text'},
+          'text3': {'transform': 'key', 'source_column': 'text'}}
+      schema = [
+          {'name': 'num', 'type': 'integer'},
+          {'name': 'target', 'type': 'float'},
+          {'name': 'text', 'type': 'string'}]
+      data = ['1,2,hello world\n', '4,8,bye moon\n', '5,10,hello moon\n', '11,22,moon moon\n']
+      file_io.recursive_create_dir(output_dir)
+      file_io.write_string_to_file(os.path.join(output_dir, 'schema.json'),
+                                   json.dumps(schema, indent=2))
+      file_io.write_string_to_file(os.path.join(output_dir, 'features.json'),
+                                   json.dumps(features, indent=2))
+      file_io.write_string_to_file(os.path.join(output_dir, 'data.csv'),
+                                   ''.join(data))
+
+      cmd = ['python %s' % os.path.join(CODE_PATH, 'analyze.py'),
+             '--output-dir=' + os.path.join(output_dir, 'analysis'),
+             '--csv-file-pattern=' + os.path.join(output_dir, 'data.csv'),
+             '--csv-schema-file=' + os.path.join(output_dir, 'schema.json'),
+             '--features-file=' + os.path.join(output_dir, 'features.json')]
+      subprocess.check_call(' '.join(cmd), shell=True)
+
+      cmd = ['python %s' % os.path.join(CODE_PATH, 'transform.py'),
+             '--output-dir=' + os.path.join(output_dir, 'transform'),
+             '--csv-file-pattern=' + os.path.join(output_dir, 'data.csv'),
+             '--analysis-output-dir=' + os.path.join(output_dir, 'analysis'),
+             '--output-filename-prefix=features']
+      subprocess.check_call(' '.join(cmd), shell=True)
+
+      # Check tf.example file has the expected features
+      file_list = file_io.get_matching_files(os.path.join(output_dir, 'transform', 'features*'))
+      options = tf.python_io.TFRecordOptions(
+          compression_type=tf.python_io.TFRecordCompressionType.GZIP)
+      record_iter = tf.python_io.tf_record_iterator(path=file_list[0], options=options)
+      tf_example = tf.train.Example()
+      tf_example.ParseFromString(next(record_iter))
+
+      self.assertEqual(1, len(tf_example.features.feature['num'].int64_list.value))
+      self.assertEqual(1, len(tf_example.features.feature['num2'].int64_list.value))
+      self.assertEqual(1, len(tf_example.features.feature['target'].float_list.value))
+      self.assertEqual(2, len(tf_example.features.feature['text_ids'].int64_list.value))
+      self.assertEqual(2, len(tf_example.features.feature['text_weights'].float_list.value))
+      self.assertEqual(2, len(tf_example.features.feature['text2_ids'].int64_list.value))
+      self.assertEqual(2, len(tf_example.features.feature['text2_weights'].float_list.value))
+      self.assertEqual(1, len(tf_example.features.feature['text3'].bytes_list.value))
+
+      cmd = ['cd %s && ' % CODE_PATH,
+             'python -m trainer.task',
+             '--train-data-paths=' + os.path.join(output_dir, 'data.csv'),
+             '--eval-data-paths=' + os.path.join(output_dir, 'data.csv'),
+             '--job-dir=' + os.path.join(output_dir, 'training'),
+             '--analysis-output-dir=' + os.path.join(output_dir, 'analysis'),
+             '--model-type=linear_regression',
+             '--train-batch-size=4',
+             '--eval-batch-size=4',
+             '--max-steps=200',
+             '--learning-rate=0.1',
+             '--run-transforms']
+      subprocess.check_call(' '.join(cmd), shell=True)
+
+      result = run_exported_model(
+          model_path=os.path.join(output_dir, 'training', 'model'),
+          csv_data=['20,hello moon'])
+
+      # check keys were made
+      self.assertEqual(20, result['num2'])
+      self.assertEqual('hello moon', result['text3'])
+    finally:
+      shutil.rmtree(output_dir)
+
 
 class TestOptionalKeys(unittest.TestCase):
-
   def testNoKeys(self):
     output_dir = tempfile.mkdtemp()
     try:
@@ -66,25 +233,10 @@ class TestOptionalKeys(unittest.TestCase):
 
       subprocess.check_call(' '.join(cmd), shell=True)
 
-      with tf.Graph().as_default(), tf.Session() as sess:
-        meta_graph_pb = tf.saved_model.loader.load(
-            sess=sess,
-            tags=[tf.saved_model.tag_constants.SERVING],
-            export_dir=os.path.join(output_dir, 'training', 'model'))
-        signature = meta_graph_pb.signature_def['serving_default']
-
-        input_alias_map = {
-            friendly_name: tensor_info_proto.name
-            for (friendly_name, tensor_info_proto) in signature.inputs.items()}
-        output_alias_map = {
-            friendly_name: tensor_info_proto.name
-            for (friendly_name, tensor_info_proto) in signature.outputs.items()}
-
-        _, csv_tensor_name = input_alias_map.items()[0]
-        result = sess.run(fetches=output_alias_map,
-                          feed_dict={csv_tensor_name: ['20']})
-        print('result', result)
-        self.assertTrue(abs(40 - result['predicted']) < 5)
+      result = run_exported_model(
+          model_path=os.path.join(output_dir, 'training', 'model'),
+          csv_data=['20'])
+      self.assertTrue(abs(40 - result['predicted']) < 5)
     finally:
       shutil.rmtree(output_dir)
 
@@ -133,27 +285,12 @@ class TestOptionalKeys(unittest.TestCase):
 
       subprocess.check_call(' '.join(cmd), shell=True)
 
-      with tf.Graph().as_default(), tf.Session() as sess:
-        meta_graph_pb = tf.saved_model.loader.load(
-            sess=sess,
-            tags=[tf.saved_model.tag_constants.SERVING],
-            export_dir=os.path.join(output_dir, 'training', 'model'))
-        signature = meta_graph_pb.signature_def['serving_default']
-
-        input_alias_map = {
-            friendly_name: tensor_info_proto.name
-            for (friendly_name, tensor_info_proto) in signature.inputs.items()}
-        output_alias_map = {
-            friendly_name: tensor_info_proto.name
-            for (friendly_name, tensor_info_proto) in signature.outputs.items()}
-
-        _, csv_tensor_name = input_alias_map.items()[0]
-        result = sess.run(fetches=output_alias_map,
-                          feed_dict={csv_tensor_name: ['7,4.5,hello,1']})
-
-        self.assertEqual(7, result['keyint'])
-        self.assertAlmostEqual(4.5, result['keyfloat'])
-        self.assertEqual('hello', result['keystr'])
+      result = run_exported_model(
+          model_path=os.path.join(output_dir, 'training', 'model'),
+          csv_data=['7,4.5,hello,1'])
+      self.assertEqual(7, result['keyint'])
+      self.assertAlmostEqual(4.5, result['keyfloat'])
+      self.assertEqual('hello', result['keystr'])
     finally:
       shutil.rmtree(output_dir)
 


### PR DESCRIPTION
this is done by adding a 'source_column' key to the transform dict in the features file. If this value is missing, the analyze script will automatically add it based on the key value. 

This also means tf-feature names do not have to have the same name as the schema/input file names. But a user would only see the tf-feature names in the exported model if they mark a feature as a key. 

A feature can be an input to a model and a key. 