### PR TITLE
remove the printing lag

### DIFF
--- a/google/datalab/contrib/mltoolbox/_shell_process.py
+++ b/google/datalab/contrib/mltoolbox/_shell_process.py
@@ -71,6 +71,7 @@ def run_and_monitor(args, pid_to_wait, std_out_filter_fn=None, cwd=None):
 
       if std_out_filter_fn is None or std_out_filter_fn(line):
         sys.stdout.write(line)
+        sys.stdout.flush()
   finally:
     if monitor_process:
       monitor_process.kill()

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/analyze.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/analyze.py
@@ -223,7 +223,7 @@ def run_cloud_analysis(output_dir, csv_file_pattern, bigquery_table, schema,
 
   numerical_vocab_stats = {}
   for col_name, transform_set in six.iteritems(inverted_features_target):
-    sys.stdout.write('Analyzing column %s...' % col_name)
+    sys.stdout.write('Analyzing column %s...\n' % col_name)
     sys.stdout.flush()
     # All transforms in transform_set require the same analysis. So look
     # at the first transform.
@@ -283,7 +283,7 @@ def run_cloud_analysis(output_dir, csv_file_pattern, bigquery_table, schema,
       numerical_vocab_stats[col_name] = {'min': df.iloc[0]['min_value'],
                                          'max': df.iloc[0]['max_value'],
                                          'mean': df.iloc[0]['avg_value']}
-    sys.stdout.write('done.\n')
+    sys.stdout.write('column %s analyzed.\n' % col_name)
     sys.stdout.flush()
 
   # get num examples
@@ -312,10 +312,14 @@ def run_local_analysis(output_dir, csv_file_pattern, schema, inverted_features):
   Raises:
     ValueError: on unknown transfrorms/schemas
   """
+  sys.stdout.write('Expanding any file patterns...\n')
+  sys.stdout.flush()
   header = [column['name'] for column in schema]
   input_files = []
   for file_pattern in csv_file_pattern:
     input_files.extend(file_io.get_matching_files(file_pattern))
+  sys.stdout.write('file list computed.\n')
+  sys.stdout.flush()
 
   # Make a copy of inverted_features and update the target transform to be
   # identity or one hot depending on the schema.
@@ -341,7 +345,7 @@ def run_local_analysis(output_dir, csv_file_pattern, schema, inverted_features):
   # for each file, update the numerical stats from that file, and update the set
   # of unique labels.
   for input_file in input_files:
-    sys.stdout.write('Analyzing file %s...' % input_file)
+    sys.stdout.write('Analyzing file %s...\n' % input_file)
     sys.stdout.flush()
     with file_io.FileIO(input_file, 'r') as f:
       for line in csv.reader(f):
@@ -380,7 +384,7 @@ def run_local_analysis(output_dir, csv_file_pattern, schema, inverted_features):
             numerical_results[col_name]['count'] += 1
             numerical_results[col_name]['sum'] += float(parsed_line[col_name])
 
-    sys.stdout.write('done.\n')
+    sys.stdout.write('file %s analyzed.\n' % input_file)
     sys.stdout.flush()
 
   # Write the vocab files. Each label is on its own line.


### PR DESCRIPTION
some people think “Analyzing file /content/datalab/so/cleaned_train.csv” is printed out too late. and that I'm missing a sys.stdout.flush(). But I was already doing this!

Looking into this, I noticed the lag does not exist in the terminal version of the code, it only happens in the magic. The solution required two changes

1. in DL's subprocess, it should flush after printing
1. in analyze, output needs to have newlines, because p.stdout.readline() waits for a newline. This means we cannot do the "doing x..done" pattern. I now do "doing x...\n x is done" pattern.

I'm also printing when we are expanding the file pattern for local run as this can take a while if the files are on gcs.
