### PR TITLE
Bump google-api-python-client from ==1.5.1 to >=1.6.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'future==0.16.0',
     'futures==3.0.5',
     'google-cloud==0.19.0',
-    'google-api-python-client==1.5.1',
+    'google-api-python-client>=1.6.2',
     'seaborn==0.7.0',
     'plotly==1.12.5',
     'httplib2==0.10.3',

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'future==0.16.0',
     'futures==3.0.5',
     'google-cloud==0.19.0',
-    'google-api-python-client>=1.6.2',
+    'google-api-python-client==1.6.2',
     'seaborn==0.7.0',
     'plotly==1.12.5',
     'httplib2==0.10.3',


### PR DESCRIPTION
Hello! 

We're trying to install datalab internally at Spotify and running into dependency collisions.

By pinning google-api-python-client to 1.5.1, `datalab` package ends up install `uritemplate=0.6`:

```
Collecting uritemplate<1,>=0.6 (from google-api-python-client==1.5.1->datalab)
```

uritemplate is up to 3.0.x now. 0.6 is an old version of the package which is incompatible with dozens of packages in anaconda distro.

Could we bump the `google-api-python-client` dependency to `>=1.6.2`? Those folks upgrade `uritemplate` to 3.0.0 in version `1.6.2`: https://github.com/google/google-api-python-client/blob/master/setup.py#L69