### PR TITLE
make pydatalab use tf 1.2.0

### DIFF
--- a/google/datalab/contrib/mltoolbox/_local_predict.py
+++ b/google/datalab/contrib/mltoolbox/_local_predict.py
@@ -88,7 +88,7 @@ def _download_images(data, img_cols):
   for d in data:
     for img_col in img_cols:
       if d.get(img_col, None):
-        with file_io.FileIO(d[img_col], 'r') as fi:
+        with file_io.FileIO(d[img_col], 'rb') as fi:
           im = Image.open(fi)
         images[img_col].append(im)
       else:

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/setup.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/setup.py
@@ -27,7 +27,7 @@ setup(
   long_description="""
   """,
   install_requires=[
-    'tensorflow==1.0.1',
+    'tensorflow==1.2.0',
     'protobuf==3.1.0',
     'pillow==3.4.1',  # ML Engine does not have PIL installed
   ],

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/feature_transforms.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/feature_transforms.py
@@ -71,7 +71,7 @@ Image.new('RGB', (16, 16)).save(_img_buf, 'jpeg')
 IMAGE_DEFAULT_STRING = base64.urlsafe_b64encode(_img_buf.getvalue())
 
 IMAGE_BOTTLENECK_TENSOR_SIZE = 2048
-
+IMAGE_HIDDEN_TENSOR_SIZE = int(IMAGE_BOTTLENECK_TENSOR_SIZE / 4)
 
 # ------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------
@@ -498,9 +498,16 @@ def csv_header_and_defaults(features, schema, stats, keep_target):
 
   return csv_header, record_defaults
 
+def build_csv_serving_tensors_for_transform_step(
+    analysis_path, features, schema, stats, keep_target):
+  """Builds a serving function starting from raw csv.
 
-def build_csv_serving_tensors(analysis_path, features, schema, stats, keep_target):
-  """Returns a placeholder tensor and transformed tensors."""
+  This should only be used by transform.py (the transform step), and the 
+
+  For image columns, the image should be a base64 string encoding the image.
+  The output of this function will transform that image to a 2048 long vector
+  using the inception model.
+  """
 
   csv_header, record_defaults = csv_header_and_defaults(features, schema, stats, keep_target)
 
@@ -521,7 +528,30 @@ def build_csv_serving_tensors(analysis_path, features, schema, stats, keep_targe
       transformed_features[k] = v
 
   return input_fn_utils.InputFnOps(
-      transformed_features, None, {"csv_example": placeholder})
+      transformed_features, None, {"csv_example": placeholder})  
+
+def build_csv_serving_tensors_for_training_step(analysis_path, features, schema, stats, keep_target):
+  """Builds a serving function starting from raw csv, used at model export time.
+
+  For image columns, the image should be a base64 string encoding the image.
+  The output of this function will transform that image to a 2048 long vector
+  using the inception model and then a fully connected net is attached to
+  the 2048 long image embedding.
+  """
+
+  transformed_features, _, placeholder_dict = build_csv_serving_tensors_for_transform_step(
+      analysis_path=analysis_path,
+      features=features,
+      schema=schema,
+      stats=stats,
+      keep_target=keep_target)
+
+  transformed_features = image_feature_engineering(
+      features=features,
+      feature_tensors_dict=transformed_features)
+
+  return input_fn_utils.InputFnOps(
+      transformed_features, None, placeholder_dict)
 
 
 def build_csv_transforming_training_input_fn(schema,
@@ -611,6 +641,9 @@ def build_csv_transforming_training_input_fn(schema,
         transformed_features[k] = tf.expand_dims(v, -1)
       else:
         transformed_features[k] = v
+
+    # image_feature_engineering does not need to be called as images are not
+    # supported in raw csv for training. 
 
     # Remove the target tensor, and return it directly
     target_name = get_target_name(features)
@@ -716,6 +749,10 @@ def build_tfexample_transfored_training_input_fn(schema,
         # Sparse tensor
         transformed_features[k] = v
 
+    transformed_features = image_feature_engineering(
+        features=features,
+        feature_tensors_dict=transformed_features)
+
     # Remove the target tensor, and return it directly
     target_name = get_target_name(features)
     if not target_name or target_name not in transformed_features:
@@ -726,6 +763,28 @@ def build_tfexample_transfored_training_input_fn(schema,
     return transformed_features, transformed_target
 
   return transformed_training_input_fn
+
+
+def image_feature_engineering(features, feature_tensors_dict):
+  """Add a hidden layer on image features.
+
+  Args:
+    features: features dict
+    feature_tensors_dict: dict of feature-name: tensor
+  """
+  engineered_features = {}
+  for name, feature_tensor in six.iteritems(feature_tensors_dict):
+    if name in features and features[name]['transform'] == IMAGE_TRANSFORM:
+      bottleneck_with_no_gradient = tf.stop_gradient(feature_tensor)
+      with tf.name_scope(name, 'Wx_plus_b'):
+        hidden = tf.contrib.layers.fully_connected(
+            bottleneck_with_no_gradient,
+            IMAGE_HIDDEN_TENSOR_SIZE)
+        engineered_features[name] = hidden
+    else:
+      engineered_features[name] = feature_tensor
+  return engineered_features
+
 
 
 def get_target_name(features):

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/feature_transforms.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/feature_transforms.py
@@ -79,6 +79,7 @@ IMAGE_HIDDEN_TENSOR_SIZE = int(IMAGE_BOTTLENECK_TENSOR_SIZE / 4)
 # ------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------
 
+
 def _scale(x, min_x_value, max_x_value, output_min, output_max):
   """Scale a column to [output_min, output_max].
 
@@ -498,11 +499,15 @@ def csv_header_and_defaults(features, schema, stats, keep_target):
 
   return csv_header, record_defaults
 
-def build_csv_serving_tensors_for_transform_step(
-    analysis_path, features, schema, stats, keep_target):
+
+def build_csv_serving_tensors_for_transform_step(analysis_path,
+                                                 features,
+                                                 schema,
+                                                 stats,
+                                                 keep_target):
   """Builds a serving function starting from raw csv.
 
-  This should only be used by transform.py (the transform step), and the 
+  This should only be used by transform.py (the transform step), and the
 
   For image columns, the image should be a base64 string encoding the image.
   The output of this function will transform that image to a 2048 long vector
@@ -528,9 +533,14 @@ def build_csv_serving_tensors_for_transform_step(
       transformed_features[k] = v
 
   return input_fn_utils.InputFnOps(
-      transformed_features, None, {"csv_example": placeholder})  
+      transformed_features, None, {"csv_example": placeholder})
 
-def build_csv_serving_tensors_for_training_step(analysis_path, features, schema, stats, keep_target):
+
+def build_csv_serving_tensors_for_training_step(analysis_path,
+                                                features,
+                                                schema,
+                                                stats,
+                                                keep_target):
   """Builds a serving function starting from raw csv, used at model export time.
 
   For image columns, the image should be a base64 string encoding the image.
@@ -643,7 +653,7 @@ def build_csv_transforming_training_input_fn(schema,
         transformed_features[k] = v
 
     # image_feature_engineering does not need to be called as images are not
-    # supported in raw csv for training. 
+    # supported in raw csv for training.
 
     # Remove the target tensor, and return it directly
     target_name = get_target_name(features)
@@ -784,7 +794,6 @@ def image_feature_engineering(features, feature_tensors_dict):
     else:
       engineered_features[name] = feature_tensor
   return engineered_features
-
 
 
 def get_target_name(features):

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/feature_transforms.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/feature_transforms.py
@@ -125,7 +125,7 @@ def _string_to_int(x, vocab):
     Returns:
       a Tensor/SparseTensor of indexes (int) of the same shape as x.
     """
-    table = lookup.string_to_index_table_from_tensor(
+    table = lookup.index_table_from_tensor(
         vocab,
         default_value=len(vocab))
     return table.lookup(x)

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
@@ -432,68 +432,6 @@ def make_prediction_output_tensors(args, features, input_ops, model_fn_ops,
 
   return outputs
 
-def make_export_strategy_unused(
-        args,
-        keep_target,
-        assets_extra,
-        features,
-        schema,
-        stats):
-  """Makes prediction graph that takes json input.
-
-  Args:
-    args: command line args
-    keep_target: If ture, target column is returned in prediction graph. Target
-        column must also exist in input data
-    assets_extra: other fiels to copy to the output folder
-    job_dir: root job folder
-    features: features dict
-    schema: schema list
-    stats: stats dict
-  """
-  target_name = feature_transforms.get_target_name(features)
-  csv_header = [col['name'] for col in schema]
-  if not keep_target:
-    csv_header.remove(target_name)
-
-
-  def _serving_input_fn():
-    if keep_target:
-      input_ops = feature_transforms.build_csv_serving_tensors_for_training_step(
-          args.analysis, features, schema, stats, keep_target)
-    else:
-      input_ops = feature_transforms.build_csv_serving_tensors_for_training_step(
-          args.analysis, features, schema, stats, keep_target)
-    return input_ops
-
-  def export_fn(estimator, export_dir_base, checkpoint_path=None, eval_result=None):
-    export_result = estimator.export_savedmodel(
-          export_dir_base,
-          _serving_input_fn,
-          assets_extra=assets_extra,
-          as_text=False,
-          checkpoint_path=checkpoint_path)
-
-    saved_model_export_utils.garbage_collect_exports(export_dir_base, 5)
-    # save the last model to the model folder.
-    # export_dir_base = A/B/intermediate_models/
-    if keep_target:
-      final_dir = os.path.join(args.job_dir, 'evaluation_model')
-    else:
-      final_dir = os.path.join(args.job_dir, 'model')
-    if file_io.is_directory(final_dir):
-      file_io.delete_recursively(final_dir)
-    file_io.recursive_create_dir(final_dir)
-    recursive_copy(export_result, final_dir)
-    return export_result
-
-  if keep_target:
-    intermediate_dir = 'intermediate_evaluation_models'
-  else:
-    intermediate_dir = 'intermediate_prediction_models'
-  return export_strategy.ExportStrategy(intermediate_dir, export_fn)
-
-
 
 # This function is strongly based on
 # tensorflow/contrib/learn/python/learn/estimators/estimator.py:export_savedmodel()
@@ -676,16 +614,6 @@ def get_estimator(args, output_dir, features, stats, target_vocab_size):
     raise ValueError('bad --model-type value')
 
   return estimator
-
-
-def update_output_layer(estimator):
-    def _model_fn(features, labels, mode, params):
-        key = features.pop(KEY)
-        model_fn_ops = estimator.model_fn(
-           features=features, labels=labels, mode=mode, params=params)
-        model_fn_ops.predictions[KEY] = key
-        return model_fn_ops
-    return _model_fn
 
 
 def read_vocab(args, column_name):

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
@@ -35,6 +35,8 @@ from tensorflow.python.client import session as tf_session
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.lib.io import file_io
+from tensorflow.python.ops import resources
+from tensorflow.python.ops import lookup_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import data_flow_ops
 from tensorflow.python.ops import variables
@@ -498,16 +500,12 @@ def make_export_strategy(
           export_dir_base)
 
       with tf_session.Session('') as session:
-        variables.local_variables_initializer()
-        data_flow_ops.tables_initializer()
-        saver_for_restore = saver.Saver(
-            variables.global_variables(),
-            sharded=True)
+        saver_for_restore = saver.Saver(sharded=True)
         saver_for_restore.restore(session, checkpoint_path)
-
         init_op = control_flow_ops.group(
             variables.local_variables_initializer(),
-            data_flow_ops.tables_initializer())
+            resources.initialize_resources(resources.shared_resources()),
+            lookup_ops.tables_initializer())
 
         # Perform the export
         builder = saved_model_builder.SavedModelBuilder(export_dir)

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
@@ -626,6 +626,8 @@ def make_feature_engineering_fn(features):
       if name in features and features[name]['transform'] == feature_transforms.IMAGE_TRANSFORM:
         bottleneck_with_no_gradient = tf.stop_gradient(feature_tensor)
         with tf.name_scope(name, 'Wx_plus_b'):
+          print('1'*100)
+          print('in EF fun')
           hidden = layers.fully_connected(
               bottleneck_with_no_gradient,
               int(feature_transforms.IMAGE_BOTTLENECK_TENSOR_SIZE / 4))

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
@@ -35,7 +35,6 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.lib.io import file_io
 from tensorflow.python.ops import resources
-from tensorflow.python.ops import lookup_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.saved_model import builder as saved_model_builder
@@ -508,7 +507,7 @@ def make_export_strategy(
         init_op = control_flow_ops.group(
             variables.local_variables_initializer(),
             resources.initialize_resources(resources.shared_resources()),
-            lookup_ops.tables_initializer())
+            tf.tables_initializer())
 
         # Perform the export
         builder = saved_model_builder.SavedModelBuilder(export_dir)

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
@@ -25,7 +25,6 @@ import sys
 import six
 import tensorflow as tf
 
-from tensorflow.contrib import layers
 from tensorflow.contrib.framework.python.ops import variables as contrib_variables
 from tensorflow.contrib.learn.python.learn import export_strategy
 from tensorflow.contrib.learn.python.learn import learn_runner
@@ -38,7 +37,6 @@ from tensorflow.python.lib.io import file_io
 from tensorflow.python.ops import resources
 from tensorflow.python.ops import lookup_ops
 from tensorflow.python.ops import control_flow_ops
-from tensorflow.python.ops import data_flow_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.saved_model import builder as saved_model_builder
 from tensorflow.python.saved_model import signature_def_utils
@@ -500,7 +498,7 @@ def make_export_strategy(
           export_dir_base)
 
       if (model_fn_ops.scaffold is not None and
-          model_fn_ops.scaffold.saver is not None):
+         model_fn_ops.scaffold.saver is not None):
         saver_for_restore = model_fn_ops.scaffold.saver
       else:
         saver_for_restore = saver.Saver(sharded=True)

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/trainer/task.py
@@ -336,7 +336,7 @@ def build_feature_columns(features, stats, model_type):
     elif transform_name == feature_transforms.IMAGE_TRANSFORM:
       new_feature = tf.contrib.layers.real_valued_column(
           name,
-          dimension=feature_transforms.IMAGE_BOTTLENECK_TENSOR_SIZE)
+          dimension=feature_transforms.IMAGE_HIDDEN_TENSOR_SIZE)
     else:
       raise ValueError('Unknown transfrom %s' % transform_name)
 
@@ -432,7 +432,7 @@ def make_prediction_output_tensors(args, features, input_ops, model_fn_ops,
 
   return outputs
 
-def make_export_strategy(
+def make_export_strategy_unused(
         args,
         keep_target,
         assets_extra,
@@ -459,10 +459,10 @@ def make_export_strategy(
 
   def _serving_input_fn():
     if keep_target:
-      input_ops = feature_transforms.build_csv_serving_tensors(
+      input_ops = feature_transforms.build_csv_serving_tensors_for_training_step(
           args.analysis, features, schema, stats, keep_target)
     else:
-      input_ops = feature_transforms.build_csv_serving_tensors(
+      input_ops = feature_transforms.build_csv_serving_tensors_for_training_step(
           args.analysis, features, schema, stats, keep_target)
     return input_ops
 
@@ -498,7 +498,7 @@ def make_export_strategy(
 # This function is strongly based on
 # tensorflow/contrib/learn/python/learn/estimators/estimator.py:export_savedmodel()
 # The difference is we need to modify estimator's output layer.
-def make_export_strategy_old(
+def make_export_strategy(
         args,
         keep_target,
         assets_extra,
@@ -526,7 +526,7 @@ def make_export_strategy_old(
     with ops.Graph().as_default() as g:
       contrib_variables.create_global_step(g)
 
-      input_ops = feature_transforms.build_csv_serving_tensors(
+      input_ops = feature_transforms.build_csv_serving_tensors_for_training_step(
           args.analysis, features, schema, stats, keep_target)
       model_fn_ops = estimator._call_model_fn(input_ops.features,
                                               None,
@@ -561,11 +561,15 @@ def make_export_strategy_old(
       export_dir = saved_model_export_utils.get_timestamped_export_dir(
           export_dir_base)
 
-      with tf_session.Session('') as session:
+      if (model_fn_ops.scaffold is not None and
+          model_fn_ops.scaffold.saver is not None):
+        saver_for_restore = model_fn_ops.scaffold.saver
+      else:
         saver_for_restore = saver.Saver(sharded=True)
+
+      with tf_session.Session('') as session:
         saver_for_restore.restore(session, checkpoint_path)
         init_op = control_flow_ops.group(
-            variables.global_variables_initializer(),
             variables.local_variables_initializer(),
             resources.initialize_resources(resources.shared_resources()),
             lookup_ops.tables_initializer())
@@ -617,28 +621,6 @@ def make_export_strategy_old(
   return export_strategy.ExportStrategy(intermediate_dir, export_fn)
 
 
-def make_feature_engineering_fn(features):
-  """feature_engineering_fn for adding a hidden layer on image embeddings."""
-
-  def feature_engineering_fn(feature_tensors_dict, target):
-    engineered_features = {}
-    for name, feature_tensor in six.iteritems(feature_tensors_dict):
-      if name in features and features[name]['transform'] == feature_transforms.IMAGE_TRANSFORM:
-        bottleneck_with_no_gradient = tf.stop_gradient(feature_tensor)
-        with tf.name_scope(name, 'Wx_plus_b'):
-          print('1'*100)
-          print('in EF fun')
-          hidden = layers.fully_connected(
-              bottleneck_with_no_gradient,
-              int(feature_transforms.IMAGE_BOTTLENECK_TENSOR_SIZE / 4))
-          engineered_features[name] = hidden
-      else:
-        engineered_features[name] = feature_tensor
-    return engineered_features, target
-
-  return feature_engineering_fn
-
-
 def get_estimator(args, output_dir, features, stats, target_vocab_size):
   # Check layers used for dnn models.
   if is_dnn_model(args.model) and not args.hidden_layer_sizes:
@@ -648,7 +630,6 @@ def get_estimator(args, output_dir, features, stats, target_vocab_size):
 
   # Build tf.learn features
   feature_columns = build_feature_columns(features, stats, args.model)
-  feature_engineering_fn = make_feature_engineering_fn(features)
 
   # Set how often to run checkpointing in terms of time.
   config = tf.contrib.learn.RunConfig(
@@ -662,8 +643,7 @@ def get_estimator(args, output_dir, features, stats, target_vocab_size):
         config=config,
         model_dir=train_dir,
         optimizer=tf.train.AdamOptimizer(
-            args.learning_rate, epsilon=args.epsilon),
-        feature_engineering_fn=feature_engineering_fn)
+            args.learning_rate, epsilon=args.epsilon))
   elif args.model == 'linear_regression':
     estimator = tf.contrib.learn.LinearRegressor(
         feature_columns=feature_columns,
@@ -672,8 +652,7 @@ def get_estimator(args, output_dir, features, stats, target_vocab_size):
         optimizer=tf.train.FtrlOptimizer(
             args.learning_rate,
             l1_regularization_strength=args.l1_regularization,
-            l2_regularization_strength=args.l2_regularization),
-        feature_engineering_fn=feature_engineering_fn)
+            l2_regularization_strength=args.l2_regularization))
   elif args.model == 'dnn_classification':
     estimator = tf.contrib.learn.DNNClassifier(
         feature_columns=feature_columns,
@@ -682,8 +661,7 @@ def get_estimator(args, output_dir, features, stats, target_vocab_size):
         config=config,
         model_dir=train_dir,
         optimizer=tf.train.AdamOptimizer(
-            args.learning_rate, epsilon=args.epsilon),
-        feature_engineering_fn=feature_engineering_fn)
+            args.learning_rate, epsilon=args.epsilon))
   elif args.model == 'linear_classification':
     estimator = tf.contrib.learn.LinearClassifier(
         feature_columns=feature_columns,
@@ -693,8 +671,7 @@ def get_estimator(args, output_dir, features, stats, target_vocab_size):
         optimizer=tf.train.FtrlOptimizer(
             args.learning_rate,
             l1_regularization_strength=args.l1_regularization,
-            l2_regularization_strength=args.l2_regularization),
-        feature_engineering_fn=feature_engineering_fn)
+            l2_regularization_strength=args.l2_regularization))
   else:
     raise ValueError('bad --model-type value')
 

--- a/solutionbox/code_free_ml/mltoolbox/code_free_ml/transform.py
+++ b/solutionbox/code_free_ml/mltoolbox/code_free_ml/transform.py
@@ -284,7 +284,7 @@ class TransformFeaturesDoFn(beam.DoFn):
     # Build the transformation graph
     with g.as_default():
       transformed_features, _, placeholders = (
-          feature_transforms.build_csv_serving_tensors(
+          feature_transforms.build_csv_serving_tensors_for_transform_step(
               analysis_path=self._analysis_output_dir, 
               features=self._features, 
               schema=self._schema,

--- a/solutionbox/code_free_ml/test_mltoolbox/run_all.sh
+++ b/solutionbox/code_free_ml/test_mltoolbox/run_all.sh
@@ -2,15 +2,15 @@
 set -e
 
 echo '*** Running code_free_ml test_analyze.py ***'
-python test_analyze.py
+python test_analyze.py --verbose
 
 echo '*** Running code_free_ml test_feature_transforms.py ***'
-python test_feature_transforms.py
+python test_feature_transforms.py --verbose
 
 echo '*** Running code_free_ml test_transform.py ***'
-python test_transform.py
+python test_transform.py --verbose
 
 echo '*** Running code_free_ml test_training.py ***'
-python test_training.py
+python test_training.py --verbose
 
 echo 'Finished code_free_ml run_all.sh!'

--- a/solutionbox/code_free_ml/test_mltoolbox/test_feature_transforms.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_feature_transforms.py
@@ -49,7 +49,7 @@ class TestGraphBuilding(unittest.TestCase):
     stats = {'column_stats': {}}
     with tf.Graph().as_default():
       with tf.Session().as_default() as session:
-        outputs, labels, inputs = feature_transforms.build_csv_serving_tensors(
+        outputs, labels, inputs = feature_transforms.build_csv_serving_tensors_for_transform_step(
             analysis_path, features, schema, stats, keep_target=False)
         feed_inputs = {inputs['csv_example']: predict_data}
 

--- a/solutionbox/code_free_ml/test_mltoolbox/test_training.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_training.py
@@ -58,7 +58,7 @@ def run_exported_model(model_path, csv_data):
 class TestSpecialCharacters(unittest.TestCase):
   """Test special characters are supported."""
 
-  def testCommaQuote(self):
+  def xtestCommaQuote(self):
     """Test when csv input data has quotes and commas."""
     output_dir = tempfile.mkdtemp()
     try:
@@ -787,7 +787,7 @@ class TestTrainer(unittest.TestCase):
         problem_type=problem_type,
         model_type=model_type)
 
-  def xtestClassificationDNN(self):
+  def testClassificationDNN(self):
     self._logger.debug('\n\nTesting Classification DNN')
 
     problem_type = 'classification'

--- a/solutionbox/code_free_ml/test_mltoolbox/test_training.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_training.py
@@ -445,7 +445,7 @@ class TestTrainer(unittest.TestCase):
 
   def tearDown(self):
     self._logger.debug('TestTrainer: removing test dir ' + self._test_dir)
-    shutil.rmtree(self._test_dir)
+    #shutil.rmtree(self._test_dir)
 
   def make_image_files(self):
     img1_file = os.path.join(self._test_dir, 'img1.jpg')
@@ -787,7 +787,7 @@ class TestTrainer(unittest.TestCase):
         problem_type=problem_type,
         model_type=model_type)
 
-  def testClassificationDNN(self):
+  def xtestClassificationDNN(self):
     self._logger.debug('\n\nTesting Classification DNN')
 
     problem_type = 'classification'
@@ -822,7 +822,7 @@ class TestTrainer(unittest.TestCase):
         problem_type=problem_type,
         model_type=model_type)
 
-  def xtestClassificationDNNWithImage(self):
+  def testClassificationDNNWithImage(self):
     self._logger.debug('\n\nTesting Classification DNN With Image')
 
     problem_type = 'classification'

--- a/solutionbox/code_free_ml/test_mltoolbox/test_training.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_training.py
@@ -164,7 +164,6 @@ class TestSpecialCharacters(unittest.TestCase):
              '--transform']
       subprocess.check_call(' '.join(cmd), shell=True)
 
-      # Run prediction.
       result = run_exported_model(
           model_path=os.path.join(output_dir, 'training', 'model'),
           csv_data=['"red,","one, two, three"'])
@@ -359,7 +358,7 @@ class TestOptionalKeys(unittest.TestCase):
       result = run_exported_model(
           model_path=os.path.join(output_dir, 'training', 'model'),
           csv_data=['20'])
-      print(result)
+
       self.assertTrue(abs(40 - result['predicted']) < 5)
     finally:
       shutil.rmtree(output_dir)

--- a/solutionbox/code_free_ml/test_mltoolbox/test_training.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_training.py
@@ -166,7 +166,7 @@ class TestSpecialCharacters(unittest.TestCase):
 class TestMultipleFeatures(unittest.TestCase):
   """Test one source column can be used in many features."""
 
-  def testMultipleColumnsRaw(self):
+  def xtestMultipleColumnsRaw(self):
     """Test training starting from raw csv."""
     output_dir = tempfile.mkdtemp()
     try:
@@ -222,7 +222,7 @@ class TestMultipleFeatures(unittest.TestCase):
     finally:
       shutil.rmtree(output_dir)
 
-  def testMultipleColumnsTransformed(self):
+  def xtestMultipleColumnsTransformed(self):
     """Test training starting from tf.example."""
     output_dir = tempfile.mkdtemp()
     try:
@@ -303,7 +303,7 @@ class TestMultipleFeatures(unittest.TestCase):
 
 
 class TestOptionalKeys(unittest.TestCase):
-  def testNoKeys(self):
+  def xtestNoKeys(self):
     output_dir = tempfile.mkdtemp()
     try:
       features = {
@@ -350,7 +350,7 @@ class TestOptionalKeys(unittest.TestCase):
     finally:
       shutil.rmtree(output_dir)
 
-  def testManyKeys(self):
+  def xtestManyKeys(self):
     output_dir = tempfile.mkdtemp()
     try:
       features = {
@@ -759,7 +759,7 @@ class TestTrainer(unittest.TestCase):
         self.assertItemsEqual(expected_output_keys, result.keys())
         self.assertEqual([12, 11], result['key'].flatten().tolist())
 
-  def testClassificationLinear(self):
+  def xtestClassificationLinear(self):
     self._logger.debug('\n\nTesting Classification Linear')
 
     problem_type = 'classification'
@@ -773,7 +773,7 @@ class TestTrainer(unittest.TestCase):
         problem_type=problem_type,
         model_type=model_type)
 
-  def testRegressionLinear(self):
+  def xtestRegressionLinear(self):
     self._logger.debug('\n\nTesting Regression Linear')
 
     problem_type = 'regression'
@@ -787,7 +787,7 @@ class TestTrainer(unittest.TestCase):
         problem_type=problem_type,
         model_type=model_type)
 
-  def testClassificationDNN(self):
+  def xtestClassificationDNN(self):
     self._logger.debug('\n\nTesting Classification DNN')
 
     problem_type = 'classification'
@@ -805,7 +805,7 @@ class TestTrainer(unittest.TestCase):
         problem_type=problem_type,
         model_type=model_type)
 
-  def testRegressionDNN(self):
+  def xtestRegressionDNN(self):
     self._logger.debug('\n\nTesting Regression DNN')
 
     problem_type = 'regression'
@@ -822,7 +822,7 @@ class TestTrainer(unittest.TestCase):
         problem_type=problem_type,
         model_type=model_type)
 
-  def testClassificationDNNWithImage(self):
+  def xtestClassificationDNNWithImage(self):
     self._logger.debug('\n\nTesting Classification DNN With Image')
 
     problem_type = 'classification'

--- a/solutionbox/code_free_ml/test_mltoolbox/test_training.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_training.py
@@ -58,7 +58,7 @@ def run_exported_model(model_path, csv_data):
 class TestSpecialCharacters(unittest.TestCase):
   """Test special characters are supported."""
 
-  def xtestCommaQuote(self):
+  def testCommaQuote(self):
     """Test when csv input data has quotes and commas."""
     output_dir = tempfile.mkdtemp()
     try:
@@ -153,11 +153,13 @@ class TestSpecialCharacters(unittest.TestCase):
              '--transform']
       subprocess.check_call(' '.join(cmd), shell=True)
 
+      # Run prediction.
       result = run_exported_model(
           model_path=os.path.join(output_dir, 'training', 'model'),
           csv_data=['"red,","one, two, three"'])
 
-      # Check it made the correct prediction
+      # The prediction data is a training row. As the data is samll, the model
+      # should have near 100% accuracy. Check it made the correct prediction.
       self.assertEqual(result['predicted'], 'red,')
     finally:
       shutil.rmtree(output_dir)
@@ -166,7 +168,7 @@ class TestSpecialCharacters(unittest.TestCase):
 class TestMultipleFeatures(unittest.TestCase):
   """Test one source column can be used in many features."""
 
-  def xtestMultipleColumnsRaw(self):
+  def testMultipleColumnsRaw(self):
     """Test training starting from raw csv."""
     output_dir = tempfile.mkdtemp()
     try:
@@ -222,7 +224,7 @@ class TestMultipleFeatures(unittest.TestCase):
     finally:
       shutil.rmtree(output_dir)
 
-  def xtestMultipleColumnsTransformed(self):
+  def testMultipleColumnsTransformed(self):
     """Test training starting from tf.example."""
     output_dir = tempfile.mkdtemp()
     try:
@@ -303,7 +305,7 @@ class TestMultipleFeatures(unittest.TestCase):
 
 
 class TestOptionalKeys(unittest.TestCase):
-  def xtestNoKeys(self):
+  def testNoKeys(self):
     output_dir = tempfile.mkdtemp()
     try:
       features = {
@@ -346,11 +348,12 @@ class TestOptionalKeys(unittest.TestCase):
       result = run_exported_model(
           model_path=os.path.join(output_dir, 'training', 'model'),
           csv_data=['20'])
+      print(result)
       self.assertTrue(abs(40 - result['predicted']) < 5)
     finally:
       shutil.rmtree(output_dir)
 
-  def xtestManyKeys(self):
+  def testManyKeys(self):
     output_dir = tempfile.mkdtemp()
     try:
       features = {
@@ -445,7 +448,7 @@ class TestTrainer(unittest.TestCase):
 
   def tearDown(self):
     self._logger.debug('TestTrainer: removing test dir ' + self._test_dir)
-    #shutil.rmtree(self._test_dir)
+    shutil.rmtree(self._test_dir)
 
   def make_image_files(self):
     img1_file = os.path.join(self._test_dir, 'img1.jpg')
@@ -759,7 +762,7 @@ class TestTrainer(unittest.TestCase):
         self.assertItemsEqual(expected_output_keys, result.keys())
         self.assertEqual([12, 11], result['key'].flatten().tolist())
 
-  def xtestClassificationLinear(self):
+  def testClassificationLinear(self):
     self._logger.debug('\n\nTesting Classification Linear')
 
     problem_type = 'classification'
@@ -773,7 +776,7 @@ class TestTrainer(unittest.TestCase):
         problem_type=problem_type,
         model_type=model_type)
 
-  def xtestRegressionLinear(self):
+  def testRegressionLinear(self):
     self._logger.debug('\n\nTesting Regression Linear')
 
     problem_type = 'regression'
@@ -787,7 +790,7 @@ class TestTrainer(unittest.TestCase):
         problem_type=problem_type,
         model_type=model_type)
 
-  def xtestClassificationDNN(self):
+  def testClassificationDNN(self):
     self._logger.debug('\n\nTesting Classification DNN')
 
     problem_type = 'classification'
@@ -805,7 +808,7 @@ class TestTrainer(unittest.TestCase):
         problem_type=problem_type,
         model_type=model_type)
 
-  def xtestRegressionDNN(self):
+  def testRegressionDNN(self):
     self._logger.debug('\n\nTesting Regression DNN')
 
     problem_type = 'regression'

--- a/solutionbox/code_free_ml/test_mltoolbox/test_transform.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_transform.py
@@ -88,6 +88,7 @@ class TestTransformRawData(unittest.TestCase):
   def tearDownClass(cls):
     shutil.rmtree(cls.working_dir)
 
+  @unittest.skipIf(not HAS_CREDENTIALS, 'GCS access missing')
   def test_local_csv_transform(self):
     """Test transfrom from local csv files."""
 

--- a/solutionbox/code_free_ml/test_mltoolbox/test_transform.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_transform.py
@@ -88,7 +88,6 @@ class TestTransformRawData(unittest.TestCase):
   def tearDownClass(cls):
     shutil.rmtree(cls.working_dir)
 
-  @unittest.skipIf(not HAS_CREDENTIALS, 'GCS access missing')
   def test_local_csv_transform(self):
     """Test transfrom from local csv files."""
 

--- a/solutionbox/image_classification/mltoolbox/image/classification/_cloud.py
+++ b/solutionbox/image_classification/mltoolbox/image/classification/_cloud.py
@@ -29,7 +29,7 @@ import urllib
 from . import _util
 
 
-_TF_GS_URL = 'gs://cloud-datalab/deploy/tf/tensorflow-1.0.0-cp27-cp27mu-manylinux1_x86_64.whl'
+_TF_GS_URL = 'gs://cloud-datalab/deploy/tf/tensorflow-1.2.0-cp27-none-linux_x86_64.whl'
 _PROTOBUF_GS_URL = 'gs://cloud-datalab/deploy/tf/protobuf-3.1.0-py2.py3-none-any.whl'
 
 

--- a/solutionbox/image_classification/mltoolbox/image/classification/_model.py
+++ b/solutionbox/image_classification/mltoolbox/image/classification/_model.py
@@ -21,7 +21,6 @@ import logging
 import tensorflow as tf
 from tensorflow.contrib import layers
 from tensorflow.python.ops import control_flow_ops
-from tensorflow.python.ops import data_flow_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.saved_model import builder as saved_model_builder
 from tensorflow.python.saved_model import signature_def_utils
@@ -337,7 +336,7 @@ class Model(object):
                                    last_checkpoint)
       init_op_serving = control_flow_ops.group(
           variables.local_variables_initializer(),
-          data_flow_ops.tables_initializer())
+          tf.tables_initializer())
 
       builder = saved_model_builder.SavedModelBuilder(output_dir)
       builder.add_meta_graph_and_variables(

--- a/solutionbox/image_classification/mltoolbox/image/classification/setup.py
+++ b/solutionbox/image_classification/mltoolbox/image/classification/setup.py
@@ -16,7 +16,7 @@ import datetime
 from setuptools import setup
 
 minor = datetime.datetime.now().strftime("%y%m%d%H%M")
-version = '0.1'
+version = '0.2'
 
 setup(
   name='mltoolbox_datalab_image_classification',

--- a/solutionbox/image_classification/setup.py
+++ b/solutionbox/image_classification/setup.py
@@ -16,7 +16,7 @@ import datetime
 from setuptools import setup
 
 minor = datetime.datetime.now().strftime("%y%m%d%H%M")
-version = '0.1'
+version = '0.2'
 
 setup(
   name='mltoolbox_datalab_image_classification',

--- a/solutionbox/structured_data/mltoolbox/_structured_data/__version__.py
+++ b/solutionbox/structured_data/mltoolbox/_structured_data/__version__.py
@@ -11,4 +11,4 @@
 # the License.
 
 # Source of truth for the version of this package.
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/solutionbox/structured_data/mltoolbox/_structured_data/_package.py
+++ b/solutionbox/structured_data/mltoolbox/_structured_data/_package.py
@@ -51,7 +51,7 @@ import warnings
 # dataflow workers should not need it.
 
 
-_TF_GS_URL = 'gs://cloud-datalab/deploy/tf/tensorflow-1.0.0-cp27-cp27mu-manylinux1_x86_64.whl'
+_TF_GS_URL = 'gs://cloud-datalab/deploy/tf/tensorflow-1.2.0-cp27-none-linux_x86_64.whl'
 _PROTOBUF_GS_URL = 'gs://cloud-datalab/deploy/tf/protobuf-3.1.0-py2.py3-none-any.whl'
 
 

--- a/solutionbox/structured_data/mltoolbox/_structured_data/preprocess/local_preprocess.py
+++ b/solutionbox/structured_data/mltoolbox/_structured_data/preprocess/local_preprocess.py
@@ -149,7 +149,7 @@ def run_analysis(args):
 
   # Read the schema and input feature types
   schema_list = json.loads(
-      file_io.read_file_to_string(args.schema_file).decode())
+      file_io.read_file_to_string(args.schema_file))
 
   run_numerical_categorical_analysis(args, schema_list)
 

--- a/solutionbox/structured_data/mltoolbox/_structured_data/trainer/util.py
+++ b/solutionbox/structured_data/mltoolbox/_structured_data/trainer/util.py
@@ -33,7 +33,6 @@ from tensorflow.python.ops import variables
 from tensorflow.contrib.framework.python.ops import variables as contrib_variables
 from tensorflow.contrib.learn.python.learn.estimators import model_fn as model_fn_lib
 from tensorflow.python.training import saver
-from tensorflow.python.ops import data_flow_ops
 from tensorflow.python.framework import ops
 from tensorflow.python.client import session as tf_session
 from tensorflow.python.saved_model import builder as saved_model_builder
@@ -216,7 +215,7 @@ def make_export_strategy(train_config, args, keep_target, assets_extra=None):
           export_dir_base)
 
       if (model_fn_ops.scaffold is not None and
-          model_fn_ops.scaffold.saver is not None):
+         model_fn_ops.scaffold.saver is not None):
         saver_for_restore = model_fn_ops.scaffold.saver
       else:
         saver_for_restore = saver.Saver(sharded=True)

--- a/solutionbox/structured_data/mltoolbox/_structured_data/trainer/util.py
+++ b/solutionbox/structured_data/mltoolbox/_structured_data/trainer/util.py
@@ -28,7 +28,6 @@ from tensorflow.contrib.learn.python.learn.utils import (
     saved_model_export_utils)
 
 from tensorflow.python.ops import resources
-from tensorflow.python.ops import lookup_ops
 from tensorflow.python.ops import variables
 from tensorflow.contrib.framework.python.ops import variables as contrib_variables
 from tensorflow.contrib.learn.python.learn.estimators import model_fn as model_fn_lib
@@ -225,7 +224,7 @@ def make_export_strategy(train_config, args, keep_target, assets_extra=None):
         init_op = control_flow_ops.group(
             variables.local_variables_initializer(),
             resources.initialize_resources(resources.shared_resources()),
-            lookup_ops.tables_initializer())
+            tf.tables_initializer())
 
         # Perform the export
         builder = saved_model_builder.SavedModelBuilder(export_dir)

--- a/solutionbox/structured_data/mltoolbox/_structured_data/trainer/util.py
+++ b/solutionbox/structured_data/mltoolbox/_structured_data/trainer/util.py
@@ -215,18 +215,18 @@ def make_export_strategy(train_config, args, keep_target, assets_extra=None):
       export_dir = saved_model_export_utils.get_timestamped_export_dir(
           export_dir_base)
 
-      with tf_session.Session('') as session:
+      if (model_fn_ops.scaffold is not None and
+          model_fn_ops.scaffold.saver is not None):
+        saver_for_restore = model_fn_ops.scaffold.saver
+      else:
         saver_for_restore = saver.Saver(sharded=True)
+
+      with tf_session.Session('') as session:
         saver_for_restore.restore(session, checkpoint_path)
         init_op = control_flow_ops.group(
             variables.local_variables_initializer(),
             resources.initialize_resources(resources.shared_resources()),
             lookup_ops.tables_initializer())
-
-
-        init_op = control_flow_ops.group(
-            variables.local_variables_initializer(),
-            data_flow_ops.tables_initializer())
 
         # Perform the export
         builder = saved_model_builder.SavedModelBuilder(export_dir)

--- a/solutionbox/structured_data/test_mltoolbox/test_package_functions.py
+++ b/solutionbox/structured_data/test_mltoolbox/test_package_functions.py
@@ -32,6 +32,7 @@ import google.datalab.ml as dlml  # noqa: E402
 import unittest  # noqa: E402
 
 
+@unittest.skipIf(not six.PY2, 'Python 2 is required')
 class TestAnalyze(unittest.TestCase):
 
   def test_not_csvdataset(self):
@@ -114,6 +115,7 @@ class TestAnalyze(unittest.TestCase):
                     job.fatal_error.message)
 
 
+@unittest.skipIf(not six.PY2, 'Python 2 is required')
 class TestFunctionSignature(unittest.TestCase):
 
   def _argspec(self, fn_obj):

--- a/solutionbox/structured_data/test_mltoolbox/test_sd_trainer.py
+++ b/solutionbox/structured_data/test_mltoolbox/test_sd_trainer.py
@@ -65,7 +65,7 @@ class TestTrainer(unittest.TestCase):
 
   def tearDown(self):
     self._logger.debug('TestTrainer: removing test dir ' + self._test_dir)
-    #shutil.rmtree(self._test_dir)
+    shutil.rmtree(self._test_dir)
 
   def _run_training(self, problem_type, model_type, transforms, extra_args=[]):
     """Runs training.

--- a/solutionbox/structured_data/test_mltoolbox/test_sd_trainer.py
+++ b/solutionbox/structured_data/test_mltoolbox/test_sd_trainer.py
@@ -65,7 +65,7 @@ class TestTrainer(unittest.TestCase):
 
   def tearDown(self):
     self._logger.debug('TestTrainer: removing test dir ' + self._test_dir)
-    shutil.rmtree(self._test_dir)
+    #shutil.rmtree(self._test_dir)
 
   def _run_training(self, problem_type, model_type, transforms, extra_args=[]):
     """Runs training.

--- a/tests/mltoolbox_structured_data/sd_e2e_tests.py
+++ b/tests/mltoolbox_structured_data/sd_e2e_tests.py
@@ -16,7 +16,9 @@ from __future__ import print_function
 
 import logging
 import os
+import six
 import sys
+import unittest
 
 # Set up the path so that we can import local packages.
 sys.path.append(
@@ -26,6 +28,7 @@ sys.path.append(
 import test_mltoolbox.test_datalab_e2e as e2e  # noqa
 
 
+@unittest.skipIf(not six.PY2, 'Python 2 is required')
 class TestLinearRegression(e2e.TestLinearRegression):
   """Test linear regression works e2e locally.
   """

--- a/tests/mltoolbox_structured_data/traininglib_tests.py
+++ b/tests/mltoolbox_structured_data/traininglib_tests.py
@@ -13,7 +13,9 @@ from __future__ import absolute_import
 
 import logging
 import os
+import six
 import sys
+import unittest
 
 # Set up the path so that we can import local packages.
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
@@ -22,6 +24,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
 import test_mltoolbox.test_sd_trainer as sdtraining
 
 
+@unittest.skipIf(not six.PY2, 'Python 2 is required')
 class TestCoreTrainingLib(sdtraining.TestTrainer):
   """Wraps the training tests in the structured data package.
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ skip_missing_interpreters = true
 # need them to run our tests suite.
 #
 # tox always installs the current package, so there's no need to list it here.
-deps = tensorflow==1.0.0
+deps = tensorflow==1.2.0
        # Note: protobuf 3.2.0 has the "python: double free or corruption" bug.
        protobuf==3.1.0
        # Dropping this seems to cause problems with conda in some cases.


### PR DESCRIPTION
many  changes:

* tf estimator's feature_engineering_fn broke somehow. But I learned support for this is being removed anyways. So the work that function did (apply a hidden layer to image embedding columns) moved to the training/serving input functions. This required a new serving function for the transform step as the transform step should not have a hidden layer.

* tf 1.2.0 does a better job of str vs bytes for python3. I ended up removing the old mltoolbox code from the python3 tests. Before, non-dataflow steps were being tested in python 3, but this is silly as mltoolbox cannot be used without dataflow and hence must be python 2.

* protobuf is still used in setup.py files. This is because tf has to be installed on Dataflow workers. 

* remove string_to_index_table_from_tensor warning

* updated make_export_strategy to sync with export_savedmodel. I explored Eli's trick in https://stackoverflow.com/questions/44381879/training-and-predicting-with-instance-keys However, because of the target/no target exported models, my export function would need to change the model. I need to connect with Eli more, but I don't see how we can just call the estimator's export_savedmodel. Also updated make_export_strategy in _structure_data mltoolbox package.

* bump old mltoolbox package version numbers


