### PR TITLE
Ignoring IDEA-generated *.iml files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyi
 *.map
 *.egg-info
+*.iml
 .idea
 MANIFEST
 build


### PR DESCRIPTION
Using IntelliJ for editing python files creates *.iml files that are created and used only by the IDE. These need to be ignored by git.