### PR TITLE
A few cleanups and fixes to get the end-to-end working

### DIFF
--- a/google/datalab/bigquery/commands/_bigquery.py
+++ b/google/datalab/bigquery/commands/_bigquery.py
@@ -901,7 +901,8 @@ for help on a specific command.
   _add_command(parser, _create_load_subparser, _load_cell)
 
   # %bq pipeline
-  _add_command(parser, contrib_bq._create_pipeline_subparser, contrib_bq._pipeline_cell)
+  _add_command(parser, contrib_bq._create_pipeline_subparser, contrib_bq._pipeline_cell,
+               cell_required=True)
 
   return parser
 

--- a/google/datalab/contrib/bigquery/operators/_bq_extract_operator.py
+++ b/google/datalab/contrib/bigquery/operators/_bq_extract_operator.py
@@ -26,12 +26,9 @@ class ExtractOperator(BaseOperator):
     self._csv_options = csv_options or {}
 
   def execute(self, context):
-
     if self._table:
       pydatalab_context = google.datalab.Context.default()
       source_table = google.datalab.bigquery.Table(self._table, context=pydatalab_context)
-      if not source_table:
-        raise Exception('Could not find table %s' % self._table)
       job = source_table.extract(
         self._path, format='CSV' if self._format == 'csv' else 'NEWLINE_DELIMITED_JSON',
         csv_delimiter=self._csv_options.get('delimiter'),

--- a/google/datalab/contrib/bigquery/operators/_bq_load_operator.py
+++ b/google/datalab/contrib/bigquery/operators/_bq_load_operator.py
@@ -27,7 +27,8 @@ class LoadOperator(BaseOperator):
     A message about whether the load succeeded or failed.
   """
   @apply_defaults
-  def __init__(self, table, path, mode, format, schema, csv_options=None, *args, **kwargs):
+  def __init__(self, table, path, mode='append', format=None, schema=None, csv_options=None, *args,
+               **kwargs):
     super(LoadOperator, self).__init__(*args, **kwargs)
     self._table = table
     self._path = path

--- a/tests/bigquery/pipeline_tests.py
+++ b/tests/bigquery/pipeline_tests.py
@@ -188,7 +188,7 @@ class TestCases(unittest.TestCase):
       'output_table_format': 'cloud-datalab-samples.endpoints.logs_%(ds)s'
     }
     mock_notebook_item.return_value = google.datalab.bigquery.Query(
-        'SELECT @column FROM {0} where endpoint=@endpoint'.format(env['input_table_format']))
+        'SELECT @column FROM `{0}` where endpoint=@endpoint'.format(env['input_table_format']))
 
     mock_environment.return_value = env
     args = {'name': 'bq_pipeline_test'}
@@ -262,7 +262,7 @@ default_args = {
 
 dag = DAG\(dag_id='bq_pipeline_test', schedule_interval='@hourly', default_args=default_args\)
 
-bq_pipeline_execute_task = ExecuteOperator\(task_id='bq_pipeline_execute_task_id', parameters=(.*), sql='SELECT @column FROM cloud-datalab-samples.httplogs.logs_{{ ds_nodash }} where endpoint=@endpoint', table='cloud-datalab-samples.endpoints.logs_{{ ds_nodash }}', dag=dag\)
+bq_pipeline_execute_task = ExecuteOperator\(task_id='bq_pipeline_execute_task_id', parameters=(.*), sql='SELECT @column FROM `cloud-datalab-samples.httplogs.logs_{{ ds_nodash }}` where endpoint=@endpoint', table='cloud-datalab-samples.endpoints.logs_{{ ds_nodash }}', dag=dag\)
 bq_pipeline_extract_task = ExtractOperator\(task_id='bq_pipeline_extract_task_id', csv_options=None, format='csv', path='gs://bucket/cloud-datalab-samples-endpoints_{{ ds_nodash }}.csv', table='cloud-datalab-samples.endpoints.logs_{{ ds_nodash }}', dag=dag\)
 bq_pipeline_load_task = LoadOperator\(task_id='bq_pipeline_load_task_id', csv_options=(.*), format='csv', mode='create', path='gs://bucket/cloud-datalab-samples-httplogs_{{ ds_nodash }}', schema=(.*), table='cloud-datalab-samples.httplogs.logs_{{ ds_nodash }}', dag=dag\)
 bq_pipeline_execute_task.set_upstream\(bq_pipeline_load_task\)


### PR DESCRIPTION
 - Escaping BQ-table names with `. This will require a change to the user interface.
 - Convenience default parameters for LoadOperator
 - Remove unnecessary check for table-existence
 - Requiring cell for %%bq pipeline