### PR TITLE
Add "%%ml explain" to mlworkbench.

### DIFF
--- a/google/datalab/contrib/mlworkbench/__init__.py
+++ b/google/datalab/contrib/mlworkbench/__init__.py
@@ -14,5 +14,7 @@
 from __future__ import absolute_import
 
 from ._local_predict import get_prediction_results, get_probs_for_labels, local_batch_predict
+from ._prediction_explainer import PredictionExplainer
 
-__all__ = ['get_prediction_results', 'get_probs_for_labels', 'local_batch_predict']
+__all__ = ['get_prediction_results', 'get_probs_for_labels', 'local_batch_predict',
+           'PredictionExplainer']

--- a/google/datalab/contrib/mlworkbench/_local_predict.py
+++ b/google/datalab/contrib/mlworkbench/_local_predict.py
@@ -157,6 +157,21 @@ def _get_display_data_with_images(data, images):
   return display_data
 
 
+def get_model_schema_and_features(model_dir):
+  """Get a local model's schema and features config.
+
+  Args:
+    model_dir: local or GCS path of a model.
+  Returns:
+    A tuple of schema (list) and features config (dict).
+  """
+  schema_file = os.path.join(model_dir, 'assets.extra', 'schema.json')
+  schema = json.loads(file_io.read_file_to_string(schema_file).decode())
+  features_file = os.path.join(model_dir, 'assets.extra', 'features.json')
+  features_config = json.loads(file_io.read_file_to_string(features_file).decode())
+  return schema, features_config
+
+
 def get_prediction_results(model_dir_or_id, data, headers, img_cols=None,
                            cloud=False, with_source=True, show_image=True):
   """ Predict with a specified model.

--- a/google/datalab/contrib/mlworkbench/_prediction_explainer.py
+++ b/google/datalab/contrib/mlworkbench/_prediction_explainer.py
@@ -41,10 +41,10 @@ class PredictionExplainer(object):
         self._headers = [x['name'] for x in schema]
         self._text_columns, self._image_columns = [], []
         for k, v in six.iteritems(features):
-          if v['transform'] in ['image_to_vec']:
-            self._image_columns.append(v['source_column'])
-          elif v['transform'] in ['bag_of_words', 'tfidf']:
-            self._text_columns.append(v['source_column'])
+            if v['transform'] in ['image_to_vec']:
+                self._image_columns.append(v['source_column'])
+            elif v['transform'] in ['bag_of_words', 'tfidf']:
+                self._text_columns.append(v['source_column'])
 
     def _make_text_predict_fn(self, labels, instance, column_to_explain):
         """Create a predict_fn that can be used by LIME text explainer. """

--- a/google/datalab/contrib/mlworkbench/_prediction_explainer.py
+++ b/google/datalab/contrib/mlworkbench/_prediction_explainer.py
@@ -16,12 +16,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-
 import csv
-import json
 from lime.lime_text import LimeTextExplainer
+from lime.lime_image import LimeImageExplainer
 import numpy as np
-import os
+from PIL import Image
 import six
 from tensorflow.python.lib.io import file_io
 
@@ -38,25 +37,14 @@ class PredictionExplainer(object):
         """
 
         self._model_dir = model_dir
-        self._text_column_names = list(self._get_text_column_names())
-        self._headers = list(self._get_headers())
-
-    def _get_text_column_names(self):
-        """Get text column names from features config file included in model."""
-
-        features_file = os.path.join(self._model_dir, 'assets.extra', 'features.json')
-        features_config = json.loads(file_io.read_file_to_string(features_file).decode())
-        for k, v in six.iteritems(features_config):
-            if v['transform'] in ['bag_of_words', 'tfidf']:
-                yield v['source_column']
-
-    def _get_headers(self):
-        """Get field headers from schema file included in model."""
-
-        schema_file = os.path.join(self._model_dir, 'assets.extra', 'schema.json')
-        schema = json.loads(file_io.read_file_to_string(schema_file).decode())
-        for x in schema:
-            yield x['name']
+        schema, features = _local_predict.get_model_schema_and_features(model_dir)
+        self._headers = [x['name'] for x in schema]
+        self._text_columns, self._image_columns = [], []
+        for k, v in six.iteritems(features):
+          if v['transform'] in ['image_to_vec']:
+            self._image_columns.append(v['source_column'])
+          elif v['transform'] in ['bag_of_words', 'tfidf']:
+            self._text_columns.append(v['source_column'])
 
     def _make_text_predict_fn(self, labels, instance, column_to_explain):
         """Create a predict_fn that can be used by LIME text explainer. """
