### PR TITLE
Making email an optional/customizable field in cell_body

### DIFF
--- a/google/datalab/contrib/bigquery/commands/_bigquery.py
+++ b/google/datalab/contrib/bigquery/commands/_bigquery.py
@@ -75,7 +75,7 @@ def _get_pipeline_spec_from_config(bq_pipeline_config):
     pipeline_spec['tasks'][execute_task_config_name] = execute_task_config
   if extract_task_config:
     pipeline_spec['tasks'][extract_task_config_name] = extract_task_config
-  pipeline_spec['email'] = bq_pipeline_config.get('email')
+  pipeline_spec['emails'] = bq_pipeline_config.get('emails')
 
   if not load_task_config and not execute_task_config and not extract_task_config:
     raise Exception('Pipeline has no tasks to execute.')

--- a/google/datalab/contrib/bigquery/commands/_bigquery.py
+++ b/google/datalab/contrib/bigquery/commands/_bigquery.py
@@ -52,9 +52,9 @@ def _pipeline_cell(args, cell_body):
 
 
 def _get_pipeline_spec_from_config(bq_pipeline_config):
-  input_config = bq_pipeline_config.get('input', None)
-  transformation_config = bq_pipeline_config.get('transformation', None)
-  output_config = bq_pipeline_config.get('output', None)
+  input_config = bq_pipeline_config.get('input')
+  transformation_config = bq_pipeline_config.get('transformation')
+  output_config = bq_pipeline_config.get('output')
 
   load_task_config_name = 'bq_pipeline_load_task'
   execute_task_config_name = 'bq_pipeline_execute_task'
@@ -75,6 +75,7 @@ def _get_pipeline_spec_from_config(bq_pipeline_config):
     pipeline_spec['tasks'][execute_task_config_name] = execute_task_config
   if extract_task_config:
     pipeline_spec['tasks'][extract_task_config_name] = extract_task_config
+  pipeline_spec['email'] = bq_pipeline_config.get('email')
 
   if not load_task_config and not execute_task_config and not extract_task_config:
     raise Exception('Pipeline has no tasks to execute.')

--- a/google/datalab/contrib/pipeline/_pipeline.py
+++ b/google/datalab/contrib/pipeline/_pipeline.py
@@ -71,7 +71,8 @@ from pytz import timezone
     start_datetime_obj = self._pipeline_spec.get('schedule').get('start')
     end_datetime_obj = self._pipeline_spec.get('schedule').get('end')
 
-    default_args = Pipeline._get_default_args(start_datetime_obj, end_datetime_obj)
+    default_args = Pipeline._get_default_args(start_datetime_obj, end_datetime_obj,
+                                              self._pipeline_spec.get('email'))
     dag_definition = self._get_dag_definition(
         self._pipeline_spec.get('schedule')['interval'])
 
@@ -88,15 +89,20 @@ from pytz import timezone
         task_definitions + up_steam_statements
 
   @staticmethod
-  def _get_default_args(start, end):
+  def _get_default_args(start, end, emails):
     start_date_str = Pipeline._get_datetime_expr_str(start)
     end_date_str = Pipeline._get_datetime_expr_str(end)
+
+    email_list = emails
+    if emails:
+      email_list = emails.split(',')
+
     # TODO(rajivpb): Get the email address in some other way.
     airflow_default_args_format = """
 default_args = {{
     'owner': 'Datalab',
     'depends_on_past': False,
-    'email': ['foo@bar.com'],
+    'email': {2},
     'start_date': {0},
     'end_date': {1},
     'email_on_failure': True,
@@ -106,7 +112,7 @@ default_args = {{
 }}
 
 """
-    return airflow_default_args_format.format(start_date_str, end_date_str)
+    return airflow_default_args_format.format(start_date_str, end_date_str, email_list)
 
   @staticmethod
   def _get_datetime_expr_str(datetime_obj):

--- a/google/datalab/contrib/pipeline/_pipeline.py
+++ b/google/datalab/contrib/pipeline/_pipeline.py
@@ -72,7 +72,7 @@ from pytz import timezone
     end_datetime_obj = self._pipeline_spec.get('schedule').get('end')
 
     default_args = Pipeline._get_default_args(start_datetime_obj, end_datetime_obj,
-                                              self._pipeline_spec.get('email'))
+                                              self._pipeline_spec.get('emails'))
     dag_definition = self._get_dag_definition(
         self._pipeline_spec.get('schedule')['interval'])
 

