### PR TITLE
Fix an issue that when variable replacement fails in cell input, it does not give proper error message.

### DIFF
--- a/google/datalab/bigquery/commands/_bigquery.py
+++ b/google/datalab/bigquery/commands/_bigquery.py
@@ -929,13 +929,7 @@ def bq(line, cell=None):
   Use %bq --help for a list of commands, or %bq <command> --help for help
   on a specific command.
   """
-  namespace = {}
-  if line.find('$') >= 0:
-    # We likely have variables to expand; get the appropriate context.
-    namespace = google.datalab.utils.commands.notebook_environment()
-
-  return google.datalab.utils.commands.handle_magic_line(line, cell, _bigquery_parser,
-                                                         namespace=namespace)
+  return google.datalab.utils.commands.handle_magic_line(line, cell, _bigquery_parser)
 
 
 def _dispatch_handler(args, cell, parser, handler, cell_required=False, cell_prohibited=False):

--- a/google/datalab/contrib/mlworkbench/commands/_ml.py
+++ b/google/datalab/contrib/mlworkbench/commands/_ml.py
@@ -648,9 +648,6 @@ def _batch_predict(args, cell):
     raise ValueError('"cloud_config" is provided but no "--cloud". '
                      'Do you want local run or cloud run?')
 
-  data = args['prediction_data']
-  google.datalab.utils.commands.validate_config(data, required_keys=['csv'])
-
   if args['cloud']:
     parts = args['model'].split('.')
     if len(parts) != 2:
@@ -664,7 +661,7 @@ def _batch_predict(args, cell):
     job_request = {
       'version_name': version_name,
       'data_format': 'TEXT',
-      'input_paths': file_io.get_matching_files(data['csv']),
+      'input_paths': file_io.get_matching_files(args['prediction_data']['csv']),
       'output_path': args['output'],
     }
     job_request.update(cloud_config)
@@ -673,7 +670,7 @@ def _batch_predict(args, cell):
   else:
     print('local prediction...')
     _local_predict.local_batch_predict(args['model'],
-                                       data['csv'],
+                                       args['prediction_data']['csv'],
                                        args['output'],
                                        args['format'],
                                        args['batch_size'])

--- a/google/datalab/utils/commands/_commands.py
+++ b/google/datalab/utils/commands/_commands.py
@@ -243,6 +243,9 @@ class CommandParser(argparse.ArgumentParser):
         # It is okay --- probably because cell is not in yaml or json format.
         pass
 
+      if cell_config:
+        google.datalab.utils.commands.replace_vars(cell_config, namespace)
+
       for arg in cell_args:
         if (cell_args[arg]['required'] and
            (cell_config is None or cell_config.get(arg, None) is None)):

--- a/google/datalab/utils/commands/_commands.py
+++ b/google/datalab/utils/commands/_commands.py
@@ -208,12 +208,13 @@ class CommandParser(argparse.ArgumentParser):
       cell_config = None
       try:
         cell_config, cell = google.datalab.utils.commands.parse_config_for_selected_keys(
-            cell, namespace, line_args)
+            cell, line_args)
       except:
         # It is okay --- probably because cell is not in yaml or json format.
         pass
 
       if cell_config:
+        google.datalab.utils.commands.replace_vars(cell_config, namespace)
         for arg_name in cell_config:
           arg_value = cell_config[arg_name]
           if arg_value is None:
@@ -237,13 +238,14 @@ class CommandParser(argparse.ArgumentParser):
     if cell_args:
       try:
         cell_config, _ = google.datalab.utils.commands.parse_config_for_selected_keys(
-            cell, namespace, cell_args)
+            cell, cell_args)
       except:
         # It is okay --- probably because cell is not in yaml or json format.
         pass
 
       for arg in cell_args:
-        if cell_args[arg]['required'] and cell_config.get(arg, None) is None:
+        if (cell_args[arg]['required'] and
+           (cell_config is None or cell_config.get(arg, None) is None)):
           raise ValueError('Cell config "%s" is required.' % arg)
 
     if cell_config:

--- a/google/datalab/utils/commands/_utils.py
+++ b/google/datalab/utils/commands/_utils.py
@@ -338,7 +338,7 @@ def parse_config(config, env, as_dict=True):
   return config
 
 
-def parse_config_for_selected_keys(content, env, keys):
+def parse_config_for_selected_keys(content, keys):
   """ Parse a config from a magic cell body for selected config keys.
 
   For example, if 'content' is:
@@ -353,7 +353,6 @@ def parse_config_for_selected_keys(content, env, keys):
 
   Args:
     content: the input content. A string. It has to be a yaml or JSON string.
-    env: user supplied dictionary for replacing vars (for example, $myvalue).
     keys: a list of keys to retrieve from content. Note that it only checks top level keys
         in the dict.
 
@@ -383,7 +382,6 @@ def parse_config_for_selected_keys(content, env, keys):
   for key in keys:
     config_items[key] = config.pop(key, None)
 
-  replace_vars(config_items, env)
   if not config:
     return config_items, None
 


### PR DESCRIPTION
The fix moves replace_vars() out of the try block, so if replace_vars() fails the error will show up.

The change in _bigquery.py is needed because otherwise an empty (but not None) namespace is passed to parser, and if there are any variable ref in cell input, it will fail to resolve. Also, handle_magic_line() takes care of namespace if it is None, so no need to explicitly pass in a namespace.