@@ -70,6 +58,25 @@ class PredictionExplainer(object):
 
             df = _local_predict.get_prediction_results(self._model_dir, predict_input,
                                                        self._headers, with_source=False)
+            probs = _local_predict.get_probs_for_labels(labels, df)
+            return np.asarray(probs)
+
+        return _predict_fn
+
+    def _make_image_predict_fn(self, labels, instance, column_to_explain):
+        """Create a predict_fn that can be used by LIME image explainer. """
+
+        def _predict_fn(perturbed_image):
+
+            predict_input = []
+            for x in perturbed_image:
+                instance_copy = dict(instance)
+                instance_copy[column_to_explain] = Image.fromarray(x)
+                predict_input.append(instance_copy)
+
+            df = _local_predict.get_prediction_results(
+                self._model_dir, predict_input, self._headers,
+                img_cols=self._image_columns, with_source=False)
             probs = _local_predict.get_probs_for_labels(labels, df)
             return np.asarray(probs)
 
@@ -100,14 +107,14 @@ class PredictionExplainer(object):
               but there are multiple text columns in model input.
         """
 
-        if len(self._text_column_names) > 1 and not column_name:
+        if len(self._text_columns) > 1 and not column_name:
             raise ValueError('There are multiple text columns in the input of the model. ' +
                              'Please specify "column_name".')
-        elif column_name and column_name not in self._text_column_names:
+        elif column_name and column_name not in self._text_columns:
             raise ValueError('Specified column_name "%s" not found in the model input.'
                              % column_name)
 
-        text_column_name = column_name if column_name else self._text_column_names[0]
+        text_column_name = column_name if column_name else self._text_columns[0]
         if isinstance(instance, six.string_types):
             instance = csv.DictReader([instance], fieldnames=self._headers).next()
 
@@ -116,4 +123,57 @@ class PredictionExplainer(object):
         exp = explainer.explain_instance(
             instance[text_column_name], predict_fn, labels=range(len(labels)),
             num_features=num_features, num_samples=num_samples)
+        return exp
+
+    def explain_image(self, labels, instance, column_name=None, num_features=100000,
+                      num_samples=300, batch_size=200, hide_color=0):
+        """Explain an image of a prediction.
+
+        It analyze the prediction by LIME, and returns a report of which words are most impactful
+        in contributing to certain labels.
+
+        Args:
+          labels: a list of labels to explain.
+          instance: the prediction instance. It needs to conform to model's input. Can be a csv
+              line string, or a dict.
+          column_name: which image column to explain. Can be None if there is only one image column
+              in the model input.
+          num_features: maximum number of areas (features) to analyze. Passed to
+              LIME LimeImageExplainer directly.
+          num_samples: size of the neighborhood to learn the linear model. Passed to
+              LIME LimeImageExplainer directly.
+          batch_size: size of batches passed to predict_fn. Passed to
+              LIME LimeImageExplainer directly.
+          hide_color: the color used to perturb images. Passed to
+              LIME LimeImageExplainer directly.
+
+        Returns:
+          A LIME's LimeImageExplainer.
+
+        Throws:
+          ValueError if the given image column is not found in model input or column_name is None
+              but there are multiple image columns in model input.
+        """
+
+        if len(self._image_columns) > 1 and not column_name:
+            raise ValueError('There are multiple image columns in the input of the model. ' +
+                             'Please specify "column_name".')
+        elif column_name and column_name not in self._image_columns:
+            raise ValueError('Specified column_name "%s" not found in the model input.'
+                             % column_name)
+
+        image_column_name = column_name if column_name else self._image_columns[0]
+        if isinstance(instance, six.string_types):
+            instance = csv.DictReader([instance], fieldnames=self._headers).next()
+
+        predict_fn = self._make_image_predict_fn(labels, instance, image_column_name)
+        explainer = LimeImageExplainer()
+        with file_io.FileIO(instance[image_column_name], 'rb') as fi:
+            im = Image.open(fi)
+        im.thumbnail((299, 299), Image.ANTIALIAS)
+        rgb_im = np.asarray(im.convert('RGB'))
+        exp = explainer.explain_instance(
+            rgb_im, predict_fn, labels=range(len(labels)), top_labels=None,
+            hide_color=hide_color, num_features=num_features,
+            num_samples=num_samples, batch_size=batch_size)
         return exp

--- a/google/datalab/contrib/mlworkbench/_prediction_explainer.py
+++ b/google/datalab/contrib/mlworkbench/_prediction_explainer.py
@@ -1,0 +1,119 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Google Cloud Platform library - ML Workbench Model Prediction Explainer."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+
+import csv
+import json
+from lime.lime_text import LimeTextExplainer
+import numpy as np
+import os
+import six
+from tensorflow.python.lib.io import file_io
+
+from . import _local_predict
+
+
+class PredictionExplainer(object):
+    """An explainer that explains text and image predictions based on LIME."""
+
+    def __init__(self, model_dir):
+        """
+        Args:
+          model_dir: the directory of the model to use for prediction.
+        """
+
+        self._model_dir = model_dir
+        self._text_column_names = list(self._get_text_column_names())
+        self._headers = list(self._get_headers())
+
+    def _get_text_column_names(self):
+        """Get text column names from features config file included in model."""
+
+        features_file = os.path.join(self._model_dir, 'assets.extra', 'features.json')
+        features_config = json.loads(file_io.read_file_to_string(features_file).decode())
+        for k, v in six.iteritems(features_config):
+            if v['transform'] in ['bag_of_words', 'tfidf']:
+                yield v['source_column']
+
+    def _get_headers(self):
+        """Get field headers from schema file included in model."""
+
+        schema_file = os.path.join(self._model_dir, 'assets.extra', 'schema.json')
+        schema = json.loads(file_io.read_file_to_string(schema_file).decode())
+        for x in schema:
+            yield x['name']
+
+    def _make_text_predict_fn(self, labels, instance, column_to_explain):
+        """Create a predict_fn that can be used by LIME text explainer. """
+
+        def _predict_fn(perturbed_text):
+            predict_input = []
+            for x in perturbed_text:
+                instance_copy = dict(instance)
+                instance_copy[column_to_explain] = x
+                predict_input.append(instance_copy)
+
+            df = _local_predict.get_prediction_results(self._model_dir, predict_input,
+                                                       self._headers, with_source=False)
+            probs = _local_predict.get_probs_for_labels(labels, df)
+            return np.asarray(probs)
+
+        return _predict_fn
+
+    def explain_text(self, labels, instance, column_name=None, num_features=10, num_samples=5000):
+        """Explain a text field of a prediction.
+
+        It analyze the prediction by LIME, and returns a report of which words are most impactful
+        in contributing to certain labels.
+
+        Args:
+          labels: a list of labels to explain.
+          instance: the prediction instance. It needs to conform to model's input. Can be a csv
+              line string, or a dict.
+          column_name: which text column to explain. Can be None if there is only one text column
+              in the model input.
+          num_features: maximum number of words (features) to analyze. Passed to
+              LIME LimeTextExplainer directly.
+          num_samples: size of the neighborhood to learn the linear model. Passed to
+              LIME LimeTextExplainer directly.
+
+        Returns:
+          A LIME's LimeTextExplainer.
+
+        Throws:
+          ValueError if the given text column is not found in model input or column_name is None
+              but there are multiple text columns in model input.
+        """
+
+        if len(self._text_column_names) > 1 and not column_name:
+            raise ValueError('There are multiple text columns in the input of the model. ' +
+                             'Please specify "column_name".')
+        elif column_name and column_name not in self._text_column_names:
+            raise ValueError('Specified column_name "%s" not found in the model input.'
+                             % column_name)
+
+        text_column_name = column_name if column_name else self._text_column_names[0]
+        if isinstance(instance, six.string_types):
+            instance = csv.DictReader([instance], fieldnames=self._headers).next()
+
+        predict_fn = self._make_text_predict_fn(labels, instance, text_column_name)
+        explainer = LimeTextExplainer(class_names=labels)
+        exp = explainer.explain_instance(
+            instance[text_column_name], predict_fn, labels=range(len(labels)),
+            num_features=num_features, num_samples=num_samples)
+        return exp

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'pytz>=2015.4',
     'pyyaml==3.11',
     'requests==2.9.1',
+    'scikit-image==0.13.0',
     'scikit-learn==0.18.2',
     'ipykernel==4.5.2',
     'psutil==4.3.0',

--- a/tests/main.py
+++ b/tests/main.py
@@ -46,6 +46,7 @@ import mltoolbox_structured_data.dl_interface_tests
 import mltoolbox_structured_data.sd_e2e_tests
 import mltoolbox_structured_data.traininglib_tests
 import mlworkbench_magic.archive_tests
+import mlworkbench_magic.explainer_tests
 import mlworkbench_magic.local_predict_tests
 import mlworkbench_magic.ml_tests
 import mlworkbench_magic.shell_process_tests
@@ -119,6 +120,7 @@ _INTEGRATION_TEST_MODULES = [
     mltoolbox_structured_data.sd_e2e_tests,  # Not everything runs in Python 3.
     mltoolbox_structured_data.traininglib_tests,
     mlworkbench_magic.local_predict_tests,
+    mlworkbench_magic.explainer_tests,
     # TODO: the test fails in travis only. Need to investigate.
     # mlworkbench_magic.shell_process_tests,
     mlworkbench_magic.archive_tests,

--- a/tests/mlworkbench_magic/explainer_tests.py
+++ b/tests/mlworkbench_magic/explainer_tests.py
@@ -108,9 +108,11 @@ class TestMLExplainer(unittest.TestCase):
     apple = exp_instance.as_list(label=0)
     self.assertEqual(len(apple), 2)
     for word, score in apple:
+      # "green" and "long" are both negative to "apple"
       self.assertLess(score, 0.0)
 
     cucumber = exp_instance.as_list(label=2)
     self.assertEqual(len(cucumber), 2)
     for word, score in cucumber:
+      # "green" and "long" are both positive to "cucumber"
       self.assertGreater(score, 0.0)

--- a/tests/mlworkbench_magic/explainer_tests.py
+++ b/tests/mlworkbench_magic/explainer_tests.py
@@ -38,17 +38,18 @@ IPython.core.display.HTML = lambda x: x
 IPython.core.display.JSON = lambda x: x
 
 
-mlmagic.MLTOOLBOX_CODE_PATH = os.path.abspath(os.path.join(
-    os.path.dirname(__file__), '../../solutionbox/code_free_ml/mltoolbox/code_free_ml'))
-
-
 class TestMLExplainer(unittest.TestCase):
   """Integration tests of PredictionExplainer"""
 
   def setUp(self):
+    self._code_path = mlmagic.MLTOOLBOX_CODE_PATH
+    mlmagic.MLTOOLBOX_CODE_PATH = os.path.abspath(
+        os.path.join(os.path.dirname(__file__),
+                     '../../solutionbox/code_free_ml/mltoolbox/code_free_ml'))
     self._test_dir = tempfile.mkdtemp()
 
   def tearDown(self):
+    mlmagic.MLTOOLBOX_CODE_PATH = self._code_path
     shutil.rmtree(self._test_dir)
 
   def _create_text_test_data(self):

--- a/tests/mlworkbench_magic/explainer_tests.py
+++ b/tests/mlworkbench_magic/explainer_tests.py
@@ -1,0 +1,116 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+"""Tests the \%\%ml magics functions without runing any jobs."""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+import unittest
+import os
+import shutil
+import tempfile
+
+
+# import Python so we can mock the parts we need to here.
+import IPython.core.display
+import IPython.core.magic
+
+import google.datalab.contrib.mlworkbench.commands._ml as mlmagic  # noqa
+from google.datalab.contrib.mlworkbench import PredictionExplainer
+
+
+def noop_decorator(func):
+  return func
+
+
+IPython.core.magic.register_line_cell_magic = noop_decorator
+IPython.core.magic.register_line_magic = noop_decorator
+IPython.core.magic.register_cell_magic = noop_decorator
+IPython.core.display.HTML = lambda x: x
+IPython.core.display.JSON = lambda x: x
+
+
+mlmagic.MLTOOLBOX_CODE_PATH = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), '../../solutionbox/code_free_ml/mltoolbox/code_free_ml'))
+
+
+class TestMLExplainer(unittest.TestCase):
+  """Integration tests of PredictionExplainer"""
+
+  def setUp(self):
+    self._test_dir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    shutil.rmtree(self._test_dir)
+
+  def _create_text_test_data(self):
+    """Create text model."""
+
+    test_data = """1,sour green round,lime
+    2,melon green long,cucumber
+    3,sweet round red,apple"""
+    train_csv = os.path.join(self._test_dir, 'train.csv')
+    with open(train_csv, 'w') as f:
+      f.write(test_data)
+
+    analyze_dir = os.path.join(self._test_dir, 'analysis')
+    train_dir = os.path.join(self._test_dir, 'train')
+
+    mlmagic.ml(
+        line='analyze',
+        cell="""\
+            output: %s
+            training_data:
+              csv: %s
+              schema:
+                - name: key
+                  type: INTEGER
+                - name: text
+                  type: STRING
+                - name: target
+                  type: STRING
+            features:
+              key:
+                transform: key
+              text:
+                transform: bag_of_words
+              target:
+                transform: target""" % (analyze_dir, train_csv))
+
+    mlmagic.ml(
+        line='train',
+        cell="""\
+            output: %s
+            analysis: %s
+            training_data:
+              csv: %s
+            evaluation_data:
+              csv: %s
+            model_args:
+              model: linear_classification
+              top-n: 0
+              max-steps: 300""" % (train_dir, analyze_dir, train_csv, train_csv))
+
+  def test_text_explainer(self):
+    """Test text explainer."""
+
+    self._create_text_test_data()
+    explainer = PredictionExplainer(os.path.join(self._test_dir, 'train', 'model'))
+    exp_instance = explainer.explain_text(['apple', 'lime', 'cucumber'], '4,green long')
+    apple = exp_instance.as_list(label=0)
+    self.assertEqual(len(apple), 2)
+    for word, score in apple:
+      self.assertLess(score, 0.0)
+
+    cucumber = exp_instance.as_list(label=2)
+    self.assertEqual(len(cucumber), 2)
+    for word, score in cucumber:
+      self.assertGreater(score, 0.0)

--- a/tests/mlworkbench_magic/explainer_tests.py
+++ b/tests/mlworkbench_magic/explainer_tests.py
@@ -9,7 +9,7 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
-"""Tests the \%\%ml magics functions without runing any jobs."""
+"""Integration Tests of PredictionExplainer."""
 
 from __future__ import absolute_import
 from __future__ import unicode_literals

--- a/tests/mlworkbench_magic/explainer_tests.py
+++ b/tests/mlworkbench_magic/explainer_tests.py
@@ -185,8 +185,7 @@ class TestMLExplainer(unittest.TestCase):
               top-n: 0
               max-steps: 200""" % (train_dir, analyze_dir, transform_dir, transform_dir))
 
