### PR TITLE
make some parameter names shorter

### DIFF
--- a/google/datalab/contrib/mltoolbox/commands/_ml.py
+++ b/google/datalab/contrib/mltoolbox/commands/_ml.py
@@ -171,7 +171,7 @@ cloud: A dictionary of cloud config. All of them are optional. The "cloud" itsel
                                 help='path of analysis output directory.')
   transform_parser.add_argument('--output', required=True,
                                 help='path of output directory.')
-  transform_parser.add_argument('--prefix', required=True, metavar='NAME'
+  transform_parser.add_argument('--prefix', required=True, metavar='NAME',
                                 help='The prefix of the output file name. The output files will ' +
                                      'be like NAME_00000_of_00005.tar.gz')
   transform_parser.add_argument('--cloud', action='store_true', default=False,

--- a/google/datalab/contrib/mltoolbox/commands/_ml.py
+++ b/google/datalab/contrib/mltoolbox/commands/_ml.py
@@ -257,7 +257,8 @@ prediction_data: $my_data
                               help='The model path if not --cloud, or the id in ' +
                                    'the form of model.version if --cloud.')
   predict_parser.add_argument('--headers', required=True,
-                              help='The comma seperated headers of the prediction data.')
+                              help='The comma seperated headers of the prediction data. '
+                                   'Order must match the training order.')
   predict_parser.add_argument('--image_columns',
                               help='Comma seperated headers of image URL columns. ' +
                                    'Required if prediction data contains image URL columns.')

--- a/google/datalab/contrib/mltoolbox/commands/_ml.py
+++ b/google/datalab/contrib/mltoolbox/commands/_ml.py
@@ -126,7 +126,7 @@ features: A dictionary with key being column name. The list of supported transfo
                 column contains metadata-like information and will be output as-is in prediction.
 
 Also support in-notebook variables, such as:
-%%ml analyze --output_dir path/to/dir
+%%ml analyze --output path/to/dir
 training_data: $my_csv_dataset
 features: $features_def
 """, formatter_class=argparse.RawTextHelpFormatter)
@@ -171,9 +171,9 @@ cloud: A dictionary of cloud config. All of them are optional. The "cloud" itsel
                                 help='path of analysis output directory.')
   transform_parser.add_argument('--output', required=True,
                                 help='path of output directory.')
-  transform_parser.add_argument('--prefix', required=True,
+  transform_parser.add_argument('--prefix', required=True, metavar='NAME'
                                 help='The prefix of the output file name. The output files will ' +
-                                     'be like output_filename_prefix_00001_of_0000n')
+                                     'be like NAME_00000_of_00005.tar.gz')
   transform_parser.add_argument('--cloud', action='store_true', default=False,
                                 help='whether to run transform in cloud or local.')
   transform_parser.add_argument('--shuffle', action='store_true', default=False,
@@ -270,7 +270,7 @@ prediction_data: $my_data
   batch_predict_parser = parser.subcommand(
       'batch_predict', help="""Batch prediction with local or deployed models.
 
-%%ml batch_predict --model path/to/model --output_file path/to/output --output_format csv [--cloud]
+%%ml batch_predict --model path/to/model --output path/to/output --format csv [--cloud]
 prediction_data:
   csv_file_pattern: path/to/file_pattern
 

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/analyze.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/analyze.py
@@ -119,7 +119,7 @@ def parse_arguments(argv):
                       action='store_true',
                       help='Analysis will use cloud services.')
   parser.add_argument('--output',
-                      metavar='FOLDER',
+                      metavar='DIR',
                       type=str,
                       required=True,
                       help='GCS or local folder')

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/analyze.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/analyze.py
@@ -54,7 +54,7 @@ def parse_arguments(argv):
           Description of input files
           --------------------------
 
-          1) If using csv files, the --csv-schema-file must be the file path to
+          1) If using csv files, the --schema parameter must be the file path to
              a schema file. The format of this file must be a valid BigQuery
              schema file, which is a JSON file containing a list of dicts.
              Consider the example schema file below:
@@ -70,11 +70,11 @@ def parse_arguments(argv):
              in the schema list. Also, we only support three BigQuery types (
              integer, float, and string).
 
-             If instead of csv files, --bigquery-table is used, the schema file
+             If instead of csv files, --bigquery is used, the schema file
              is not needed as this program will extract it from
              the table directly.
 
-          2) --features-file is a file path to a file describing the
+          2) --features is a file path to a file describing the
              transformations. Below is an example features file:
 
              {
@@ -124,22 +124,27 @@ def parse_arguments(argv):
                       required=True,
                       help='GCS or local folder')
 
-  # CSV inputs
-  parser.add_argument('--csv-file-pattern',
-                      metavar='FILE',
-                      type=str,
-                      required=False,
-                      action='append',
-                      help=('Input CSV file names. May contain a file pattern. '
-                            'File prefix must include absolute file path.'))
-  parser.add_argument('--csv-schema',
-                      metavar='FILE',
-                      type=str,
-                      required=False,
-                      help=('BigQuery json schema file path'))
+  input_group = parser.add_argument_group(
+      title='Data Source Parameters',
+      description='schema is only needed if using --csv')
 
