### PR TITLE
Add "%%ml evaluate regression" and "%%ml evaluate accuracy" commands.

### DIFF
--- a/google/datalab/contrib/mlworkbench/commands/_ml.py
+++ b/google/datalab/contrib/mlworkbench/commands/_ml.py
@@ -831,6 +831,7 @@ def _tensorboard_list(args, cell):
 
 
 def _get_evaluation_csv_schema(csv_file):
+  # ML Workbench produces predict_results_schema.json in local batch prediction.
   schema_file = os.path.join(os.path.dirname(csv_file), 'predict_results_schema.json')
   if not file_io.file_exists(schema_file):
     raise ValueError('csv data requires headers.')

--- a/google/datalab/kernel/__init__.py
+++ b/google/datalab/kernel/__init__.py
@@ -83,7 +83,7 @@ def load_ipython_extension(shell):
     return _orig_run_line_magic(self, magic_name, line)
 
   def _run_cell_magic(self, magic_name, line, cell):
-    if len(cell) == 0 or cell.isspace():
+    if cell is None or len(cell) == 0 or cell.isspace():
       fn = self.find_line_magic(magic_name)
       if fn:
         return _orig_run_line_magic(self, magic_name, line)


### PR DESCRIPTION
Also flatten the data source for %%ml evaluate, so it takes "csv", or "bigquery" directly instead of having them under "data".
Fix another issue that if a magic is not registered and being run, a confusing error appears.