-  @unittest.skipIf(not six.PY2 or not HAS_CREDENTIALS,
-                   'Integration test that invokes mlworkbench with DataFlow.')
+  @unittest.skipIf(not six.PY2, 'Integration test that invokes mlworkbench with DataFlow.')
   def test_text_explainer(self):
     """Test text explainer."""
 
@@ -205,7 +204,8 @@ class TestMLExplainer(unittest.TestCase):
       # "green" and "long" are both positive to "cucumber"
       self.assertGreater(score, 0.0)
 
-  @unittest.skipIf(not six.PY2, 'Integration test that invokes mlworkbench with DataFlow.')
+  @unittest.skipIf(not six.PY2 or not HAS_CREDENTIALS,
+                   'Integration test that invokes mlworkbench with DataFlow.')
   def test_image_explainer(self):
     """Test image explainer."""
 

--- a/tests/mlworkbench_magic/explainer_tests.py
+++ b/tests/mlworkbench_magic/explainer_tests.py
@@ -23,7 +23,6 @@ import tempfile
 import IPython.core.display
 import IPython.core.magic
 
-import google.datalab.contrib.mlworkbench.commands._ml as mlmagic  # noqa
 from google.datalab.contrib.mlworkbench import PredictionExplainer
 
 
@@ -36,6 +35,8 @@ IPython.core.magic.register_line_magic = noop_decorator
 IPython.core.magic.register_cell_magic = noop_decorator
 IPython.core.display.HTML = lambda x: x
 IPython.core.display.JSON = lambda x: x
