### PR TITLE
fix evaluation issue

### DIFF
--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/feature_transforms.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/feature_transforms.py
@@ -534,7 +534,7 @@ def build_csv_transforming_training_input_fn(schema,
                                              randomize_input=False,
                                              min_after_dequeue=1,
                                              reader_num_threads=1,
-                                             allow_smaller_final_batch=False):
+                                             allow_smaller_final_batch=True):
   """Creates training input_fn that reads raw csv data and applies transforms.
 
   Args:
@@ -633,7 +633,7 @@ def build_tfexample_transfored_training_input_fn(schema,
                                                  randomize_input=False,
                                                  min_after_dequeue=1,
                                                  reader_num_threads=1,
-                                                 allow_smaller_final_batch=False):
+                                                 allow_smaller_final_batch=True):
   """Creates training input_fn that reads transformed tf.example files.
 
   Args:

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/feature_transforms.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/feature_transforms.py
@@ -533,7 +533,8 @@ def build_csv_transforming_training_input_fn(schema,
                                              num_epochs=None,
                                              randomize_input=False,
                                              min_after_dequeue=1,
-                                             reader_num_threads=1):
+                                             reader_num_threads=1,
+                                             allow_smaller_final_batch=False):
   """Creates training input_fn that reads raw csv data and applies transforms.
 
   Args:
@@ -550,6 +551,8 @@ def build_csv_transforming_training_input_fn(schema,
         dequeue, used to ensure a level of mixing of elements. Only used if
         randomize_input is True.
     reader_num_threads: The number of threads enqueuing data.
+    allow_smaller_final_batch: If false, fractional batches at the end of
+        training or evaluation are not used.
 
   Returns:
     An input_fn suitable for training that reads raw csv training data and
@@ -582,7 +585,8 @@ def build_csv_transforming_training_input_fn(schema,
           capacity=queue_capacity,
           min_after_dequeue=min_after_dequeue,
           enqueue_many=True,
-          num_threads=reader_num_threads)
+          num_threads=reader_num_threads,
+          allow_smaller_final_batch=allow_smaller_final_batch)
 
     else:
       _, batch_csv_lines = tf.train.batch(
@@ -590,7 +594,8 @@ def build_csv_transforming_training_input_fn(schema,
           batch_size=training_batch_size,
           capacity=queue_capacity,
           enqueue_many=True,
-          num_threads=reader_num_threads)
+          num_threads=reader_num_threads,
+          allow_smaller_final_batch=allow_smaller_final_batch)
 
     csv_header, record_defaults = csv_header_and_defaults(features, schema, stats, keep_target=True)
     parsed_tensors = tf.decode_csv(batch_csv_lines, record_defaults, name='csv_to_tensors')
@@ -627,7 +632,8 @@ def build_tfexample_transfored_training_input_fn(schema,
                                                  num_epochs=None,
                                                  randomize_input=False,
                                                  min_after_dequeue=1,
-                                                 reader_num_threads=1):
+                                                 reader_num_threads=1,
+                                                 allow_smaller_final_batch=False):
   """Creates training input_fn that reads transformed tf.example files.
 
   Args:
