### PR TITLE
Fix two %%bq load/extract issues.

### DIFF
--- a/google/datalab/bigquery/commands/_bigquery.py
+++ b/google/datalab/bigquery/commands/_bigquery.py
@@ -854,9 +854,10 @@ def _extract_cell(args, cell_body):
     if not source:
       raise Exception('Could not find table %s' % args['table'])
 
+    csv_delimiter = args['delimiter'] if args['format'] == 'csv' else None
     job = source.extract(args['path'],
-                         format='CSV' if args['format'] == 'csv' else 'NEWLINE_DELIMITED_JSON',
-                         csv_delimiter=args['delimiter'], csv_header=args['header'],
+                         format=args['format'],
+                         csv_delimiter=csv_delimiter, csv_header=args['header'],
                          compress=args['compress'])
   elif args['query'] or args['view']:
     source_name = args['view'] or args['query']
@@ -918,7 +919,7 @@ def _load_cell(args, cell_body):
                                                    quote=args['quote'])
   job = table.load(args['path'],
                    mode=args['mode'],
-                   source_format=('csv' if args['format'] == 'csv' else 'NEWLINE_DELIMITED_JSON'),
+                   source_format=args['format'],
                    csv_options=csv_options,
                    ignore_unknown_values=not args['strict'])
   if job.failed:

--- a/tests/kernel/bigquery_tests.py
+++ b/tests/kernel/bigquery_tests.py
@@ -671,7 +671,7 @@ WITH q1 AS (
   @mock.patch('google.datalab.bigquery.commands._bigquery._get_table')
   @mock.patch('google.datalab.utils.commands.get_notebook_item')
   def test_extract_cell_table(self, mock_get_notebook_item, mock_get_table, mock_table_extract):
-    args = {'table': 'test-table', 'path': 'test-path', 'format': None, 'delimiter': None,
+    args = {'table': 'test-table', 'path': 'test-path', 'format': 'json', 'delimiter': None,
             'header': None, 'compress': None, 'nocache': None}
     mock_get_table.return_value = None
     with self.assertRaisesRegexp(Exception, 'Could not find table test-table'):
@@ -684,7 +684,7 @@ WITH q1 AS (
     mock_table_extract.return_value.errors = None
     self.assertEqual(google.datalab.bigquery.commands._bigquery._extract_cell(args, None),
                      'test-results')
-    mock_table_extract.assert_called_with('test-path', format='NEWLINE_DELIMITED_JSON',
+    mock_table_extract.assert_called_with('test-path', format='json',
                                           csv_delimiter=None, csv_header=None, compress=None)
 
   @mock.patch('google.datalab.Context.default')
@@ -715,7 +715,7 @@ WITH q1 AS (
   def test_load_cell(self, mock_get_table, mock_table_load, mock_table_exists,
                      mock_table_create, mock_default_context):
     args = {'table': 'project.test.table', 'mode': 'create', 'path': 'test/path', 'skip': None,
-            'csv': None, 'delimiter': None, 'format': None, 'strict': None, 'quote': None}
+            'csv': None, 'delimiter': None, 'format': 'csv', 'strict': None, 'quote': None}
     context = self._create_context()
     table = google.datalab.bigquery.Table('project.test.table')
     mock_get_table.return_value = table
@@ -755,7 +755,7 @@ WITH q1 AS (
     google.datalab.bigquery.commands._bigquery._load_cell(args, json.dumps(cell_body))
 
     mock_table_load.assert_called_with('test/path', mode='create',
-                                       source_format='NEWLINE_DELIMITED_JSON',
+                                       source_format='csv',
                                        csv_options=mock.ANY, ignore_unknown_values=True)
 
     mock_get_table.return_value = None


### PR DESCRIPTION
- %%bq load with json fails with "Invalid source format NEWLINE_DELIMITED_JSON"
- %%bq extract with json fails because we set a csv_delimiter and BQ doesn't like it.