+
+import google.datalab.contrib.mlworkbench.commands._ml as mlmagic  # noqa
 
 
 class TestMLExplainer(unittest.TestCase):

--- a/tests/mlworkbench_magic/explainer_tests.py
+++ b/tests/mlworkbench_magic/explainer_tests.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import unittest
+import google.datalab
 from PIL import Image
 import numpy as np
 import os
@@ -27,6 +28,15 @@ import IPython.core.display
 import IPython.core.magic
 
 from google.datalab.contrib.mlworkbench import PredictionExplainer
+
+
+# Some tests put files in GCS or use BigQuery. If HAS_CREDENTIALS is false,
+# those tests will not run.
+HAS_CREDENTIALS = True
+try:
+  google.datalab.Context.default().project_id
+except Exception:
+  HAS_CREDENTIALS = False
 
 
 def noop_decorator(func):
@@ -175,7 +185,8 @@ class TestMLExplainer(unittest.TestCase):
               top-n: 0
               max-steps: 200""" % (train_dir, analyze_dir, transform_dir, transform_dir))
 
-  @unittest.skipIf(not six.PY2, 'Integration test that invokes mlworkbench with DataFlow.')
+  @unittest.skipIf(not six.PY2 or not HAS_CREDENTIALS,
+                   'Integration test that invokes mlworkbench with DataFlow.')
   def test_text_explainer(self):
     """Test text explainer."""
 

--- a/tests/mlworkbench_magic/explainer_tests.py
+++ b/tests/mlworkbench_magic/explainer_tests.py
@@ -16,6 +16,7 @@ from __future__ import unicode_literals
 import unittest
 import os
 import shutil
+import six
 import tempfile
 
 
@@ -101,6 +102,7 @@ class TestMLExplainer(unittest.TestCase):
               top-n: 0
               max-steps: 300""" % (train_dir, analyze_dir, train_csv, train_csv))
 