--- a/tests/bigquery/pipeline_tests.py
+++ b/tests/bigquery/pipeline_tests.py
@@ -139,6 +139,7 @@ class TestCases(unittest.TestCase):
     args = {'name': 'bq_pipeline_test', 'debug': True}
     # TODO(rajivpb): The references to foo_query need to be resolved.
     cell_body = """
+            email: foo1@test.com,foo2@test.com
             schedule:
                 start: 2009-05-05T22:28:15Z
                 end: 2009-05-06T22:28:15Z
@@ -188,7 +189,7 @@ from pytz import timezone
 default_args = {
     'owner': 'Datalab',
     'depends_on_past': False,
-    'email': \['foo@bar.com'\],
+    'email': \['foo1@test.com', 'foo2@test.com'\],
     'start_date': datetime.datetime.strptime\('2009-05-05T22:28:15', '%Y-%m-%dT%H:%M:%S'\).replace\(tzinfo=timezone\('UTC'\)\),
     'end_date': datetime.datetime.strptime\('2009-05-06T22:28:15', '%Y-%m-%dT%H:%M:%S'\).replace\(tzinfo=timezone\('UTC'\)\),
     'email_on_failure': True,

--- a/tests/bigquery/pipeline_tests.py
+++ b/tests/bigquery/pipeline_tests.py
@@ -139,7 +139,7 @@ class TestCases(unittest.TestCase):
     args = {'name': 'bq_pipeline_test', 'debug': True}
     # TODO(rajivpb): The references to foo_query need to be resolved.
     cell_body = """
-            email: foo1@test.com,foo2@test.com
+            emails: foo1@test.com,foo2@test.com
             schedule:
                 start: 2009-05-05T22:28:15Z
                 end: 2009-05-06T22:28:15Z

