### PR TITLE
%%ml analyze can take a tarball 

### DIFF
--- a/google/datalab/contrib/mltoolbox/_archive.py
+++ b/google/datalab/contrib/mltoolbox/_archive.py
@@ -44,9 +44,9 @@ def extract_archive(archive_path, dest):
       archive_path = os.path.join(tmpfolder, os.path.name(archive_path))
 
     if archive_path.lower().endswith('.tar.gz'):
-      flags = '-xvzf'
+      flags = '-xzf'
     elif archive_path.lower().endswith('.tar'):
-      flags = '-xvf'
+      flags = '-xf'
     else:
       raise ValueError('Only tar.gz or tar.Z files are supported.')
 

--- a/google/datalab/contrib/mltoolbox/_archive.py
+++ b/google/datalab/contrib/mltoolbox/_archive.py
@@ -1,0 +1,57 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Google Cloud Platform library - ml cell magic."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import os
+import shutil
+import tempfile
+
+import google.datalab.contrib.mltoolbox._shell_process as _shell_process
+
+
+def extract_archive(archive_path, dest):
+  """Extract a local or GCS archive file to a folder.
+
+  Args:
+    archive_path: local or gcs path to a *.tar.gz or *.tar file
+    dest: local folder the archive will be extracted to
+  """
+  # Make the dest folder if it does not exist
+  if not os.path.isdir(dest):
+    os.makedirs(dest)
+
+  try:
+    tmpfolder = None
+    if archive_path.startswith('gs://'):
+      # Copy the file to a local temp folder
+      tmpfolder = tempfile.mkdtemp()
+      cmd_args = ['gsutil', 'cp', archive_path, tmpfolder]
+      _shell_process.run_and_monitor(cmd_args, os.getpid())
+      archive_path = os.path.join(tmpfolder, os.path.name(archive_path))
+
+    if archive_path.lower().endswith('.tar.gz'):
+      flags = '-xvzf'
+    elif archive_path.lower().endswith('.tar'):
+      flags = '-xvf'
+    else:
+      raise ValueError('Only tar.gz or tar.Z files are supported.')
+
+    cmd_args = ['tar', flags, archive_path, '-C', dest]
+    _shell_process.run_and_monitor(cmd_args, os.getpid())
+  finally:
+    if tmpfolder:
+      shutil.rmtree(tmpfolder)

--- a/google/datalab/contrib/mltoolbox/commands/_ml.py
+++ b/google/datalab/contrib/mltoolbox/commands/_ml.py
@@ -38,6 +38,7 @@ import google.datalab.bigquery as bq
 import google.datalab.utils.commands
 import google.datalab.contrib.mltoolbox._local_predict as _local_predict
 import google.datalab.contrib.mltoolbox._shell_process as _shell_process
+import google.datalab.contrib.mltoolbox._archive as _archive
 
 
 MLTOOLBOX_CODE_PATH = '/datalab/lib/pydatalab/solutionbox/code_free_ml/mltoolbox/code_free_ml/'
@@ -129,7 +130,8 @@ features: $features_def
                               help='path of output directory.')
   analyze_parser.add_argument('--cloud', action='store_true', default=False,
                               help='whether to run analysis in cloud or local.')
-
+  analyze_parser.add_argument('--code_source', required=False,
+                              help='A local GCS tarball path to use as the source.s')
   analyze_parser.set_defaults(func=_analyze)
 
   transform_parser = parser.subcommand(
@@ -302,7 +304,13 @@ def _analyze(args, cell):
     features = cell_data['features']
     features_file = _create_json_file(tmpdir, features, 'features.json')
     cmd_args.extend(['--features-file', features_file])
-    _shell_process.run_and_monitor(cmd_args, os.getpid(), cwd=MLTOOLBOX_CODE_PATH)
+
+    if args.code_source:
+      code_path = _archive.extract_archive(args.code_source, tmpdir)
+    else:
+      code_path = MLTOOLBOX_CODE_PATH
+
+    _shell_process.run_and_monitor(cmd_args, os.getpid(), cwd=code_path)
   finally:
     shutil.rmtree(tmpdir)
 

--- a/google/datalab/contrib/mltoolbox/commands/_ml.py
+++ b/google/datalab/contrib/mltoolbox/commands/_ml.py
@@ -130,8 +130,8 @@ features: $features_def
                               help='path of output directory.')
   analyze_parser.add_argument('--cloud', action='store_true', default=False,
                               help='whether to run analysis in cloud or local.')
-  analyze_parser.add_argument('--code_source', required=False,
-                              help='A local GCS tarball path to use as the source.s')
+  analyze_parser.add_argument('--source_code', required=False,
+                              help='A local or GCS tarball path to use as the source.')
   analyze_parser.set_defaults(func=_analyze)
 
   transform_parser = parser.subcommand(
@@ -305,8 +305,9 @@ def _analyze(args, cell):
     features_file = _create_json_file(tmpdir, features, 'features.json')
     cmd_args.extend(['--features-file', features_file])
 
-    if args.code_source:
-      code_path = _archive.extract_archive(args.code_source, tmpdir)
+    if args['source_code']:
+      code_path = os.path.join(tmpdir, 'source_code')
+      _archive.extract_archive(args['source_code'], code_path)
     else:
       code_path = MLTOOLBOX_CODE_PATH
 

--- a/google/datalab/contrib/mltoolbox/commands/_ml.py
+++ b/google/datalab/contrib/mltoolbox/commands/_ml.py
@@ -130,8 +130,9 @@ features: $features_def
                               help='path of output directory.')
   analyze_parser.add_argument('--cloud', action='store_true', default=False,
                               help='whether to run analysis in cloud or local.')