+  @unittest.skipIf(not six.PY2, 'Integration test that invokes mlworkbench with DataFlow.')
   def test_text_explainer(self):
     """Test text explainer."""
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ skip_missing_interpreters = true
 deps = tensorflow==1.2.0
        # Note: protobuf 3.2.0 has the "python: double free or corruption" bug.
        protobuf==3.1.0
+       lime==0.1.1.23
        # Dropping this seems to cause problems with conda in some cases.
        scipy
        solutionbox/structured_data/
@@ -24,7 +25,7 @@ commands =
 [testenv:py27]
 # google-cloud-dataflow only supports python2.7, so we add that here.
 deps = {[testenv]deps}
-       google-cloud-dataflow==0.5.5
+       google-cloud-dataflow==2.0.0
 
 [testenv:flake8]
 commands = flake8 --exclude=.tox,.git,./*.egg,build,.cache,env,__pycache__,docs
@@ -33,7 +34,7 @@ deps = flake8
 [testenv:coveralls]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps = {[testenv]deps}
-       google-cloud-dataflow==0.5.5
+       google-cloud-dataflow==2.0.0
        coveralls 
 commands =
   coverage run tests/main.py


### PR DESCRIPTION
- API for explainer
- magic

Also, include the change to make "headers" and "image_columns" unneeded in prediction with local models. Instead we get headers and image_columns from local model's assets files. In the future, we can do same for online models.

There is also an ongoing change to expose inception checkpoint as transform config item, so we don't have to download from GCS and can enable the image tests in travis.