### PR TITLE
support sql statement in datalab magic

### DIFF
--- a/google/datalab/contrib/mltoolbox/commands/_ml.py
+++ b/google/datalab/contrib/mltoolbox/commands/_ml.py
@@ -246,7 +246,7 @@ def _analyze(args, cell):
         # see https://cloud.google.com/bigquery/querying-data#temporary_and_permanent_tables
         print('Creating temporary table that will be deleted in 24 hours')
         r = bq.Query(training_data['bigquery_sql']).execute().result()
-        cmd_args.extend(['--bigquery-table', r.full_name]))
+        cmd_args.extend(['--bigquery-table', r.full_name])
       else:
         raise ValueError('Invalid training_data dict. ' +
                          'Requires either "csv_file_pattern" and "csv_schema", or "bigquery".')
@@ -299,7 +299,7 @@ def _transform(args, cell):
         # see https://cloud.google.com/bigquery/querying-data#temporary_and_permanent_tables
         print('Creating temporary table that will be deleted in 24 hours')
         r = bq.Query(training_data['bigquery_sql']).execute().result()
-        cmd_args.extend(['--bigquery-table', r.full_name]))
+        cmd_args.extend(['--bigquery-table', r.full_name])
     else:
       raise ValueError('Invalid training_data dict. ' +
                        'Requires either "csv_file_pattern" and "csv_schema", or "bigquery".')


### PR DESCRIPTION
* the command line does not support sql as that would require using more datalab bq commands, but the command line at some point not require datalab.
* prints a message that the sql statement is being saved to a temp table. So I think in transform, if the job takes longer than a day, there might be errors.