-  # If using bigquery table
-  parser.add_argument('--bigquery-table',
+  # CSV input
+  input_group.add_argument('--csv',
+                           metavar='FILE',
+                           type=str,
+                           required=False,
+                           action='append',
+                           help='Input CSV absolute file paths. May contain a '
+                                'file pattern.')
+  input_group.add_argument('--schema',
+                           metavar='FILE',
+                           type=str,
+                           required=False,
+                           help='Schema file path. Only required if using csv files')
+
+  # Bigquery input
+  input_group.add_argument('--bigquery',
+                      metavar='PROJECT_ID.DATASET.TABLE_NAME',
                       type=str,
                       required=False,
                       help=('Must be in the form project.dataset.table_name'))
@@ -154,22 +159,22 @@ def parse_arguments(argv):
 
   if args.cloud:
     if not args.output.startswith('gs://'):
-      raise ValueError('--output-dir must point to a location on GCS')
-    if (args.csv_file_pattern and
-       not all(x.startswith('gs://') for x in args.csv_file_pattern)):
-      raise ValueError('--csv-file-pattern must point to a location on GCS')
-    if args.csv_schema and not args.csv_schema.startswith('gs://'):
-      raise ValueError('--csv-schema-file must point to a location on GCS')
+      raise ValueError('--output must point to a location on GCS')
+    if (args.csv and
+       not all(x.startswith('gs://') for x in args.csv)):
+      raise ValueError('--csv must point to a location on GCS')
+    if args.schema and not args.schema.startswith('gs://'):
+      raise ValueError('--schema must point to a location on GCS')
 
-  if not args.cloud and args.bigquery_table:
-    raise ValueError('--bigquery-table must be used with --cloud')
+  if not args.cloud and args.bigquery:
+    raise ValueError('--bigquery must be used with --cloud')
 
-  if not ((args.bigquery_table and args.csv_file_pattern is None and
-           args.csv_schema is None) or
-          (args.bigquery_table is None and args.csv_file_pattern and
-           args.csv_schema)):
-    raise ValueError('either --csv-schema-file and --csv-file-pattern must both'
-                     ' be set or just --bigquery-table is set')
+  if not ((args.bigquery and args.csv is None and
+           args.schema is None) or
+          (args.bigquery is None and args.csv and
+           args.schema)):
+    raise ValueError('either --csv and --schema must both'
+                     ' be set or just --bigquery is set')
 
   return args
 
@@ -576,12 +581,12 @@ def invert_features(features):
 def main(argv=None):
   args = parse_arguments(sys.argv if argv is None else argv)
 
-  if args.csv_schema:
+  if args.schema:
     schema = json.loads(
-        file_io.read_file_to_string(args.csv_schema).decode())
+        file_io.read_file_to_string(args.schema).decode())
   else:
     import google.datalab.bigquery as bq
-    schema = bq.Table(args.bigquery_table).schema._bq_schema
+    schema = bq.Table(args.bigquery).schema._bq_schema
   features = json.loads(
       file_io.read_file_to_string(args.features).decode())
 
@@ -594,14 +599,14 @@ def main(argv=None):
   if args.cloud:
     run_cloud_analysis(
         output_dir=args.output,
-        csv_file_pattern=args.csv_file_pattern,
-        bigquery_table=args.bigquery_table,
+        csv_file_pattern=args.csv,
+        bigquery_table=args.bigquery,
         schema=schema,
         inverted_features=inverted_features)
   else:
     run_local_analysis(
         output_dir=args.output,
-        csv_file_pattern=args.csv_file_pattern,
+        csv_file_pattern=args.csv,
         schema=schema,
         inverted_features=inverted_features)
 

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/analyze.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/analyze.py
@@ -144,10 +144,10 @@ def parse_arguments(argv):
 
   # Bigquery input
   input_group.add_argument('--bigquery',
-                      metavar='PROJECT_ID.DATASET.TABLE_NAME',
-                      type=str,
-                      required=False,
-                      help=('Must be in the form project.dataset.table_name'))
+                           metavar='PROJECT_ID.DATASET.TABLE_NAME',
+                           type=str,
+                           required=False,
+                           help=('Must be in the form project.dataset.table_name'))
 
   parser.add_argument('--features',
                       metavar='FILE',

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
@@ -82,16 +82,17 @@ class DatalabParser():
 
     # The arguments added here are required to exist by Datalab's "%%ml train" magics.
     self.full_parser.add_argument(
-        '--train-data-paths', type=str, required=True, action='append', metavar='FILE')
+        '--train', type=str, required=True, action='append', metavar='FILE')
     self.full_parser.add_argument(
-        '--eval-data-paths', type=str, required=True, action='append', metavar='FILE')
+        '--eval', type=str, required=True, action='append', metavar='FILE')
     self.full_parser.add_argument('--job-dir', type=str, required=True)
     self.full_parser.add_argument(
-        '--output-dir-from-analysis-step', type=str, required=True, metavar='FOLDER',
+        '--analysis', type=str, required=True,
+        metavar='ANALYSIS_OUTPUT_FOLDER',
         help=('Output folder of analysis. Should contain the schema, stats, and '
               'vocab files. Path must be on GCS if running cloud training.'))
     self.full_parser.add_argument(
-        '--run-transforms', action='store_true', default=False,
+        '--transform', action='store_true', default=False,
         help='If used, input data is raw csv that needs transformation.')
 
   def make_datalab_help_action(self):
