### PR TITLE
Fixing all unit-test warnings so that unit-tests console is "clean" after execution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'requests==2.9.1',
     'scikit-image==0.13.0',
     'scikit-learn==0.18.2',
+    'six==1.11.0',
     'ipykernel==4.5.2',
     'psutil==4.3.0',
     'jsonschema==2.6.0',

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,8 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'ipykernel==4.5.2',
     'psutil==4.3.0',
     'jsonschema==2.6.0',
+    # six needs to be pinned to 1.10.0 to work-around an apache_beam bug:
+    # https://stackoverflow.com/questions/46300173/import-apache-beam-metaclass-conflict
     'six==1.10.0',
   ],
   package_data={

--- a/setup.py
+++ b/setup.py
@@ -103,10 +103,10 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'requests==2.9.1',
     'scikit-image==0.13.0',
     'scikit-learn==0.18.2',
-    'six==1.11.0',
     'ipykernel==4.5.2',
     'psutil==4.3.0',
     'jsonschema==2.6.0',
+    'six==1.10.0',
   ],
   package_data={
     'google.datalab.notebook': [

--- a/tests/_util/commands_tests.py
+++ b/tests/_util/commands_tests.py
@@ -19,10 +19,7 @@ import six
 import sys
 import unittest
 import yaml
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+
 
 from google.datalab.utils.commands import CommandParser
 
@@ -111,7 +108,7 @@ class TestCases(unittest.TestCase):
 
     # 'string3' is a cell arg. Argparse will raise Exception after finding an unrecognized param.
     with self.assertRaisesRegexp(Exception, 'unrecognized arguments: --string3 value3'):
-      with TestCases.redirect_stderr(StringIO()):
+      with TestCases.redirect_stderr(six.StringIO()):
         parser.parse('subcommand1 subcommand2 -s value1 --string3 value3', 'a: b')
 
     # 'string4' is required but missing.

--- a/tests/_util/commands_tests.py
+++ b/tests/_util/commands_tests.py
@@ -111,7 +111,7 @@ class TestCases(unittest.TestCase):
 
     # 'string3' is a cell arg. Argparse will raise Exception after finding an unrecognized param.
     with self.assertRaisesRegexp(Exception, 'unrecognized arguments: --string3 value3'):
-      with TestCases.redirect_stderr(StringIO.StringIO()):
+      with TestCases.redirect_stderr(StringIO()):
         parser.parse('subcommand1 subcommand2 -s value1 --string3 value3', 'a: b')
 
     # 'string4' is required but missing.

--- a/tests/_util/commands_tests.py
+++ b/tests/_util/commands_tests.py
@@ -19,7 +19,10 @@ import six
 import sys
 import unittest
 import yaml
-import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 from google.datalab.utils.commands import CommandParser
 

--- a/tests/ml/summary_tests.py
+++ b/tests/ml/summary_tests.py
@@ -34,7 +34,14 @@ class TestSummary(unittest.TestCase):
     shutil.rmtree(self._test_dir)
 
   def _create_events(self):
+    # This is for suppressing TF warnings in the unit-test output of the form "The TensorFlow
+    # library wasn't compiled to use SSE4.2/AVX instructions..."
+    # TODO(rajivpb): Remove if this is no longer necessary.
+    os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
     with tf.Session(graph=tf.Graph()) as sess:
+      del os.environ['TF_CPP_MIN_LOG_LEVEL']
+      # Just making sure that this is unset so that os.environ is as before
+      self.assertIsNone(os.environ.get('TF_CPP_MIN_LOG_LEVEL'))
       train_num = tf.placeholder(dtype=tf.float32, shape=[])
       eval_num1 = tf.multiply(train_num, 2)
       eval_num2 = tf.add(eval_num1, 10)
@@ -82,7 +89,7 @@ class TestSummary(unittest.TestCase):
     df = events_list[0][train_dir]
     self.assertEqual(list(range(0, 10)), df['step'].tolist())
     self.assertEqual(list(range(1, 11)), df['value'].tolist())
-    self.assertIsInstance(df['time'][0], pd.tslib.Timestamp)
+    self.assertIsInstance(df['time'][0], pd.Timestamp)
 
     df = events_list[1][eval_dir]
     self.assertEqual(list(range(0, 10)), df['step'].tolist())


### PR DESCRIPTION
Before:
```
$ python PycharmProjects/pydatalab/tests/main.py --unittestonly
...........................................................................................................................................................................................................2017-09-22 17:06:35.253082: W tensorflow/core/platform/cpu_feature_guard.cc:45] The TensorFlow library wasn't compiled to use SSE4.1 instructions, but these are available on your machine and could speed up CPU computations.
2017-09-22 17:06:35.253101: W tensorflow/core/platform/cpu_feature_guard.cc:45] The TensorFlow library wasn't compiled to use SSE4.2 instructions, but these are available on your machine and could speed up CPU computations.
2017-09-22 17:06:35.253108: W tensorflow/core/platform/cpu_feature_guard.cc:45] The TensorFlow library wasn't compiled to use AVX instructions, but these are available on your machine and could speed up CPU computations.
/usr/local/google/home/rajivpb/PycharmProjects/pydatalab/tests/ml/summary_tests.py:85: FutureWarning: pandas.tslib is deprecated and will be removed in a future version.
You can access Timestamp as pandas.Timestamp
  self.assertIsInstance(df['time'][0], pd.tslib.Timestamp)
................................................................................usage: %test_subcommand_line [-h] {subcommand1} ...

test_subcommand_line description

positional arguments:
  {subcommand1}  commands
    subcommand1  subcommand1 help

optional arguments:
  -h, --help     show this help message and exit
.........../usr/local/google/home/rajivpb/virtualenvs/pydatalab/local/lib/python2.7/site-packages/numpy/lib/function_base.py:4011: RuntimeWarning: Invalid value encountered in median
  r = func(a, **kwargs)
.......................................
----------------------------------------------------------------------
Ran 333 tests in 2.687s

OK

```

After:
```
$ python PycharmProjects/pydatalab/tests/main.py --unittestonly


.............................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 333 tests in 2.732s

OK
```

For commands_tests.py, I tried the approach in https://github.com/googledatalab/pydatalab/blob/bdaac31bbfa36e3e21de743c1d6d8fb7f6b3b8ab/tests/_util/commands_tests.py#L134

but noticed the following additional spew in the output:
`/usr/local/google/home/rajivpb/virtualenvs/pydatalab/local/lib/python2.7/site-packages/numpy/lib/function_base.py:4011: RuntimeWarning: Invalid value encountered in median
`
Hence, I decided that create a new routine.

For TF-related warnings, I've wrapped a TF-session with  "os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'" and am also unsetting it soon after so that other places where a tf-session is used is not affected. 