### PR TITLE
Add airflow's 'ds' and 'ts' macros

### DIFF
--- a/google/datalab/contrib/pipeline/_pipeline.py
+++ b/google/datalab/contrib/pipeline/_pipeline.py
@@ -39,8 +39,8 @@ from pytz import timezone
   # These are documented here:
   # https://airflow.incubator.apache.org/code.html?highlight=macros#default-variables
   _airflow_macros = {
-    # formatted as YYYY-MM-DD
-    'ds': '{{ ds }}',
+    # the datetime formatted as YYYYMMDD (i.e. YYYY-MM-DD with 'no dashes')
+    'ds': '{{ ds_nodash }}',
     # the full ISO-formatted timestamp YYYY-MM-DDTHH:MM:SS.mmmmmm with no dashes or colons, i.e. in
     # the YYYYMMDDTHHMMSSmmmmmm format.
     'ts': '{{ ts_nodash }}',

--- a/google/datalab/contrib/pipeline/_pipeline.py
+++ b/google/datalab/contrib/pipeline/_pipeline.py
@@ -39,8 +39,8 @@ from pytz import timezone
   # These are documented here:
   # https://airflow.incubator.apache.org/code.html?highlight=macros#default-variables
   _airflow_macros = {
-    # the datetime formatted as YYYYMMDD (i.e. YYYY-MM-DD with 'no dashes')
-    'ds': '{{ ds_nodash }}',
+    # formatted as YYYY-MM-DD
+    'ds': '{{ ds }}',
     # the full ISO-formatted timestamp YYYY-MM-DDTHH:MM:SS.mmmmmm with no dashes or colons, i.e. in
     # the YYYYMMDDTHHMMSSmmmmmm format.
     'ts': '{{ ts_nodash }}',

--- a/google/datalab/contrib/pipeline/_pipeline.py
+++ b/google/datalab/contrib/pipeline/_pipeline.py
@@ -40,10 +40,15 @@ from pytz import timezone
   # https://airflow.incubator.apache.org/code.html?highlight=macros#default-variables
   _airflow_macros = {
     # the datetime formatted as YYYYMMDD (i.e. YYYY-MM-DD with 'no dashes')
-    'ds': '{{ ds_nodash }}',
+    'ds': '{{ ds }}',
     # the full ISO-formatted timestamp YYYY-MM-DDTHH:MM:SS.mmmmmm with no dashes or colons, i.e. in
     # the YYYYMMDDTHHMMSSmmmmmm format.
-    'ts': '{{ ts_nodash }}',
+    'ts': '{{ ts }}',
+    # the datetime formatted as YYYYMMDD (i.e. YYYY-MM-DD with 'no dashes')
+    'ds_nodash': '{{ ds_nodash }}',
+    # the full ISO-formatted timestamp YYYY-MM-DDTHH:MM:SS.mmmmmm with no dashes or colons, i.e. in
+    # the YYYYMMDDTHHMMSSmmmmmm format.
+    'ts_nodash': '{{ ts_nodash }}',
   }
 
   def __init__(self, name, pipeline_spec):

--- a/google/datalab/contrib/pipeline/_pipeline.py
+++ b/google/datalab/contrib/pipeline/_pipeline.py
@@ -39,15 +39,14 @@ from pytz import timezone
   # These are documented here:
   # https://airflow.incubator.apache.org/code.html?highlight=macros#default-variables
   _airflow_macros = {
-    # the datetime formatted as YYYYMMDD (i.e. YYYY-MM-DD with 'no dashes')
+    # the datetime formatted as YYYY-MM-DD
     'ds': '{{ ds }}',
-    # the full ISO-formatted timestamp YYYY-MM-DDTHH:MM:SS.mmmmmm with no dashes or colons, i.e. in
-    # the YYYYMMDDTHHMMSSmmmmmm format.
+    # the full ISO-formatted timestamp YYYY-MM-DDTHH:MM:SS.mmmmmm
     'ts': '{{ ts }}',
     # the datetime formatted as YYYYMMDD (i.e. YYYY-MM-DD with 'no dashes')
     'ds_nodash': '{{ ds_nodash }}',
-    # the full ISO-formatted timestamp YYYY-MM-DDTHH:MM:SS.mmmmmm with no dashes or colons, i.e. in
-    # the YYYYMMDDTHHMMSSmmmmmm format.
+    # the timestamp formatted as YYYYMMDDTHHMMSSmmmmmm (i.e full ISO-formatted timestamp
+    # YYYY-MM-DDTHH:MM:SS.mmmmmm with no dashes or colons).
     'ts_nodash': '{{ ts_nodash }}',
   }
 

--- a/tests/bigquery/pipeline_tests.py
+++ b/tests/bigquery/pipeline_tests.py
@@ -455,8 +455,8 @@ class TestCases(unittest.TestCase):
     env = {
       'endpoint': 'Interact2',
       'job_id': '1234',
-      'input_table_format': 'cloud-datalab-samples.httplogs.logs_%(ds)s',
-      'output_table_format': 'cloud-datalab-samples.endpoints.logs_%(ds)s'
+      'input_table_format': 'cloud-datalab-samples.httplogs.logs_%(ds_nodash)s',
+      'output_table_format': 'cloud-datalab-samples.endpoints.logs_%(ds_nodash)s'
     }
     mock_notebook_item.return_value = google.datalab.bigquery.Query(
         'SELECT @column FROM `{0}` where endpoint=@endpoint'.format(env['input_table_format']))
@@ -470,7 +470,7 @@ class TestCases(unittest.TestCase):
                 end: 2009-05-06T22:28:15Z
                 interval: '@hourly'
             input:
-                path: gs://bucket/cloud-datalab-samples-httplogs_%(ds)s
+                path: gs://bucket/cloud-datalab-samples-httplogs_%(ds_nodash)s
                 table: $input_table_format
                 csv:
                   header: True
@@ -490,7 +490,7 @@ class TestCases(unittest.TestCase):
             transformation:
                 query: foo_query
             output:
-                path: gs://bucket/cloud-datalab-samples-endpoints_%(ds)s.csv
+                path: gs://bucket/cloud-datalab-samples-endpoints_%(ds_nodash)s.csv
                 table: $output_table_format
             parameters:
                 - name: endpoint

--- a/tests/bigquery/pipeline_tests.py
+++ b/tests/bigquery/pipeline_tests.py
@@ -532,9 +532,9 @@ default_args = {
 
 dag = DAG\(dag_id='bq_pipeline_test', schedule_interval='@hourly', default_args=default_args\)
 
-bq_pipeline_execute_task = ExecuteOperator\(task_id='bq_pipeline_execute_task_id', parameters=(.*), sql='SELECT @column FROM `cloud-datalab-samples.httplogs.logs_{{ ds }}` where endpoint=@endpoint', table='cloud-datalab-samples.endpoints.logs_{{ ds }}', dag=dag\)
-bq_pipeline_extract_task = ExtractOperator\(task_id='bq_pipeline_extract_task_id', path='gs://bucket/cloud-datalab-samples-endpoints_{{ ds }}.csv', table='cloud-datalab-samples.endpoints.logs_{{ ds }}', dag=dag\)
-bq_pipeline_load_task = LoadOperator\(task_id='bq_pipeline_load_task_id', csv_options=(.*), path='gs://bucket/cloud-datalab-samples-httplogs_{{ ds }}', schema=(.*), table='cloud-datalab-samples.httplogs.logs_{{ ds }}', dag=dag\)
+bq_pipeline_execute_task = ExecuteOperator\(task_id='bq_pipeline_execute_task_id', parameters=(.*), sql='SELECT @column FROM `cloud-datalab-samples.httplogs.logs_{{ ds_nodash }}` where endpoint=@endpoint', table='cloud-datalab-samples.endpoints.logs_{{ ds_nodash }}', dag=dag\)
+bq_pipeline_extract_task = ExtractOperator\(task_id='bq_pipeline_extract_task_id', path='gs://bucket/cloud-datalab-samples-endpoints_{{ ds_nodash }}.csv', table='cloud-datalab-samples.endpoints.logs_{{ ds_nodash }}', dag=dag\)
+bq_pipeline_load_task = LoadOperator\(task_id='bq_pipeline_load_task_id', csv_options=(.*), path='gs://bucket/cloud-datalab-samples-httplogs_{{ ds_nodash }}', schema=(.*), table='cloud-datalab-samples.httplogs.logs_{{ ds_nodash }}', dag=dag\)
 bq_pipeline_execute_task.set_upstream\(bq_pipeline_load_task\)
 bq_pipeline_extract_task.set_upstream\(bq_pipeline_execute_task\)
 """)  # noqa

--- a/tests/bigquery/pipeline_tests.py
+++ b/tests/bigquery/pipeline_tests.py
@@ -532,9 +532,9 @@ default_args = {
 
 dag = DAG\(dag_id='bq_pipeline_test', schedule_interval='@hourly', default_args=default_args\)
 
-bq_pipeline_execute_task = ExecuteOperator\(task_id='bq_pipeline_execute_task_id', parameters=(.*), sql='SELECT @column FROM `cloud-datalab-samples.httplogs.logs_{{ ds_nodash }}` where endpoint=@endpoint', table='cloud-datalab-samples.endpoints.logs_{{ ds_nodash }}', dag=dag\)
-bq_pipeline_extract_task = ExtractOperator\(task_id='bq_pipeline_extract_task_id', path='gs://bucket/cloud-datalab-samples-endpoints_{{ ds_nodash }}.csv', table='cloud-datalab-samples.endpoints.logs_{{ ds_nodash }}', dag=dag\)
-bq_pipeline_load_task = LoadOperator\(task_id='bq_pipeline_load_task_id', csv_options=(.*), path='gs://bucket/cloud-datalab-samples-httplogs_{{ ds_nodash }}', schema=(.*), table='cloud-datalab-samples.httplogs.logs_{{ ds_nodash }}', dag=dag\)
+bq_pipeline_execute_task = ExecuteOperator\(task_id='bq_pipeline_execute_task_id', parameters=(.*), sql='SELECT @column FROM `cloud-datalab-samples.httplogs.logs_{{ ds }}` where endpoint=@endpoint', table='cloud-datalab-samples.endpoints.logs_{{ ds }}', dag=dag\)
+bq_pipeline_extract_task = ExtractOperator\(task_id='bq_pipeline_extract_task_id', path='gs://bucket/cloud-datalab-samples-endpoints_{{ ds }}.csv', table='cloud-datalab-samples.endpoints.logs_{{ ds }}', dag=dag\)
+bq_pipeline_load_task = LoadOperator\(task_id='bq_pipeline_load_task_id', csv_options=(.*), path='gs://bucket/cloud-datalab-samples-httplogs_{{ ds }}', schema=(.*), table='cloud-datalab-samples.httplogs.logs_{{ ds }}', dag=dag\)
 bq_pipeline_execute_task.set_upstream\(bq_pipeline_load_task\)
 bq_pipeline_extract_task.set_upstream\(bq_pipeline_execute_task\)
 """)  # noqa

--- a/tests/pipeline/pipeline_tests.py
+++ b/tests/pipeline/pipeline_tests.py
@@ -94,7 +94,7 @@ tasks:
     operator_def = pipeline.Pipeline(None, None)._get_operator_definition(task_id, task_details)
     self.assertEqual(
       operator_def,
-      """foo_task = BigQueryOperator(task_id='foo_task_id', bql='SELECT * FROM `cloud-datalab-samples.httplogs.logs_{{ ds_nodash }}`', use_legacy_sql=False, dag=dag)
+      """foo_task = BigQueryOperator(task_id='foo_task_id', bql='SELECT * FROM `cloud-datalab-samples.httplogs.logs_{{ ds }}`', use_legacy_sql=False, dag=dag)
 """)  # noqa
 
   @mock.patch('google.datalab.bigquery.commands._bigquery._get_table')

--- a/tests/pipeline/pipeline_tests.py
+++ b/tests/pipeline/pipeline_tests.py
@@ -90,7 +90,7 @@ tasks:
     task_details = {}
     task_details['type'] = 'BigQuery'
     task_details['query'] = google.datalab.bigquery.Query(
-      'SELECT * FROM `cloud-datalab-samples.httplogs.logs_%(ds)s`')
+      'SELECT * FROM `cloud-datalab-samples.httplogs.logs_%(ds_nodash)s`')
     operator_def = pipeline.Pipeline(None, None)._get_operator_definition(task_id, task_details)
     self.assertEqual(
       operator_def,

--- a/tests/pipeline/pipeline_tests.py
+++ b/tests/pipeline/pipeline_tests.py
@@ -94,7 +94,7 @@ tasks:
     operator_def = pipeline.Pipeline(None, None)._get_operator_definition(task_id, task_details)
     self.assertEqual(
       operator_def,
-      """foo_task = BigQueryOperator(task_id='foo_task_id', bql='SELECT * FROM `cloud-datalab-samples.httplogs.logs_{{ ds }}`', use_legacy_sql=False, dag=dag)
+      """foo_task = BigQueryOperator(task_id='foo_task_id', bql='SELECT * FROM `cloud-datalab-samples.httplogs.logs_{{ ds_nodash }}`', use_legacy_sql=False, dag=dag)
 """)  # noqa
 
   @mock.patch('google.datalab.bigquery.commands._bigquery._get_table')


### PR DESCRIPTION
Using 'ds_nodash' was problematic in SQL queries because parsing support isn't great. 'ds' is more useful in queries.