### PR TITLE
CREDENTIAL_SCOPES: Add /auth/drive for bigquery tables backed by sheets

### DIFF
--- a/datalab/context/_utils.py
+++ b/datalab/context/_utils.py
@@ -29,6 +29,7 @@ import subprocess
 # that the user can define for themselves which scopes they want to use.
 CREDENTIAL_SCOPES = [
   'https://www.googleapis.com/auth/cloud-platform',
+  'https://www.googleapis.com/auth/drive',
 ]
 
 

--- a/google/datalab/utils/_utils.py
+++ b/google/datalab/utils/_utils.py
@@ -138,6 +138,7 @@ def gcs_copy_file(source, dest):
 # that the user can define for themselves which scopes they want to use.
 CREDENTIAL_SCOPES = [
   'https://www.googleapis.com/auth/cloud-platform',
+  'https://www.googleapis.com/auth/drive',
 ]
 
 


### PR DESCRIPTION
- Allow service accounts to query bq tables backed by sheets
- Without this scope you get the following 403 error from bq, where
  "globbing file pattern" appears to come from gdrive:
```
datalab.utils._http.RequestException: HTTP request failed (status 403): Access Denied: BigQuery BigQuery: Permission denied while globbing file pattern.
```
- Repro'ing is a bit complicated:
  - In gcp, make a "service account"
  - In gcp, create a "client id" for the service account
  - In gsuite, enable "domain-wide delegation" for the client id
  - Make a sheet
  - Share the sheet with the service account id (maybe not required?)
  - Make a bq table backed by the sheet
  - Query the table using the service account creds
- Here's the most helpful reference I found:
  - https://stackoverflow.com/a/41676921/397334