### PR TITLE
Use Airflow's XCom to communicate BQ table name from ExecuteOperator to ExtractOperator

### DIFF
--- a/google/datalab/bigquery/_query_results_table.py
+++ b/google/datalab/bigquery/_query_results_table.py
@@ -68,4 +68,3 @@ class QueryResultsTable(_table.Table):
   def is_temporary(self):
     """ Whether this is a short-lived table or not. """
     return self._is_temporary
-

--- a/google/datalab/bigquery/_query_results_table.py
+++ b/google/datalab/bigquery/_query_results_table.py
@@ -68,3 +68,4 @@ class QueryResultsTable(_table.Table):
   def is_temporary(self):
     """ Whether this is a short-lived table or not. """
     return self._is_temporary
+

--- a/google/datalab/contrib/bigquery/operators/_bq_execute_operator.py
+++ b/google/datalab/contrib/bigquery/operators/_bq_execute_operator.py
@@ -31,14 +31,14 @@ class ExecuteOperator(BaseOperator):
 
   def execute(self, context):
     query = bq.Query(sql=self._sql)
-    # allow_large_results is set to False because setting it True requires the destination table to
-    # be specified.
-    # use_cache is set to False since this is most likely the case for all pipeline scenarios
+    # allow_large_results is False because setting it True requires the destination table
+    # use_cache is False since this is most likely the case in pipeline scenarios
     output_options = bq.QueryOutput.table(name=self._table, mode=self._mode, use_cache=False,
                                           allow_large_results=False)
+
     pydatalab_context = google.datalab.Context.default()
     query_params = Pipeline._get_query_parameters(self._parameters)
     job = query.execute(output_options, context=pydatalab_context, query_params=query_params)
-    # returning the name of the table used for the results so that it could be used by downstream
-    # tasks if they need it.
+
+    # Returning the table-name here makes it available for downstream task instances.
     return job.result().name

--- a/google/datalab/contrib/bigquery/operators/_bq_execute_operator.py
+++ b/google/datalab/contrib/bigquery/operators/_bq_execute_operator.py
@@ -10,7 +10,6 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
-import google
 import google.datalab.bigquery as bq
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults

--- a/google/datalab/contrib/bigquery/operators/_bq_execute_operator.py
+++ b/google/datalab/contrib/bigquery/operators/_bq_execute_operator.py
@@ -38,6 +38,7 @@ class ExecuteOperator(BaseOperator):
                                           allow_large_results=False)
     pydatalab_context = google.datalab.Context.default()
     query_params = Pipeline._get_query_parameters(self._parameters)
-    # TODO(rajivpb): Is this a sync or an async operation? Unlike load(), this does not wrap its
-    # async counterpart with a job.wait(). Test and wait if necessary.
-    query.execute(output_options, context=pydatalab_context, query_params=query_params)
+    job = query.execute(output_options, context=pydatalab_context, query_params=query_params)
+    # returning the name of the table used for the results so that it could be used by downstream
+    # tasks if they need it.
+    return job.result().name

--- a/google/datalab/contrib/bigquery/operators/_bq_execute_operator.py
+++ b/google/datalab/contrib/bigquery/operators/_bq_execute_operator.py
@@ -36,7 +36,7 @@ class ExecuteOperator(BaseOperator):
                                           allow_large_results=self._table is not None)
 
     query_params = Pipeline._get_query_parameters(self._parameters)