@@ -167,7 +168,7 @@ def parse_arguments(argv):
 
   # Model parameters
   parser.add_argument(
-    '--model-type', required=True,
+    '--model', required=True,
     choices=['linear_classification', 'linear_regression', 'dnn_classification', 'dnn_regression'])
   parser.add_argument(
       '--top-n', type=int, default=1, metavar='N',
@@ -184,9 +185,9 @@ def parse_arguments(argv):
       '--max-steps', type=int, default=5000, metavar='N',
       help='Maximum number of training steps to perform.')
   parser.add_argument(
-      '--num-epochs', type=int, metavar='N',
+      '--max-epochs', type=int, metavar='N',
       help=('Maximum number of training data epochs on which to train. If '
-            'both "max-step" and "num-epochs" are specified, the training '
+            'both "max-step" and "max-epochs" are specified, the training '
             'job will run for "max-steps" or "num-epochs", whichever occurs '
             'first. If unspecified will run for "max-steps".'))
   parser.add_argument('--train-batch-size', type=int, default=100, metavar='N')
@@ -358,7 +359,7 @@ def make_prediction_output_tensors(args, features, input_ops, model_fn_ops,
   outputs.update({key_name: tf.squeeze(input_ops.features[key_name])
                   for key_name in key_names})
 
-  if is_classification_model(args.model_type):
+  if is_classification_model(args.model):
 
     # build maps from ints to the origional categorical strings.
     string_values = read_vocab(args, target_name)
@@ -450,7 +451,7 @@ def make_export_strategy(
       contrib_variables.create_global_step(g)
 
       input_ops = feature_transforms.build_csv_serving_tensors(
-          args.output_dir_from_analysis_step, features, schema, stats, keep_target)
+          args.analysis, features, schema, stats, keep_target)
       model_fn_ops = estimator._call_model_fn(input_ops.features,
                                               None,
                                               model_fn_lib.ModeKeys.INFER)
@@ -565,13 +566,13 @@ def make_feature_engineering_fn(features):
 
 def get_estimator(args, output_dir, features, stats, target_vocab_size):
   # Check layers used for dnn models.
-  if is_dnn_model(args.model_type) and not args.hidden_layer_sizes:
+  if is_dnn_model(args.model) and not args.hidden_layer_sizes:
     raise ValueError('--hidden-layer-size* must be used with DNN models')
-  if is_linear_model(args.model_type) and args.hidden_layer_sizes:
+  if is_linear_model(args.model) and args.hidden_layer_sizes:
     raise ValueError('--hidden-layer-size* cannot be used with linear models')
 
   # Build tf.learn features
-  feature_columns = build_feature_columns(features, stats, args.model_type)
+  feature_columns = build_feature_columns(features, stats, args.model)
   feature_engineering_fn = make_feature_engineering_fn(features)
 
   # Set how often to run checkpointing in terms of time.
@@ -579,7 +580,7 @@ def get_estimator(args, output_dir, features, stats, target_vocab_size):
       save_checkpoints_secs=args.save_checkpoints_secs)
 
   train_dir = os.path.join(output_dir, 'train')
-  if args.model_type == 'dnn_regression':
+  if args.model == 'dnn_regression':
     estimator = tf.contrib.learn.DNNRegressor(
         feature_columns=feature_columns,
         hidden_units=args.hidden_layer_sizes,
@@ -588,7 +589,7 @@ def get_estimator(args, output_dir, features, stats, target_vocab_size):
         optimizer=tf.train.AdamOptimizer(
             args.learning_rate, epsilon=args.epsilon),
         feature_engineering_fn=feature_engineering_fn)
-  elif args.model_type == 'linear_regression':
+  elif args.model == 'linear_regression':
     estimator = tf.contrib.learn.LinearRegressor(
         feature_columns=feature_columns,
         config=config,
@@ -598,7 +599,7 @@ def get_estimator(args, output_dir, features, stats, target_vocab_size):
             l1_regularization_strength=args.l1_regularization,
             l2_regularization_strength=args.l2_regularization),
         feature_engineering_fn=feature_engineering_fn)
-  elif args.model_type == 'dnn_classification':
+  elif args.model == 'dnn_classification':
     estimator = tf.contrib.learn.DNNClassifier(
         feature_columns=feature_columns,
         hidden_units=args.hidden_layer_sizes,
@@ -608,7 +609,7 @@ def get_estimator(args, output_dir, features, stats, target_vocab_size):
         optimizer=tf.train.AdamOptimizer(
             args.learning_rate, epsilon=args.epsilon),
         feature_engineering_fn=feature_engineering_fn)
