### PR TITLE
Update ipython config README to use new namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ This package is available on PyPI as `datalab`:
 
 In a notebook cell, enable with:
 
-    %load_ext datalab.kernel
+    %load_ext google.datalab.kernel
 
 Alternatively add this to your `ipython_config.py` file in your profile:
 
     c = get_config()
     c.InteractiveShellApp.extensions = [
-        'datalab.kernel'
+        'google.datalab.kernel'
     ]
 
 You will typically put this under `~/.ipython/profile_default`. See


### PR DESCRIPTION
Hey we are some analysts at Spotify trying to use the new `%bq` magic. After trying to follow along with notebook examples, we noticed our notebooks were having trouble finding the `%bq` magic.

After some digging, we realized it was due to the README pointing to the old namespace in the ipython config. Figured we would change the docs here so others don't get stuck!