-  analyze_parser.add_argument('--source_code', required=False,
-                              help='A local or GCS tarball path to use as the source.')
+  analyze_parser.add_argument('--package', required=False,
+                              help='A local or GCS tarball path to use as the source. ' +
+                                   'If not set, the default source package will be used.')
   analyze_parser.set_defaults(func=_analyze)
 
   transform_parser = parser.subcommand(
@@ -305,9 +306,9 @@ def _analyze(args, cell):
     features_file = _create_json_file(tmpdir, features, 'features.json')
     cmd_args.extend(['--features-file', features_file])
 
-    if args['source_code']:
-      code_path = os.path.join(tmpdir, 'source_code')
-      _archive.extract_archive(args['source_code'], code_path)
+    if args['package']:
+      code_path = os.path.join(tmpdir, 'package')
+      _archive.extract_archive(args['package'], code_path)
     else:
       code_path = MLTOOLBOX_CODE_PATH
 

--- a/tests/main.py
+++ b/tests/main.py
@@ -39,6 +39,7 @@ import kernel.html_tests
 import kernel.storage_tests
 import kernel.utils_tests
 import ml.dataset_tests
+import mltoolbox_magic.archive_tests
 import mltoolbox_magic.local_predict_tests
 import mltoolbox_magic.shell_process_tests
 import mltoolbox_structured_data.dl_interface_tests
@@ -103,6 +104,7 @@ _INTEGRATION_TEST_MODULES = [
     mltoolbox_structured_data.traininglib_tests,
     mltoolbox_magic.local_predict_tests,
     mltoolbox_magic.shell_process_tests,
+    mltoolbox_magic.archive_tests,
 ]
 
 

--- a/tests/mltoolbox_magic/archive_tests.py
+++ b/tests/mltoolbox_magic/archive_tests.py
@@ -1,0 +1,89 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+"""Test MLToolbox Magic's archive functions."""
+from __future__ import absolute_import
+from __future__ import print_function
+
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import google.datalab.contrib.mltoolbox._archive as _archive
+
+
+class TestArchive(unittest.TestCase):
+  """Tests for untar-ing files"""
+
+  def setUp(self):
+    self._root_folder = tempfile.mkdtemp()
+
+    # Make two files to tar/compress
+    self._src_folder = tempfile.mkdtemp(dir=self._root_folder)
+    self._filename1 = 'file1.txt'
+    self._filename2 = 'file2.txt'
+    with open(os.path.join(self._src_folder, self._filename1), 'w') as f:
+      f.write('This is file 1')
+    with open(os.path.join(self._src_folder, self._filename2), 'w') as f:
+      f.write('and this is file 2')
+
+  def tearDown(self):
+    shutil.rmtree(self._root_folder)
+
+  def test_extract_archive_targz(self):
+    """Tests extracting tar.gz files."""
+
+    # Make a tar.gz file
+    archive_path = os.path.join(self._root_folder, 'test.tar.gz')
+    cmd = ['tar', '-czf', archive_path, '-C', self._src_folder, self._filename1, self._filename2]
+    subprocess.check_call(cmd)
+
+    # Undo it
+    dest = os.path.join(self._root_folder, 'output')
+    _archive.extract_archive(archive_path, dest)
+
+    expected_file1 = os.path.join(dest, self._filename1)
+    expected_file2 = os.path.join(dest, self._filename2)
+    self.assertTrue(os.path.isfile(expected_file1))
+    self.assertTrue(os.path.isfile(expected_file2))
+
+    with open(expected_file2, 'r') as f:
+      file_contents = f.read()
+    self.assertTrue(file_contents, 'and this is file2')
+
+  def test_extract_archive_tar(self):
+    """Tests extracting tar.gz files."""
+
+    # Make a tar.gz file
+    archive_path = os.path.join(self._root_folder, 'test.tar')
+    cmd = ['tar', '-cf', archive_path, '-C', self._src_folder, self._filename1, self._filename2]
+    subprocess.check_call(cmd)
+
+    # Undo it
+    dest = os.path.join(self._root_folder, 'output')
+    _archive.extract_archive(archive_path, dest)
+
+    expected_file1 = os.path.join(dest, self._filename1)
+    expected_file2 = os.path.join(dest, self._filename2)
+    self.assertTrue(os.path.isfile(expected_file1))
+    self.assertTrue(os.path.isfile(expected_file2))
+
+    with open(expected_file2, 'r') as f:
+      file_contents = f.read()
+    self.assertTrue(file_contents, 'and this is file2')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* add support for taking a tarball as the source
* will download the tarball if on gcs
* untar's it, and analyze uses the analyze.py file

todo

* support other file formats like .zip, .tar.bz, .tar.Z
* do this to transform and training too
* once we figure out the documentation story, we need to document the expected format of the tarball (analyze.py, transform.py, setup.py, trainer/task.py)