### PR TITLE
ML Workbench: If top-n is 0, instead of outputing "predicted, predict…

### DIFF
--- a/solutionbox/code_free_ml/test_mltoolbox/test_training.py
+++ b/solutionbox/code_free_ml/test_mltoolbox/test_training.py
@@ -217,10 +217,10 @@ class TestClassificationTopN(unittest.TestCase):
           csv_data=['20'])
 
       keys = result.keys()
-      self.assertIn('probability', keys)
-      self.assertIn('probability_2', keys)
-      self.assertIn('probability_3', keys)
-      self.assertNotIn('probability_4', keys)
+      self.assertIn('predicted', keys)
+      self.assertIn('1', keys)
+      self.assertIn('2', keys)
+      self.assertIn('3', keys)
     finally:
       shutil.rmtree(output_dir)
 

--- a/tests/mlworkbench_magic/local_predict_tests.py
+++ b/tests/mlworkbench_magic/local_predict_tests.py
@@ -112,9 +112,9 @@ class TestLocalPredictions(unittest.TestCase):
     image_path1 = os.path.join(self._test_dir, 'img1.jpg')
     image_path2 = os.path.join(self._test_dir, 'img2.jpg')
     image_path3 = os.path.join(self._test_dir, 'img3.jpg')
-    Image.new('RGBA', size=(128, 128), color=(155, 211, 64)).save(image_path1, "JPEG")
+    Image.new('RGB', size=(128, 128), color=(155, 211, 64)).save(image_path1, "JPEG")
     Image.new('RGB', size=(64, 64), color=(111, 21, 86)).save(image_path2, "JPEG")
-    Image.new('RGBA', size=(16, 16), color=(255, 21, 1)).save(image_path3, "JPEG")
+    Image.new('RGB', size=(16, 16), color=(255, 21, 1)).save(image_path3, "JPEG")
 
     data = [
         {'key': 1, 'num1': 4.1, 'text1': '32', 'img_url1': image_path1},
@@ -184,6 +184,8 @@ class TestLocalPredictions(unittest.TestCase):
       self._validate_results(df, True, False)
 
   def test_get_probs_for_labels(self):
+    """Test get_probs_for_labels when top-n is set to non-zero (default)."""
+
     prediction_data = [
       {'predicted': 'daisy', 'probability': 0.8,
        'predicted_2': 'rose', 'probability_2': 0.1,
@@ -191,6 +193,21 @@ class TestLocalPredictions(unittest.TestCase):
       {'predicted': 'sunflower', 'probability': 0.9,
        'predicted_2': 'daisy', 'probability_2': 0.01,
        'predicted_3': 'rose', 'probability_3': 0.02},
+    ]
+    labels = ['daisy', 'rose', 'sunflower']
+    probs = mlw.get_probs_for_labels(labels, pd.DataFrame(prediction_data))
+    expected_probs = [
+      [0.8, 0.1, 0.05],
+      [0.01, 0.02, 0.9],
+    ]
+    self.assertEqual(expected_probs, probs)
+
+  def test_get_probs_for_labels_topn_0(self):
+    """Test get_probs_for_labels when top-n is set to zero."""
+
+    prediction_data = [
+      {'predicted': 'daisy', 'daisy': 0.8, 'rose': 0.1, 'sunflower': 0.05},
+      {'predicted': 'sunflower', 'sunflower': 0.9, 'daisy': 0.01, 'rose': 0.02}
     ]
     labels = ['daisy', 'rose', 'sunflower']
     probs = mlw.get_probs_for_labels(labels, pd.DataFrame(prediction_data))


### PR DESCRIPTION
…ed_2,...probability, probability_2,...", output "predicted, class1, class2,...".

For example, if top-n is 0, before the output was:

predicted: daisy
predicted_2: roses
predicted_3: sunflower
probability: 0.9
probability_2: 0.1
probability_3: 0.1

With this change it will be:
predicted: daisy
daisy: 0.9
roses: 0.1
sunflower: 0.1

The reason for the change is that if all classes are included, top-n results are not that useful. But in some cases, it is convenient to have a column of a certain class's probability. For example, plotting ROC curve requires prob of a certain class.