### PR TITLE
Support for Datalab widgets in sandboxed outputs

### DIFF
--- a/google/datalab/kernel/__init__.py
+++ b/google/datalab/kernel/__init__.py
@@ -32,6 +32,7 @@ import google.datalab.bigquery.commands
 import google.datalab.commands
 import google.datalab.stackdriver.commands
 import google.datalab.storage.commands
+import google.datalab.utils
 import google.datalab.utils.commands
 
 _orig_request = _httplib2.Http.request
@@ -120,6 +121,9 @@ def load_ipython_extension(shell):
   except TypeError:
     pass
 
+  # Enable support for sandboxed outputs by default.
+  google.datalab.utils.initialize_sandboxed_outputs()
+
 
 def unload_ipython_extension(shell):
   _shell.InteractiveShell.run_cell_magic = _orig_run_cell_magic
@@ -131,4 +135,6 @@ def unload_ipython_extension(shell):
     del _IPython.get_ipython().user_ns['set_project_id']
   except Exception:
     pass  # We mock IPython for tests so we need this.
+
+  google.datalab.utils.uninitialize_sandboxed_outputs()
   # TODO(gram): unregister imports/magics/etc.

--- a/google/datalab/notebook/static/charting.ts
+++ b/google/datalab/notebook/static/charting.ts
@@ -422,7 +422,7 @@ module Charting {
       this.optionsCache = {};
       this.hasIPython = false;
       try {
-        if (IPython) {
+        if (IPython && IPython.notebook) {
           this.hasIPython = true;
         }
       } catch (e) {
@@ -1013,9 +1013,11 @@ module Charting {
       data = this.convertListToDataTable(data);
     }
 
+    // If there is no IPython instance, assume that this is being executed in a sandboxed output
+    // environment and render immediately.
     // If we have a datalab session, we can go ahead and draw the chart; if not, add code to do the
     // drawing to an event handler for when the kernel is ready.
-    if (IPython.notebook.kernel.is_connected()) {
+    if (!this.hasIPython || IPython.notebook.kernel.is_connected()) {
       _render(driver, dom, chartStyle, controlIds, data, options, refreshData, refreshInterval,
           totalRows)
     } else {

--- a/google/datalab/utils/__init__.py
+++ b/google/datalab/utils/__init__.py
@@ -20,9 +20,12 @@ from ._lru_cache import LRUCache
 from ._lambda_job import LambdaJob
 from ._dataflow_job import DataflowJob
 from ._utils import print_exception_with_last_stack, get_item, compare_datetimes, \
-    pick_unused_port, is_http_running_on, gcs_copy_file, python_portable_string
+    pick_unused_port, is_http_running_on, gcs_copy_file, python_portable_string, \
+    initialize_sandboxed_outputs, uninitialize_sandboxed_outputs
+
 
 __all__ = ['async', 'async_function', 'async_method', 'Http', 'RequestException', 'Iterator',
            'JSONEncoder', 'LRUCache', 'LambdaJob', 'DataflowJob',
            'print_exception_with_last_stack', 'get_item', 'compare_datetimes', 'pick_unused_port',
-           'is_http_running_on', 'gcs_copy_file', 'python_portable_string']
+           'is_http_running_on', 'gcs_copy_file', 'python_portable_string',
+           'initialize_sandboxed_outputs', 'uninitialize_sandboxed_outputs']

--- a/google/datalab/utils/_utils.py
+++ b/google/datalab/utils/_utils.py
@@ -263,3 +263,53 @@ def python_portable_string(string, encoding='utf-8'):
     return string.decode(encoding)
 
   raise ValueError('Unsupported type %s' % str(type(string)))
+
+
+_sandboxed_output_hook = None
+
+
+def initialize_sandboxed_outputs():
+  """ Initializes global browser state which some visualizations require.
+  """
+
+  global _sandboxed_output_hook
+
+  if _sandboxed_output_hook:
+    return
+
+  try:
+    import IPython
+  except ImportError:
+    # If not executing within IPython then initialization is unnecessary.
+    return
+
+  def configure_global_state():
+    """ Called for every cell execution to configure the individual output. """
+    IPython.display.display(IPython.core.display.HTML('''
+          <script src="/static/components/requirejs/require.js"></script>
+          <script>
+            requirejs.config({
+              paths: {
+                base: '/static/base',
+              },
+            });
+          </script>
+          '''))
+  _sandboxed_output_hook = configure_global_state
+  IPython.get_ipython().events.register('pre_run_cell', _sandboxed_output_hook)
+  # Invoke immediately to enable for the current cell.
+  configure_global_state()
+
+
+def uninitialize_sandboxed_outputs():
+  """ Uninitializes initialize_sandboxed_outputs()
+  """
+  global _sandboxed_output_hook
+
+  if not _sandboxed_output_hook:
+    return
+
+  import IPython
+
+  IPython.get_ipython().events.unregister('pre_run_cell', _sandboxed_output_hook)
+  _sandboxed_output_hook = None


### PR DESCRIPTION
Re-sending [this change](https://github.com/googledatalab/pydatalab/pull/481/files) by @blois to get around CLA issue.

This adds support for running Datalab widgets in sandboxed browser environments where the global window environment has not been populated with any of the regular Datalab state.

An open question is when this code should be invoked- it can be something which the user needs to explicitly opt into by invoking from their notebook code, or it could be invoked automatically since it's basically a pre-req for some of the visualizations.