-  elif args.model_type == 'linear_classification':
+  elif args.model == 'linear_classification':
     estimator = tf.contrib.learn.LinearClassifier(
         feature_columns=feature_columns,
         n_classes=target_vocab_size,
@@ -635,7 +636,7 @@ def read_vocab(args, column_name):
   Returns:
     List of vocab words or [] if the vocab file is not found.
   """
-  vocab_path = os.path.join(args.output_dir_from_analysis_step,
+  vocab_path = os.path.join(args.analysis,
                             feature_transforms.VOCAB_ANALYSIS_FILE % column_name)
 
   if not file_io.file_exists(vocab_path):
@@ -671,11 +672,11 @@ def get_experiment_fn(args):
 
   def get_experiment(output_dir):
     # Read schema, input features, and transforms.
-    schema_path_with_target = os.path.join(args.output_dir_from_analysis_step,
+    schema_path_with_target = os.path.join(args.analysis,
                                            feature_transforms.SCHEMA_FILE)
-    features_path = os.path.join(args.output_dir_from_analysis_step,
+    features_path = os.path.join(args.analysis,
                                  feature_transforms.FEATURES_FILE)
-    stats_path = os.path.join(args.output_dir_from_analysis_step,
+    stats_path = os.path.join(args.analysis,
                               feature_transforms.STATS_FILE)
 
     schema = read_json_file(schema_path_with_target)
@@ -721,7 +722,7 @@ def get_experiment_fn(args):
         stats=stats)
 
     # Build readers for training.
-    if args.run_transforms:
+    if args.transform:
       if any(v['transform'] == feature_transforms.IMAGE_TRANSFORM
              for k, v in six.iteritems(features)):
         raise ValueError('"image_to_vec" transform requires transformation step. ' +
@@ -731,10 +732,10 @@ def get_experiment_fn(args):
           schema=schema,
           features=features,
           stats=stats,
-          analysis_output_dir=args.output_dir_from_analysis_step,
-          raw_data_file_pattern=args.train_data_paths,
+          analysis_output_dir=args.analysis,
+          raw_data_file_pattern=args.train,
           training_batch_size=args.train_batch_size,
-          num_epochs=args.num_epochs,
+          num_epochs=args.max_epochs,
           randomize_input=True,
           min_after_dequeue=10,
           reader_num_threads=multiprocessing.cpu_count())
@@ -742,8 +743,8 @@ def get_experiment_fn(args):
           schema=schema,
           features=features,
           stats=stats,
-          analysis_output_dir=args.output_dir_from_analysis_step,
-          raw_data_file_pattern=args.eval_data_paths,
+          analysis_output_dir=args.analysis,
+          raw_data_file_pattern=args.eval,
           training_batch_size=args.eval_batch_size,
           num_epochs=1,
           randomize_input=False,
@@ -752,18 +753,18 @@ def get_experiment_fn(args):
       input_reader_for_train = feature_transforms.build_tfexample_transfored_training_input_fn(
           schema=schema,
           features=features,
-          analysis_output_dir=args.output_dir_from_analysis_step,
-          raw_data_file_pattern=args.train_data_paths,
+          analysis_output_dir=args.analysis,
+          raw_data_file_pattern=args.train,
           training_batch_size=args.train_batch_size,
-          num_epochs=args.num_epochs,
+          num_epochs=args.max_epochs,
           randomize_input=True,
           min_after_dequeue=10,
           reader_num_threads=multiprocessing.cpu_count())
       input_reader_for_eval = feature_transforms.build_tfexample_transfored_training_input_fn(
           schema=schema,
           features=features,
-          analysis_output_dir=args.output_dir_from_analysis_step,
-          raw_data_file_pattern=args.eval_data_paths,
+          analysis_output_dir=args.analysis,
+          raw_data_file_pattern=args.eval,
           training_batch_size=args.eval_batch_size,
           num_epochs=1,
           randomize_input=False,

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
@@ -88,7 +88,7 @@ class DatalabParser():
     self.full_parser.add_argument('--job-dir', type=str, required=True)
     self.full_parser.add_argument(
         '--analysis', type=str, required=True,
-        metavar='ANALYSIS_OUTPUT_FOLDER',
+        metavar='ANALYSIS_OUTPUT_DIR',
         help=('Output folder of analysis. Should contain the schema, stats, and '
               'vocab files. Path must be on GCS if running cloud training.'))
     self.full_parser.add_argument(

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/transform.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/transform.py
@@ -86,7 +86,7 @@ def parse_arguments(argv):
 
   parser.add_argument(
       '--analysis',
-      metavar='ANALYSIS_OUTPUT_FOLDER',
+      metavar='ANALYSIS_OUTPUT_DIR',
       required=True,
       help='The output folder of analyze')
 
@@ -98,7 +98,7 @@ def parse_arguments(argv):
 
   parser.add_argument(
       '--output',
-      metavar='FOLDER',
+      metavar='DIR',
       default=None,
       required=True,
       help=('Google Cloud Storage or Local directory in which '

--- a/solutionbox/code_free_ml/test_mltoolbox/test_analyze.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_analyze.py
@@ -494,10 +494,10 @@ class TestOneSourceColumnManyFeatures(unittest.TestCase):
                     'img': {'transform': 'image_to_vec'}}, indent=2))
 
       cmd = ['python %s/analyze.py' % CODE_PATH,
-             '--output-dir=' + output_folder,
-             '--csv-file-pattern=' + input_data_path,
-             '--csv-schema-file=' + input_schema_path,
-             '--features-file=' + input_feature_path]
+             '--output=' + output_folder,
+             '--csv=' + input_data_path,
+             '--schema=' + input_schema_path,
+             '--features=' + input_feature_path]
       subprocess.check_call(' '.join(cmd), shell=True)
 
       self.assertTrue(os.path.isfile(os.path.join(output_folder, 'vocab_cat.csv')))

--- a/solutionbox/code_free_ml/test_mltoolbox/test_cloud_workflow.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_cloud_workflow.py
@@ -191,10 +191,10 @@ class TestCloudServices(unittest.TestCase):
 
     cmd = ['python %s' % os.path.join(CODE_PATH, 'analyze.py'),
            '--cloud' if cloud else '',
-           '--output-dir=' + self._analysis_output,
-           '--csv-file-pattern=' + self._csv_train_filename,
-           '--csv-schema-file=' + self._schema_filename,
-           '--features-file=' + self._features_filename]
+           '--output=' + self._analysis_output,
+           '--csv=' + self._csv_train_filename,
+           '--schema=' + self._schema_filename,
+           '--features=' + self._features_filename]
 
     self._logger.debug('Running subprocess: %s \n\n' % ' '.join(cmd))
     subprocess.check_call(' '.join(cmd), shell=True)
@@ -217,10 +217,10 @@ class TestCloudServices(unittest.TestCase):
                     '--num-workers=3']
 
     cmd = ['python %s' % os.path.join(CODE_PATH, 'transform.py'),
-           '--csv-file-pattern=' + self._csv_train_filename,
-           '--output-dir-from-analysis-step=' + self._analysis_output,
-           '--output-filename-prefix=features_train',
-           '--output-dir=' + self._transform_output,
+           '--csv=' + self._csv_train_filename,
+           '--analysis=' + self._analysis_output,
+           '--prefix=features_train',
+           '--output=' + self._transform_output,
            '--shuffle'] + extra_args
 
     self._logger.debug('Running subprocess: %s \n\n' % ' '.join(cmd))
@@ -228,10 +228,10 @@ class TestCloudServices(unittest.TestCase):
 
     # Don't wate time running a 2nd DF job, run it locally.
     cmd = ['python %s' % os.path.join(CODE_PATH, 'transform.py'),
-           '--csv-file-pattern=' + self._csv_eval_filename,
-           '--output-dir-from-analysis-step=' + self._analysis_output,
-           '--output-filename-prefix=features_eval',
-           '--output-dir=' + self._transform_output]
+           '--csv=' + self._csv_eval_filename,
+           '--analysis=' + self._analysis_output,
+           '--prefix=features_eval',
+           '--output=' + self._transform_output]
 
     self._logger.debug('Running subprocess: %s \n\n' % ' '.join(cmd))
     subprocess.check_call(' '.join(cmd), shell=True)
@@ -261,10 +261,10 @@ class TestCloudServices(unittest.TestCase):
         '--job-dir=' + self._train_output,
         '--package-path=' + os.path.join(CODE_PATH, 'trainer'),
         '--',
-        '--train-data-paths=' + os.path.join(self._transform_output, 'features_train*'),
-        '--eval-data-paths=' + os.path.join(self._transform_output, 'features_eval*'),
-        '--output-dir-from-analysis-step=' + self._analysis_output,
-        '--model-type=linear_regression',
+        '--train=' + os.path.join(self._transform_output, 'features_train*'),
+        '--eval=' + os.path.join(self._transform_output, 'features_eval*'),
+        '--analysis=' + self._analysis_output,
+        '--model=linear_regression',
         '--train-batch-size=10',
         '--eval-batch-size=10',
         '--max-steps=' + str(self._max_steps)]

--- a/solutionbox/code_free_ml/test_mltoolbox/test_training.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_training.py
@@ -87,10 +87,10 @@ class TestSpecialCharacters(unittest.TestCase):
 
       # Run analysis and check the output vocabs are correctly encoded in csv
       cmd = ['python %s' % os.path.join(CODE_PATH, 'analyze.py'),
-             '--output-dir=' + os.path.join(output_dir, 'analysis'),
-             '--csv-file-pattern=' + os.path.join(output_dir, 'data.csv'),
-             '--csv-schema-file=' + os.path.join(output_dir, 'schema.json'),
-             '--features-file=' + os.path.join(output_dir, 'features.json')]
+             '--output=' + os.path.join(output_dir, 'analysis'),
+             '--csv=' + os.path.join(output_dir, 'data.csv'),
+             '--schema=' + os.path.join(output_dir, 'schema.json'),
+             '--features=' + os.path.join(output_dir, 'features.json')]
       subprocess.check_call(' '.join(cmd), shell=True)
 
       df_vocab_cat_expected = pd.DataFrame(
@@ -128,10 +128,10 @@ class TestSpecialCharacters(unittest.TestCase):
 
       # Run transform, and check there are no reported errors.
       cmd = ['python %s' % os.path.join(CODE_PATH, 'transform.py'),
-             '--csv-file-pattern=' + os.path.join(output_dir, 'data.csv'),
-             '--output-dir-from-analysis-step=' + os.path.join(output_dir, 'analysis'),
-             '--output-filename-prefix=features_train',
-             '--output-dir=' + os.path.join(output_dir, 'transform')]
+             '--csv=' + os.path.join(output_dir, 'data.csv'),
+             '--analysis=' + os.path.join(output_dir, 'analysis'),
+             '--prefix=features_train',
+             '--output=' + os.path.join(output_dir, 'transform')]
       subprocess.check_call(' '.join(cmd), shell=True)
 
       error_files = glob.glob(os.path.join(output_dir, 'transform', 'error*'))
@@ -141,16 +141,16 @@ class TestSpecialCharacters(unittest.TestCase):
       # Run training
       cmd = ['cd %s && ' % CODE_PATH,
              'python -m trainer.task',
-             '--train-data-paths=' + os.path.join(output_dir, 'data.csv'),
-             '--eval-data-paths=' + os.path.join(output_dir, 'data.csv'),
+             '--train=' + os.path.join(output_dir, 'data.csv'),
+             '--eval=' + os.path.join(output_dir, 'data.csv'),
              '--job-dir=' + os.path.join(output_dir, 'training'),
-             '--output-dir-from-analysis-step=' + os.path.join(output_dir, 'analysis'),
-             '--model-type=linear_classification',
+             '--analysis=' + os.path.join(output_dir, 'analysis'),
+             '--model=linear_classification',
              '--train-batch-size=4',
              '--eval-batch-size=4',
              '--max-steps=500',
              '--learning-rate=1.0',
-             '--run-transforms']
+             '--transform']
       subprocess.check_call(' '.join(cmd), shell=True)
 
       result = run_exported_model(
@@ -191,24 +191,24 @@ class TestMultipleFeatures(unittest.TestCase):
                                    ''.join(data))
 
       cmd = ['python %s' % os.path.join(CODE_PATH, 'analyze.py'),
-             '--output-dir=' + os.path.join(output_dir, 'analysis'),
-             '--csv-file-pattern=' + os.path.join(output_dir, 'data.csv'),
-             '--csv-schema-file=' + os.path.join(output_dir, 'schema.json'),
-             '--features-file=' + os.path.join(output_dir, 'features.json')]
+             '--output=' + os.path.join(output_dir, 'analysis'),
+             '--csv=' + os.path.join(output_dir, 'data.csv'),
+             '--schema=' + os.path.join(output_dir, 'schema.json'),
+             '--features=' + os.path.join(output_dir, 'features.json')]
       subprocess.check_call(' '.join(cmd), shell=True)
 
       cmd = ['cd %s && ' % CODE_PATH,
              'python -m trainer.task',
-             '--train-data-paths=' + os.path.join(output_dir, 'data.csv'),
-             '--eval-data-paths=' + os.path.join(output_dir, 'data.csv'),
+             '--train=' + os.path.join(output_dir, 'data.csv'),
+             '--eval=' + os.path.join(output_dir, 'data.csv'),
              '--job-dir=' + os.path.join(output_dir, 'training'),
-             '--output-dir-from-analysis-step=' + os.path.join(output_dir, 'analysis'),
-             '--model-type=linear_regression',
+             '--analysis=' + os.path.join(output_dir, 'analysis'),
+             '--model=linear_regression',
              '--train-batch-size=4',
              '--eval-batch-size=4',
              '--max-steps=200',
              '--learning-rate=0.1',
-             '--run-transforms']
+             '--transform']
 
       subprocess.check_call(' '.join(cmd), shell=True)
 
@@ -247,17 +247,17 @@ class TestMultipleFeatures(unittest.TestCase):
                                    ''.join(data))
 
       cmd = ['python %s' % os.path.join(CODE_PATH, 'analyze.py'),
-             '--output-dir=' + os.path.join(output_dir, 'analysis'),
-             '--csv-file-pattern=' + os.path.join(output_dir, 'data.csv'),
-             '--csv-schema-file=' + os.path.join(output_dir, 'schema.json'),
-             '--features-file=' + os.path.join(output_dir, 'features.json')]
+             '--output=' + os.path.join(output_dir, 'analysis'),
+             '--csv=' + os.path.join(output_dir, 'data.csv'),
+             '--schema=' + os.path.join(output_dir, 'schema.json'),
+             '--features=' + os.path.join(output_dir, 'features.json')]
       subprocess.check_call(' '.join(cmd), shell=True)
 
       cmd = ['python %s' % os.path.join(CODE_PATH, 'transform.py'),
-             '--output-dir=' + os.path.join(output_dir, 'transform'),
-             '--csv-file-pattern=' + os.path.join(output_dir, 'data.csv'),
-             '--output-dir-from-analysis-step=' + os.path.join(output_dir, 'analysis'),
-             '--output-filename-prefix=features']
+             '--output=' + os.path.join(output_dir, 'transform'),
+             '--csv=' + os.path.join(output_dir, 'data.csv'),
+             '--analysis=' + os.path.join(output_dir, 'analysis'),
+             '--prefix=features']
       subprocess.check_call(' '.join(cmd), shell=True)
 
       # Check tf.example file has the expected features
@@ -279,16 +279,16 @@ class TestMultipleFeatures(unittest.TestCase):
 
       cmd = ['cd %s && ' % CODE_PATH,
              'python -m trainer.task',
-             '--train-data-paths=' + os.path.join(output_dir, 'data.csv'),
-             '--eval-data-paths=' + os.path.join(output_dir, 'data.csv'),
+             '--train=' + os.path.join(output_dir, 'data.csv'),
+             '--eval=' + os.path.join(output_dir, 'data.csv'),
              '--job-dir=' + os.path.join(output_dir, 'training'),
-             '--output-dir-from-analysis-step=' + os.path.join(output_dir, 'analysis'),
-             '--model-type=linear_regression',
+             '--analysis=' + os.path.join(output_dir, 'analysis'),
+             '--model=linear_regression',
              '--train-batch-size=4',
              '--eval-batch-size=4',
              '--max-steps=200',
              '--learning-rate=0.1',
-             '--run-transforms']
+             '--transform']
       subprocess.check_call(' '.join(cmd), shell=True)
 
       result = run_exported_model(
@@ -322,24 +322,24 @@ class TestOptionalKeys(unittest.TestCase):
                                    ''.join(data))
 
       cmd = ['python %s' % os.path.join(CODE_PATH, 'analyze.py'),
-             '--output-dir=' + os.path.join(output_dir, 'analysis'),
-             '--csv-file-pattern=' + os.path.join(output_dir, 'data.csv'),
-             '--csv-schema-file=' + os.path.join(output_dir, 'schema.json'),
-             '--features-file=' + os.path.join(output_dir, 'features.json')]
+             '--output=' + os.path.join(output_dir, 'analysis'),
+             '--csv=' + os.path.join(output_dir, 'data.csv'),
+             '--schema=' + os.path.join(output_dir, 'schema.json'),
+             '--features=' + os.path.join(output_dir, 'features.json')]
       subprocess.check_call(' '.join(cmd), shell=True)
 
       cmd = ['cd %s && ' % CODE_PATH,
              'python -m trainer.task',
-             '--train-data-paths=' + os.path.join(output_dir, 'data.csv'),
-             '--eval-data-paths=' + os.path.join(output_dir, 'data.csv'),
+             '--train=' + os.path.join(output_dir, 'data.csv'),
+             '--eval=' + os.path.join(output_dir, 'data.csv'),
              '--job-dir=' + os.path.join(output_dir, 'training'),
-             '--output-dir-from-analysis-step=' + os.path.join(output_dir, 'analysis'),
-             '--model-type=linear_regression',
+             '--analysis=' + os.path.join(output_dir, 'analysis'),
+             '--model=linear_regression',
              '--train-batch-size=4',
              '--eval-batch-size=4',
              '--max-steps=2000',
              '--learning-rate=0.1',
-             '--run-transforms']
+             '--transform']
 
       subprocess.check_call(' '.join(cmd), shell=True)
 
@@ -375,23 +375,23 @@ class TestOptionalKeys(unittest.TestCase):
                                    ''.join(data))
 
       cmd = ['python %s' % os.path.join(CODE_PATH, 'analyze.py'),
-             '--output-dir=' + os.path.join(output_dir, 'analysis'),
-             '--csv-file-pattern=' + os.path.join(output_dir, 'data.csv'),
-             '--csv-schema-file=' + os.path.join(output_dir, 'schema.json'),
-             '--features-file=' + os.path.join(output_dir, 'features.json')]
+             '--output=' + os.path.join(output_dir, 'analysis'),
+             '--csv=' + os.path.join(output_dir, 'data.csv'),
+             '--schema=' + os.path.join(output_dir, 'schema.json'),
+             '--features=' + os.path.join(output_dir, 'features.json')]
       subprocess.check_call(' '.join(cmd), shell=True)
 
       cmd = ['cd %s && ' % CODE_PATH,
              'python -m trainer.task',
-             '--train-data-paths=' + os.path.join(output_dir, 'data.csv'),
-             '--eval-data-paths=' + os.path.join(output_dir, 'data.csv'),
+             '--train=' + os.path.join(output_dir, 'data.csv'),
+             '--eval=' + os.path.join(output_dir, 'data.csv'),
              '--job-dir=' + os.path.join(output_dir, 'training'),
-             '--output-dir-from-analysis-step=' + os.path.join(output_dir, 'analysis'),
-             '--model-type=linear_regression',
+             '--analysis=' + os.path.join(output_dir, 'analysis'),
+             '--model=linear_regression',
              '--train-batch-size=4',
              '--eval-batch-size=4',
              '--max-steps=2000',
-             '--run-transforms']
+             '--transform']
 
       subprocess.check_call(' '.join(cmd), shell=True)
 
@@ -612,29 +612,29 @@ class TestTrainer(unittest.TestCase):
     self.make_csv_data(self._csv_predict_filename, 100, problem_type, False, with_image)
 
     cmd = ['python %s' % os.path.join(CODE_PATH, 'analyze.py'),
-           '--output-dir=' + self._analysis_output,
-           '--csv-file-pattern=' + self._csv_train_filename,
-           '--csv-schema-file=' + self._schema_filename,
-           '--features-file=' + self._features_filename]
+           '--output=' + self._analysis_output,
+           '--csv=' + self._csv_train_filename,
+           '--schema=' + self._schema_filename,
+           '--features=' + self._features_filename]
 
     subprocess.check_call(' '.join(cmd), shell=True)
 
   def _run_transform(self):
     cmd = ['python %s' % os.path.join(CODE_PATH, 'transform.py'),
-           '--csv-file-pattern=' + self._csv_train_filename,
-           '--output-dir-from-analysis-step=' + self._analysis_output,
-           '--output-filename-prefix=features_train',
-           '--output-dir=' + self._transform_output,
+           '--csv=' + self._csv_train_filename,
+           '--analysis=' + self._analysis_output,
+           '--prefix=features_train',
+           '--output=' + self._transform_output,
            '--shuffle']
 
     self._logger.debug('Running subprocess: %s \n\n' % ' '.join(cmd))
     subprocess.check_call(' '.join(cmd), shell=True)
 
     cmd = ['python %s' % os.path.join(CODE_PATH, 'transform.py'),
-           '--csv-file-pattern=' + self._csv_eval_filename,
-           '--output-dir-from-analysis-step=' + self._analysis_output,
-           '--output-filename-prefix=features_eval',
-           '--output-dir=' + self._transform_output]
+           '--csv=' + self._csv_eval_filename,
+           '--analysis=' + self._analysis_output,
+           '--prefix=features_eval',
+           '--output=' + self._transform_output]
 
     self._logger.debug('Running subprocess: %s \n\n' % ' '.join(cmd))
     subprocess.check_call(' '.join(cmd), shell=True)
@@ -649,11 +649,11 @@ class TestTrainer(unittest.TestCase):
     """
     cmd = ['cd %s && ' % CODE_PATH,
            'python -m trainer.task',
-           '--train-data-paths=' + os.path.join(self._transform_output, 'features_train*'),
-           '--eval-data-paths=' + os.path.join(self._transform_output, 'features_eval*'),
+           '--train=' + os.path.join(self._transform_output, 'features_train*'),
+           '--eval=' + os.path.join(self._transform_output, 'features_eval*'),
            '--job-dir=' + self._train_output,
-           '--output-dir-from-analysis-step=' + self._analysis_output,
-           '--model-type=%s_%s' % (model_type, problem_type),
+           '--analysis=' + self._analysis_output,
+           '--model=%s_%s' % (model_type, problem_type),
            '--train-batch-size=100',
            '--eval-batch-size=50',
            '--max-steps=' + str(self._max_steps)] + extra_args
@@ -671,15 +671,15 @@ class TestTrainer(unittest.TestCase):
     """
     cmd = ['cd %s && ' % CODE_PATH,
            'python -m trainer.task',
-           '--train-data-paths=' + self._csv_train_filename,
-           '--eval-data-paths=' + self._csv_eval_filename,
+           '--train=' + self._csv_train_filename,
+           '--eval=' + self._csv_eval_filename,
            '--job-dir=' + self._train_output,
-           '--output-dir-from-analysis-step=' + self._analysis_output,
-           '--model-type=%s_%s' % (model_type, problem_type),
+           '--analysis=' + self._analysis_output,
+           '--model=%s_%s' % (model_type, problem_type),
            '--train-batch-size=100',
            '--eval-batch-size=50',
            '--max-steps=' + str(self._max_steps),
-           '--run-transforms'] + extra_args
+           '--transform'] + extra_args
 
     self._logger.debug('Running subprocess: %s \n\n' % ' '.join(cmd))
     subprocess.check_call(' '.join(cmd), shell=True)

--- a/solutionbox/code_free_ml/test_mltoolbox/test_transform.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_transform.py
@@ -68,10 +68,10 @@ class TestTransformRawData(unittest.TestCase):
     features_file = os.path.join(cls.source_dir, 'features.json')
     file_io.write_string_to_file(features_file, json.dumps(features))
     cmd = ['python ' + os.path.join(CODE_PATH, 'analyze.py'),
-           '--output-dir=' + cls.analysis_dir,
-           '--csv-file-pattern=' + cls.csv_input_filepath,
-           '--csv-schema-file=' + schema_file,
-           '--features-file=' + features_file]
+           '--output=' + cls.analysis_dir,
+           '--csv=' + cls.csv_input_filepath,
+           '--schema=' + schema_file,
+           '--features=' + features_file]
     subprocess.check_call(' '.join(cmd), shell=True)
 
     # Setup a temp GCS bucket.
@@ -87,10 +87,10 @@ class TestTransformRawData(unittest.TestCase):
     """Test transfrom from local csv files."""
 
     cmd = ['python ' + os.path.join(CODE_PATH, 'transform.py'),
-           '--csv-file-pattern=' + self.csv_input_filepath,
-           '--output-dir-from-analysis-step=' + self.analysis_dir,
-           '--output-filename-prefix=features',
-           '--output-dir=' + self.output_dir]
+           '--csv=' + self.csv_input_filepath,
+           '--analysis=' + self.analysis_dir,
+           '--prefix=features',
+           '--output=' + self.output_dir]
     print('cmd ', ' '.join(cmd))
     subprocess.check_call(' '.join(cmd), shell=True)
 
@@ -146,11 +146,11 @@ class TestTransformRawData(unittest.TestCase):
       table.insert(data=data)
 
       cmd = ['python ' + os.path.join(CODE_PATH, 'transform.py'),
-             '--bigquery-table=%s.%s.%s' % (project_id, dataset_name, table_name),
-             '--output-dir-from-analysis-step=' + self.analysis_dir,
-             '--output-filename-prefix=features',
+             '--bigquery=%s.%s.%s' % (project_id, dataset_name, table_name),
+             '--analysis=' + self.analysis_dir,
+             '--prefix=features',
              '--project-id=' + project_id,
-             '--output-dir=' + self.output_dir]
+             '--output=' + self.output_dir]
       print('cmd ', ' '.join(cmd))
       subprocess.check_call(' '.join(cmd), shell=True)
 


### PR DESCRIPTION
These name changes are for both the non-magic and magic code unless said otherwise.


output_dir -> output
csv_file_pattern -> csv
csv_schema -> schema
(non magic) bigquery-table -> bigquery
output_dir_from_analysis_step -> analysis
output_filename_prefix -> prefix
model_type -> model
(magic) transformed_file_pattern -> transformed