--- a/tests/kernel/bigquery_tests.py
+++ b/tests/kernel/bigquery_tests.py
@@ -757,13 +757,7 @@ WITH q1 AS (
 
     @mock.patch('google.datalab.Context.default')
     @mock.patch('google.datalab.utils.commands.notebook_environment')
-    @mock.patch('google.datalab.bigquery.Table.exists')
-    @mock.patch('google.datalab.bigquery.commands._bigquery._get_table')
-    def test_pipeline_cell(self, mock_get_table, mock_table_exists, mock_environment,
-                           mock_default_context):
-      table = bq.Table('project.test.table')
-      mock_get_table.return_value = table
-      mock_table_exists.return_value = True
+    def test_pipeline_cell(self, mock_environment, mock_default_context):
       context = TestCases._create_context()
       mock_default_context.return_value = context
 
@@ -773,82 +767,24 @@ WITH q1 AS (
       }
       mock_environment.return_value = env
 
-      args = {'name': 'bq_pipeline_test', 'debug': True, 'billing': 'foo_billing'}
-      # TODO(rajivpb): The references to foo_query need to be resolved.
-      cell_body = """
+      args = {'name': 'bq_pipeline_test'}
+      small_cell_body = """
+              email: foo1@test.com
               schedule:
                   start: 2009-05-05T22:28:15Z
                   end: 2009-05-06T22:28:15Z
                   interval: '@hourly'
               input:
-                  path: test/path
                   table: project.test.table
-                  schema:
-                      - name: col1
-                        type: int64
-                        mode: NULLABLE
-                        description: description1
-                      - name: col2
-                        type: STRING
-                        mode: required
-                        description: description1
               transformation:
                   query: foo_query
               output:
-                  path: test/path
                   table: project.test.table
          """
 
-      output = google.datalab.contrib.bigquery.commands._bigquery._pipeline_cell(args, cell_body)
-
-      pattern = re.compile("""
-  import datetime
-  from airflow import DAG
-  from airflow.operators.bash_operator import BashOperator
-  from airflow.contrib.operators.bigquery_operator import BigQueryOperator
-  from airflow.contrib.operators.bigquery_table_delete_operator import BigQueryTableDeleteOperator
-  from airflow.contrib.operators.bigquery_to_bigquery import BigQueryToBigQueryOperator
-  from airflow.contrib.operators.bigquery_to_gcs import BigQueryToCloudStorageOperator
-  from airflow.contrib.operators.gcs_to_bq import GoogleCloudStorageToBigQueryOperator
-  from google.datalab.contrib.bigquery.operators.bq_load_operator import LoadOperator
-  from google.datalab.contrib.bigquery.operators.bq_execute_operator import ExecuteOperator
-  from google.datalab.contrib.bigquery.operators.bq_extract_operator import ExtractOperator
-  from datetime import timedelta
-  from pytz import timezone
-
-  default_args = {
-      'owner': 'Datalab',
-      'depends_on_past': False,
-      'email': \['foo@bar.com'\],
-      'start_date': datetime.datetime.strptime\('2009-05-05T22:28:15', '%Y-%m-%dT%H:%M:%S'\).replace\(tzinfo=timezone\('UTC'\)\),
-      'end_date': datetime.datetime.strptime\('2009-05-06T22:28:15', '%Y-%m-%dT%H:%M:%S'\).replace\(tzinfo=timezone\('UTC'\)\),
-      'email_on_failure': True,
-      'email_on_retry': False,
-      'retries': 1,
-      'retry_delay': timedelta\(minutes=1\),
-  }
-
-  dag = DAG\(dag_id='bq_pipeline_test', schedule_interval='@hourly', default_args=default_args\)
-
-  bq_pipeline_execute_task = ExecuteOperator\(task_id='bq_pipeline_execute_task_id', mode='create', query='foo_query', table='project.test.table', dag=dag\)
-  bq_pipeline_extract_task = ExtractOperator\(task_id='bq_pipeline_extract_task_id', compress=True, delimiter=',', format='csv', header=True, path='test/path', dag=dag\)
-  bq_pipeline_load_task = LoadOperator\(task_id='bq_pipeline_load_task_id', delimiter=',', format='csv', mode='create', path='test/path', quote='"', schema=(.*), skip=0, strict=True, table='project.test.table', dag=dag\)
-  bq_pipeline_execute_task.set_upstream\(bq_pipeline_load_task\)
-  bq_pipeline_extract_task.set_upstream\(bq_pipeline_execute_task\)
-  """)  # noqa
-
-      self.assertIsNotNone(pattern.match(output))
-
-      # group(1) has the string that follows the "schema=", i.e. the list of dicts.
-      actual_schema_str = pattern.match(output).group(1)
-      self.assertIn("'type': 'int64'", actual_schema_str)
-      self.assertIn("'mode': 'NULLABLE'", actual_schema_str)
-      self.assertIn("'name': 'col1'", actual_schema_str)
-      self.assertIn("'description': 'description1'", actual_schema_str)
-      self.assertIn("'type': 'STRING'", actual_schema_str)
-      self.assertIn("'mode': 'required'", actual_schema_str)
-      self.assertIn("'name': 'col2'", actual_schema_str)
-      self.assertIn("'description': 'description1'", actual_schema_str)
+      actual = google.datalab.contrib.bigquery.commands._bigquery._pipeline_cell(args,
+                                                                                 small_cell_body)
+      self.assertIn("'email': ['foo1@test.com']", actual)
 
   @mock.patch('google.datalab.utils.commands._html.Html.next_id')
   @mock.patch('google.datalab.utils.commands._html.HtmlBuilder.render_chart_data')

--- a/tests/kernel/bigquery_tests.py
+++ b/tests/kernel/bigquery_tests.py
@@ -15,7 +15,6 @@ from __future__ import unicode_literals
 import json
 import mock
 import pandas
-import re
 import six
 import unittest
 
@@ -769,7 +768,7 @@ WITH q1 AS (
 
       args = {'name': 'bq_pipeline_test'}
       small_cell_body = """
-              email: foo1@test.com
+              emails: foo1@test.com
               schedule:
                   start: 2009-05-05T22:28:15Z
                   end: 2009-05-06T22:28:15Z

--- a/tests/kernel/pipeline_tests.py
+++ b/tests/kernel/pipeline_tests.py
@@ -111,7 +111,7 @@ tasks:
 
     # test pipeline creation
     p_body = """
-email: foo1@test.com,foo2@test.com
+emails: foo1@test.com,foo2@test.com
 schedule:
   start: 2009-05-05T22:28:15Z
   end: 2009-05-06T22:28:15Z

--- a/tests/kernel/pipeline_tests.py
+++ b/tests/kernel/pipeline_tests.py
@@ -111,6 +111,7 @@ tasks:
 
     # test pipeline creation
     p_body = """
+email: foo1@test.com,foo2@test.com
 schedule:
   start: 2009-05-05T22:28:15Z
   end: 2009-05-06T22:28:15Z
@@ -151,7 +152,7 @@ from pytz import timezone
 default_args = {
     'owner': 'Datalab',
     'depends_on_past': False,
-    'email': ['foo@bar.com'],
+    'email': ['foo1@test.com', 'foo2@test.com'],
     'start_date': datetime.datetime.strptime('2009-05-05T22:28:15', '%Y-%m-%dT%H:%M:%S').replace(tzinfo=timezone('UTC')),
     'end_date': datetime.datetime.strptime('2009-05-06T22:28:15', '%Y-%m-%dT%H:%M:%S').replace(tzinfo=timezone('UTC')),
     'email_on_failure': True,

--- a/tests/pipeline/pipeline_tests.py
+++ b/tests/pipeline/pipeline_tests.py
@@ -31,6 +31,7 @@ import google.auth
 class PipelineTest(unittest.TestCase):
 
   _test_pipeline_yaml_spec = """
+email: foo1@test.com,foo2@test.com
 schedule:
   start: 2009-05-05T22:28:15Z
   end: 2009-05-06T22:28:15Z
@@ -309,26 +310,19 @@ tasks:
                                        tzinfo=timezone('UTC')))
 
   def test_get_default_args(self):
-    import yaml
+    # email is specified
     dag_dict = yaml.load(PipelineTest._test_pipeline_yaml_spec)
-    self.assertEqual(
-      pipeline.Pipeline._get_default_args(dag_dict.get('schedule').get('start'),
-                                          dag_dict.get('schedule').get('end')),
-"""
-default_args = {
-    'owner': 'Datalab',
-    'depends_on_past': False,
-    'email': ['foo@bar.com'],
-    'start_date': datetime.datetime.strptime('2009-05-05T22:28:15', '%Y-%m-%dT%H:%M:%S').replace(tzinfo=timezone('UTC')),
-    'end_date': datetime.datetime.strptime('2009-05-06T22:28:15', '%Y-%m-%dT%H:%M:%S').replace(tzinfo=timezone('UTC')),
-    'email_on_failure': True,
-    'email_on_retry': False,
-    'retries': 1,
-    'retry_delay': timedelta(minutes=1),
-}
+    actual = pipeline.Pipeline._get_default_args(dag_dict.get('schedule').get('start'),
+                                                 dag_dict.get('schedule').get('end'),
+                                                 dag_dict.get('email'))
+    self.assertIn("'email': ['foo1@test.com', 'foo2@test.com']", actual)
 
-"""  # noqa
-    )
+    # email is not specified
+    dag_dict = yaml.load(PipelineTest._test_pipeline_yaml_spec)
+    actual = pipeline.Pipeline._get_default_args(dag_dict.get('schedule').get('start'),
+                                                 dag_dict.get('schedule').get('end'),
+                                                 None)
+    self.assertIn("'email': None", actual)
 
 
 if __name__ == '__main__':

--- a/tests/pipeline/pipeline_tests.py
+++ b/tests/pipeline/pipeline_tests.py
@@ -31,7 +31,7 @@ import google.auth
 class PipelineTest(unittest.TestCase):
 
   _test_pipeline_yaml_spec = """
-email: foo1@test.com,foo2@test.com
+emails: foo1@test.com,foo2@test.com
 schedule:
   start: 2009-05-05T22:28:15Z
   end: 2009-05-06T22:28:15Z
@@ -309,15 +309,14 @@ tasks:
                      datetime.datetime(2009, 5, 5, 22, 28, 15,
                                        tzinfo=timezone('UTC')))
 
-  def test_get_default_args(self):
-    # email is specified
+  def test_get_default_args_with_email(self):
     dag_dict = yaml.load(PipelineTest._test_pipeline_yaml_spec)
     actual = pipeline.Pipeline._get_default_args(dag_dict.get('schedule').get('start'),
                                                  dag_dict.get('schedule').get('end'),
-                                                 dag_dict.get('email'))
+                                                 dag_dict.get('emails'))
     self.assertIn("'email': ['foo1@test.com', 'foo2@test.com']", actual)
 
-    # email is not specified
+  def test_get_default_args_without_email(self):
     dag_dict = yaml.load(PipelineTest._test_pipeline_yaml_spec)
     actual = pipeline.Pipeline._get_default_args(dag_dict.get('schedule').get('start'),
                                                  dag_dict.get('schedule').get('end'),


### PR DESCRIPTION
This had been provisionally hard-coded to foo@bar.com in various places. This now being surfaced as a legit settable key in the config for the pipeline in the cell-body.