### PR TITLE
Switch to using TensorFlow 1.3 in tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ skip_missing_interpreters = true
 # need them to run our tests suite.
 #
 # tox always installs the current package, so there's no need to list it here.
-deps = tensorflow==1.2.1
+deps = tensorflow==1.3
        lime==0.1.1.23
        # Dropping this seems to cause problems with conda in some cases.
        scipy


### PR DESCRIPTION
Everything *seems* to pass, which is almost too good to be true. 😉 

I didn't touch the explicit paths in `mltoolbox`, but let me know if you'd like those to stay in sync.