@@ -643,6 +649,8 @@ def build_tfexample_transfored_training_input_fn(schema,
         dequeue, used to ensure a level of mixing of elements. Only used if
         randomize_input is True.
     reader_num_threads: The number of threads enqueuing data.
+    allow_smaller_final_batch: If false, fractional batches at the end of
+        training or evaluation are not used.    
 
   Returns:
     An input_fn suitable for training that reads transformed data in tf record
@@ -677,7 +685,8 @@ def build_tfexample_transfored_training_input_fn(schema,
           capacity=queue_capacity,
           min_after_dequeue=min_after_dequeue,
           enqueue_many=True,
-          num_threads=reader_num_threads)
+          num_threads=reader_num_threads,
+          allow_smaller_final_batch=allow_smaller_final_batch)
 
     else:
       _, batch_ex_str = tf.train.batch(
@@ -685,7 +694,8 @@ def build_tfexample_transfored_training_input_fn(schema,
           batch_size=training_batch_size,
           capacity=queue_capacity,
           enqueue_many=True,
-          num_threads=reader_num_threads)
+          num_threads=reader_num_threads,
+          allow_smaller_final_batch=allow_smaller_final_batch)
 
     feature_spec = {}
     feature_info = get_transfrormed_feature_info(features, schema)

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/feature_transforms.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/feature_transforms.py
@@ -650,7 +650,7 @@ def build_tfexample_transfored_training_input_fn(schema,
         randomize_input is True.
     reader_num_threads: The number of threads enqueuing data.
     allow_smaller_final_batch: If false, fractional batches at the end of
-        training or evaluation are not used.    
+        training or evaluation are not used.
 
   Returns:
     An input_fn suitable for training that reads transformed data in tf record

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
@@ -188,10 +188,13 @@ def parse_arguments(argv):
       help=('Maximum number of training data epochs on which to train. If '
             'both "max-step" and "num-epochs" are specified, the training '
             'job will run for "max-steps" or "num-epochs", whichever occurs '
-            'first. If unspecified will run for "max-steps".'))
+            'first. If unspecified will run for "max-steps". If using '
+            'num-epochs and the last training batch is not full, the last '
+            'batch will not be used.'))
   parser.add_argument(
       '--train-batch-size', type=int, default=100, metavar='N',
-      help='How many training examples are used per step.')
+      help='How many training examples are used per step. If num-epochs is '
+           'used, the last batch may not be full.')
   parser.add_argument(
       '--eval-batch-size', type=int, default=100, metavar='N',
       help='Batch size during evaluation. Larger values increase performance '
@@ -746,8 +749,7 @@ def get_experiment_fn(args):
           num_epochs=args.num_epochs,
           randomize_input=True,
           min_after_dequeue=10,
-          reader_num_threads=multiprocessing.cpu_count(),
-          allow_smaller_final_batch=False)
+          reader_num_threads=multiprocessing.cpu_count())
       input_reader_for_eval = feature_transforms.build_csv_transforming_training_input_fn(
           schema=schema,
           features=features,
@@ -757,8 +759,7 @@ def get_experiment_fn(args):
           training_batch_size=args.eval_batch_size,
           num_epochs=1,
           randomize_input=False,
-          reader_num_threads=multiprocessing.cpu_count(),
-          allow_smaller_final_batch=True)
+          reader_num_threads=multiprocessing.cpu_count())
     else:
       input_reader_for_train = feature_transforms.build_tfexample_transfored_training_input_fn(
           schema=schema,
@@ -769,8 +770,7 @@ def get_experiment_fn(args):
           num_epochs=args.num_epochs,
           randomize_input=True,
           min_after_dequeue=10,
-          reader_num_threads=multiprocessing.cpu_count(),
-          allow_smaller_final_batch=False)
+          reader_num_threads=multiprocessing.cpu_count())
       input_reader_for_eval = feature_transforms.build_tfexample_transfored_training_input_fn(
           schema=schema,
           features=features,
@@ -779,8 +779,7 @@ def get_experiment_fn(args):
           training_batch_size=args.eval_batch_size,
           num_epochs=1,
           randomize_input=False,
-          reader_num_threads=multiprocessing.cpu_count(),
-          allow_smaller_final_batch=True)
+          reader_num_threads=multiprocessing.cpu_count())
 
     return tf.contrib.learn.Experiment(
         estimator=estimator,


### PR DESCRIPTION
This fixed the zero accuracy/wrong accuracy on my test data. However, b/62844938 says this is not the complete story. In any event, allow_smaller_final_batch=True is the correct thing to do for eval. 

For training, it is a little more complicated. If false and the batch size is large and num_epochs is used, then not all the data is used. If true and using num_epochs, the last batch could have very few elements (like 1), but the learning rate depends on batch size, so the model would overfit on the last example. I went with true for training. 