-    job = query.execute(output_options, context=None, query_params=query_params)
+    job = query.execute(output_options, query_params=query_params)
 
     # Returning the table-name here makes it available for downstream task instances.
     return {

--- a/google/datalab/contrib/bigquery/operators/_bq_extract_operator.py
+++ b/google/datalab/contrib/bigquery/operators/_bq_extract_operator.py
@@ -20,7 +20,7 @@ class ExtractOperator(BaseOperator):
   template_fields = ('_table', '_path')
 
   @apply_defaults
-  def __init__(self, table, path, format='csv', csv_options=None, *args, **kwargs):
+  def __init__(self, path, table=None, format='csv', csv_options=None, *args, **kwargs):
     super(ExtractOperator, self).__init__(*args, **kwargs)
     self._table = table
     self._path = path
@@ -28,15 +28,28 @@ class ExtractOperator(BaseOperator):
     self._csv_options = csv_options or {}
 
   def execute(self, context):
-    if self._table:
-      pydatalab_context = google.datalab.Context.default()
-      source_table = google.datalab.bigquery.Table(self._table, context=pydatalab_context)
-      job = source_table.extract(
-        self._path, format='CSV' if self._format == 'csv' else 'NEWLINE_DELIMITED_JSON',
-        csv_delimiter=self._csv_options.get('delimiter'),
-        csv_header=self._csv_options.get('header'), compress=self._csv_options.get('compress'))
-    else:
-      raise Exception('A table is needed to extract')
+    if not self._table:
+      task_instance = context['task_instance']
+      # If the table is not specified, we fetch it from the output of the execute task, i.e. the
+      # query results table. This could either be a permanent table or a temporary table. If we're
+      # here, it is most likely a temporary table. If it was a permanent one, it would have been
+      # passed in as a param and we wouldn't be here.
+      # TODO(rajivpb): Assert that if we're here, then the table is a temporary one.
+      # TODO(rajivpb):
+      # The task id of the execute task is created by concatenating 'bq_pipeline_execute_task'
+      # and '_id'. This is currently being hard-coded, but consider making this a parameter.
+      # It could require substantial changes to the underlying object model of Pipeline.
+      self._table = task_instance.xcom_pull(task_ids='bq_pipeline_execute_task_id')
+
+    if not self._table:
+      raise Exception('A table is needed to extract.')
+
+    pydatalab_context = google.datalab.Context.default()
+    source_table = google.datalab.bigquery.Table(self._table, context=pydatalab_context)
+    job = source_table.extract(
+      self._path, format='CSV' if self._format == 'csv' else 'NEWLINE_DELIMITED_JSON',
+      csv_delimiter=self._csv_options.get('delimiter'),
+      csv_header=self._csv_options.get('header'), compress=self._csv_options.get('compress'))
 
     if job.failed:
       raise Exception('Extract failed: %s' % str(job.fatal_error))

--- a/google/datalab/contrib/bigquery/operators/_bq_load_operator.py
+++ b/google/datalab/contrib/bigquery/operators/_bq_load_operator.py
@@ -42,8 +42,7 @@ class LoadOperator(BaseOperator):
 
   def execute(self, context):
     if self._table:
-      pydatalab_context = google.datalab.Context.default()
-      table = bq.Table(self._table, context=pydatalab_context)
+      table = bq.Table(self._table, context=None)
 
     if self._mode == 'create':
       if table.exists():
@@ -67,3 +66,7 @@ class LoadOperator(BaseOperator):
       raise Exception('Load failed: %s' % str(job.fatal_error))
     elif job.errors:
       raise Exception('Load completed with errors: %s' % str(job.errors))
+
+    return {
+      'result': job.result()
+    }

--- a/google/datalab/contrib/bigquery/operators/_bq_load_operator.py
+++ b/google/datalab/contrib/bigquery/operators/_bq_load_operator.py
@@ -10,7 +10,6 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
-import google
 import google.datalab.bigquery as bq
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     # six needs to be pinned to 1.10.0 to work-around an apache_beam bug:
     # https://stackoverflow.com/questions/46300173/import-apache-beam-metaclass-conflict
     'six==1.10.0',
+    'urllib3==1.22'
   ],
   package_data={
     'google.datalab.notebook': [

--- a/tests/bigquery/operator_tests.py
+++ b/tests/bigquery/operator_tests.py
@@ -92,7 +92,7 @@ class TestCases(unittest.TestCase):
     mock_table_extract.return_value.failed = False
     mock_table_extract.return_value.errors = None
     self.assertDictEqual(extract_operator.execute(context={'task_instance': mock_task_instance}),
-                     {'result': 'test-results'})
+                         {'result': 'test-results'})
     mock_table_extract.assert_called_with('test_path', format='NEWLINE_DELIMITED_JSON',
                                           csv_delimiter=None, csv_header=None, compress=None)
 
@@ -124,7 +124,8 @@ class TestCases(unittest.TestCase):
     mock_query_execute.return_value = mock_query_job
     query_results_table_name = 'foo_table'
     mock_query_job.result.return_value.name = query_results_table_name
-    self.assertDictEqual(execute_operator.execute(context=None), {'table': query_results_table_name})
+    self.assertDictEqual(execute_operator.execute(context=None),
+                         {'table': query_results_table_name})
     mock_query_output_table.assert_called_with(name=None, mode=None, use_cache=False,
                                                allow_large_results=False)
 

--- a/tests/bigquery/operator_tests.py
+++ b/tests/bigquery/operator_tests.py
@@ -40,6 +40,7 @@ from google.datalab.contrib.bigquery.operators._bq_load_operator import LoadOper
 class TestCases(unittest.TestCase):
 
   test_project_id = 'test_project'
+  test_table_name = 'project.test.table'
 
   @staticmethod
   def _create_context():
@@ -59,7 +60,7 @@ class TestCases(unittest.TestCase):
     mock_table_extract.return_value.result = lambda: 'test-results'
     mock_table_extract.return_value.failed = False
     mock_table_extract.return_value.errors = None
-    self.assertEqual(extract_operator.execute(context=None), 'test-results')
+    self.assertDictEqual(extract_operator.execute(context=None), {'result': 'test-results'})
     mock_table_extract.assert_called_with('test_path', format='NEWLINE_DELIMITED_JSON',
                                           csv_delimiter=None, csv_header=None, compress=None)
 
@@ -83,15 +84,15 @@ class TestCases(unittest.TestCase):
   def test_extract_operator_with_temporary_table(self, mock_task_instance, mock_table_extract,
                                                  mock_context_default):
     mock_context_default.return_value = TestCases._create_context()
-    mock_task_instance.xcom_pull.return_value = TestCases.test_project_id + '.test_table'
+    mock_task_instance.xcom_pull.return_value = {'table': TestCases.test_project_id + '.test_table'}
     extract_operator = ExtractOperator(path='test_path', format=None,
                                        task_id='test_extract_operator')
 
     mock_table_extract.return_value.result = lambda: 'test-results'
     mock_table_extract.return_value.failed = False
     mock_table_extract.return_value.errors = None
-    self.assertEqual(extract_operator.execute(context={'task_instance': mock_task_instance}),
-                     'test-results')
+    self.assertDictEqual(extract_operator.execute(context={'task_instance': mock_task_instance}),
+                     {'result': 'test-results'})
     mock_table_extract.assert_called_with('test_path', format='NEWLINE_DELIMITED_JSON',
                                           csv_delimiter=None, csv_header=None, compress=None)
 
@@ -111,10 +112,11 @@ class TestCases(unittest.TestCase):
 
   @mock.patch('google.datalab.Context.default')
   @mock.patch('google.datalab.bigquery.Query.execute')
+  @mock.patch('google.datalab.bigquery.QueryOutput.table')
   @mock.patch('google.datalab.bigquery._query_job.QueryJob')
   @mock.patch('google.datalab.utils.commands.get_notebook_item')
-  def test_execute_operator(self, mock_get_notebook_item, mock_query_job, mock_query_execute,
-                            mock_context_default):
+  def test_execute_operator(self, mock_get_notebook_item, mock_query_job, mock_query_output_table,
+                            mock_query_execute, mock_context_default):
     mock_context_default.return_value = self._create_context()
     mock_get_notebook_item.return_value = google.datalab.bigquery.Query('test_sql')
 
@@ -122,7 +124,9 @@ class TestCases(unittest.TestCase):
     mock_query_execute.return_value = mock_query_job
     query_results_table_name = 'foo_table'
     mock_query_job.result.return_value.name = query_results_table_name
-    self.assertEqual(execute_operator.execute(context=None), query_results_table_name)
+    self.assertDictEqual(execute_operator.execute(context=None), {'table': query_results_table_name})
+    mock_query_output_table.assert_called_with(name=None, mode=None, use_cache=False,
+                                               allow_large_results=False)
 
   @mock.patch('google.datalab.Context.default')
   @mock.patch('google.datalab.bigquery._api.Api.tables_insert')
@@ -133,7 +137,7 @@ class TestCases(unittest.TestCase):
       mock_context_default.return_value = self._create_context()
 
       mock_table_exists.return_value = True
-      load_operator = LoadOperator(table='project.test.table', path='test/path', mode='create',
+      load_operator = LoadOperator(table=TestCases.test_table_name, path='test/path', mode='create',
                                    format=None, csv_options=None, schema=None,
                                    task_id='test_operator_id')
       with self.assertRaisesRegexp(
@@ -142,7 +146,7 @@ class TestCases(unittest.TestCase):
         load_operator.execute(context=None)
 
       mock_table_exists.return_value = False
-      load_operator = LoadOperator(table='project.test.table', path='test/path', mode='append',
+      load_operator = LoadOperator(table=TestCases.test_table_name, path='test/path', mode='append',
                                    format=None, csv_options=None, schema=None,
                                    task_id='test_operator_id')
       with self.assertRaisesRegexp(Exception,
@@ -154,10 +158,10 @@ class TestCases(unittest.TestCase):
         {"type": "FLOAT", "name": "var1"},
         {"type": "FLOAT", "name": "var2"}
       ]
-      load_operator = LoadOperator(table='project.test.table', path='test/path', mode='create',
+      load_operator = LoadOperator(table=TestCases.test_table_name, path='test/path', mode='create',
                                    format=None, csv_options=None, schema=schema,
                                    task_id='test_operator_id')
-      job = google.datalab.bigquery._query_job.QueryJob('test_id', 'project.test.table',
+      job = google.datalab.bigquery._query_job.QueryJob('test_id', TestCases.test_table_name,
                                                         'test_sql', None)
       mock_table_load.return_value = job
       job._is_complete = True
@@ -172,16 +176,22 @@ class TestCases(unittest.TestCase):
         load_operator.execute(context=None)
 
       job._errors = None
-      load_operator.execute(context=None)
+      query_results_table = load_operator.execute(context=None)['result'].name
+      self.assertEqual(query_results_table.project_id, 'project')
+      self.assertEqual(query_results_table.dataset_id, 'test')
+      self.assertEqual(query_results_table.table_id, 'table')
       mock_table_load.assert_called_with('test/path', mode='create',
                                          source_format='NEWLINE_DELIMITED_JSON',
                                          csv_options=mock.ANY, ignore_unknown_values=True)
 
       mock_table_exists.return_value = True
-      load_operator = LoadOperator(table='project.test.table', path='test/path', mode='append',
+      load_operator = LoadOperator(table=TestCases.test_table_name, path='test/path', mode='append',
                                    format='csv', csv_options=None, schema=schema,
                                    task_id='test_operator_id')
-      load_operator.execute(context=None)
+      query_results_table = load_operator.execute(context=None)['result'].name
+      self.assertEqual(query_results_table.project_id, 'project')
+      self.assertEqual(query_results_table.dataset_id, 'test')
+      self.assertEqual(query_results_table.table_id, 'table')
       mock_table_load.assert_called_with('test/path', mode='append',
                                          source_format='csv', csv_options=mock.ANY,
                                          ignore_unknown_values=True)

--- a/tests/bigquery/operator_tests.py
+++ b/tests/bigquery/operator_tests.py
@@ -27,7 +27,6 @@ IPython.core.magic.register_line_magic = noop_decorator
 IPython.core.magic.register_cell_magic = noop_decorator
 IPython.get_ipython = mock.Mock()
 
-import airflow
 import google.datalab  # noqa
 import google.datalab.bigquery  # noqa
 import google.datalab.bigquery.commands  # noqa

--- a/tests/kernel/bigquery_tests.py
+++ b/tests/kernel/bigquery_tests.py
@@ -765,7 +765,6 @@ WITH q1 AS (
     context = TestCases._create_context()
     mock_default_context.return_value = context
     mock_client_get_bucket.return_value = mock.Mock(spec=google.cloud.storage.Bucket)
-    mock_blob_class.return_value  # noqa
     mock_get_notebook_item.return_value = google.datalab.bigquery.Query(
         'SELECT * FROM publicdata.samples.wikipedia LIMIT 5')
     args = {'name': 'bq_pipeline_test'}


### PR DESCRIPTION
This enables the user to leave out the table name in the output section, so the following will now work in a Datalab notebook (in the cloud-ml-dev project):

import google.datalab.kernel
import google.datalab.contrib.pipeline._pipeline

%%bq query --name demo_query
SELECT col1, col2 FROM `cloud-ml-dev.rajivpb_demo.foo_table_created`

%%bq pipeline --name bq_pipeline_demo_20171013
schedule:
  start: 2017-10-20T21:19:15Z
  end: 2017-10-20T22:28:15Z
  interval: '* * * * *'
input:
  path: gs://cloud-ml-dev-nikhilko/iris/data/data_predict.csv
  table: cloud-ml-dev.rajivpb_demo.foo_table_created
  format: csv
  schema:
    - name: prediction
      type: INTEGER
    - name: col1
      type: FLOAT
    - name: col2
      type: FLOAT
    - name: col3
      type: FLOAT
    - name: col4
      type: FLOAT
transformation:
  query: demo_query
output:
  path: gs://rajivpb-airflow-testing/data_predict_query_results_%(ds)s.csv
  format: csv
