### PR TITLE
Declare templatized attributes for airflow's jinja templates

### DIFF
--- a/google/datalab/contrib/bigquery/operators/_bq_execute_operator.py
+++ b/google/datalab/contrib/bigquery/operators/_bq_execute_operator.py
@@ -19,6 +19,8 @@ from google.datalab.contrib.pipeline._pipeline import Pipeline
 
 class ExecuteOperator(BaseOperator):
 
+  template_fields = ('_sql', '_table')
+
   @apply_defaults
   def __init__(self, sql, parameters=None, table=None, mode=None, *args, **kwargs):
     super(ExecuteOperator, self).__init__(*args, **kwargs)

--- a/google/datalab/contrib/bigquery/operators/_bq_extract_operator.py
+++ b/google/datalab/contrib/bigquery/operators/_bq_extract_operator.py
@@ -17,8 +17,10 @@ from airflow.utils.decorators import apply_defaults
 
 class ExtractOperator(BaseOperator):
 
+  template_fields = ('_table', '_path')
+
   @apply_defaults
-  def __init__(self, table, path, format, csv_options=None, *args, **kwargs):
+  def __init__(self, table, path, format='csv', csv_options=None, *args, **kwargs):
     super(ExtractOperator, self).__init__(*args, **kwargs)
     self._table = table
     self._path = path

--- a/google/datalab/contrib/bigquery/operators/_bq_load_operator.py
+++ b/google/datalab/contrib/bigquery/operators/_bq_load_operator.py
@@ -26,8 +26,11 @@ class LoadOperator(BaseOperator):
   Returns:
     A message about whether the load succeeded or failed.
   """
+
+  template_fields = ('_table', '_path')
+
   @apply_defaults
-  def __init__(self, table, path, mode='append', format=None, schema=None, csv_options=None, *args,
+  def __init__(self, table, path, mode='append', format='csv', schema=None, csv_options=None, *args,
                **kwargs):
     super(LoadOperator, self).__init__(*args, **kwargs)
     self._table = table

--- a/tests/bigquery/operator_tests.py
+++ b/tests/bigquery/operator_tests.py
@@ -151,3 +151,25 @@ class TestCases(unittest.TestCase):
       mock_table_load.assert_called_with('test/path', mode='append',
                                          source_format='csv', csv_options=mock.ANY,
                                          ignore_unknown_values=True)
+
+  def test_defaults_execute_operator(self):
+    execute_operator = ExecuteOperator(task_id='foo_task_id', sql='foo_sql')
+    self.assertIsNone(execute_operator._parameters)
+    self.assertIsNone(execute_operator._table)
+    self.assertIsNone(execute_operator._mode)
+
+    self.assertEqual(execute_operator.template_fields, ('_sql', '_table'))
+
+  def test_default_parameters_extract_operator(self):
+    extract_operator = ExtractOperator(task_id='foo_task_id', path='foo_path', table='foo_table')
+    self.assertEquals(extract_operator._format, 'csv')
+    self.assertDictEqual(extract_operator._csv_options, {})
+    self.assertEqual(extract_operator.template_fields, ('_table', '_path'))
+
+  def test_default_parameters_load_operator(self):
+    load_operator = LoadOperator(task_id='foo_task_id', path='foo_path', table='foo_table')
+    self.assertEquals(load_operator._format, 'csv')
+    self.assertEquals(load_operator._mode, 'append')
+    self.assertIsNone(load_operator._schema)
+    self.assertDictEqual(load_operator._csv_options, {})
+    self.assertEqual(load_operator.template_fields, ('_table', '_path'))


### PR DESCRIPTION
These are necessary to get the string substitutions (ds and ts) working.