### PR TITLE
Make 'schedule' an optional section, and use reasonable defaults

### DIFF
--- a/google/datalab/contrib/bigquery/commands/_bigquery.py
+++ b/google/datalab/contrib/bigquery/commands/_bigquery.py
@@ -61,10 +61,10 @@ def _pipeline_cell(args, cell_body):
         # https://github.com/googledatalab/pydatalab/issues/593
         import google.datalab.contrib.pipeline.composer._composer
         composer = google.datalab.contrib.pipeline.composer._composer.Composer(zone, environment)
-        composer.deploy(name, pipeline._get_airflow_spec())
+        composer.deploy(name, pipeline.get_airflow_spec())
 
     # TODO(rajivpb): See https://github.com/googledatalab/pydatalab/issues/501. Don't return python.
-    return pipeline._get_airflow_spec()
+    return pipeline.get_airflow_spec()
 
 
 def _get_pipeline_spec_from_config(bq_pipeline_config):

--- a/google/datalab/contrib/pipeline/commands/_pipeline.py
+++ b/google/datalab/contrib/pipeline/commands/_pipeline.py
@@ -45,7 +45,7 @@ def _create_cell(args, cell_body):
 
   debug = args.get('debug')
   if debug is True:
-    return pipeline._get_airflow_spec()
+    return pipeline.get_airflow_spec()
 
 
 def _create_create_subparser(parser):
@@ -148,7 +148,7 @@ def _dispatch_handler(args, cell, parser, handler, cell_required=False,
 
 def _repr_html_pipeline(pipeline):
   return google.datalab.utils.commands.HtmlBuilder.render_text(
-      pipeline._get_airflow_spec(), preformatted=True)
+      pipeline.get_airflow_spec(), preformatted=True)
 
 
 def _register_html_formatters():

--- a/tests/bigquery/pipeline_tests.py
+++ b/tests/bigquery/pipeline_tests.py
@@ -528,15 +528,10 @@ from datetime import timedelta
 from pytz import timezone
 
 default_args = {
-    'owner': 'Datalab',
-    'depends_on_past': False,
+    'owner': 'Google Cloud Datalab',
     'email': \['foo1@test.com', 'foo2@test.com'\],
     'start_date': datetime.datetime.strptime\('2009-05-05T22:28:15', '%Y-%m-%dT%H:%M:%S'\).replace\(tzinfo=timezone\('UTC'\)\),
     'end_date': datetime.datetime.strptime\('2009-05-06T22:28:15', '%Y-%m-%dT%H:%M:%S'\).replace\(tzinfo=timezone\('UTC'\)\),
-    'email_on_failure': True,
-    'email_on_retry': False,
-    'retries': 1,
-    'retry_delay': timedelta\(minutes=1\),
 }
 
 dag = DAG\(dag_id='bq_pipeline_test', schedule_interval='@hourly', default_args=default_args\)

--- a/tests/kernel/pipeline_tests.py
+++ b/tests/kernel/pipeline_tests.py
@@ -61,8 +61,7 @@ tasks:
 
   @mock.patch('google.datalab.utils.commands.notebook_environment')
   @mock.patch('google.datalab.Context.default')
-  def test_create_cell_no_name(self, mock_default_context,
-                               mock_notebook_environment):
+  def test_create_cell_no_name(self, mock_default_context, mock_notebook_environment):
     env = {}
     mock_default_context.return_value = TestCases._create_context()
     mock_notebook_environment.return_value = env
@@ -78,8 +77,7 @@ tasks:
 
   @mock.patch('google.datalab.utils.commands.notebook_environment')
   @mock.patch('google.datalab.Context.default')
-  def test_create_cell_debug(self, mock_default_context,
-                             mock_notebook_environment):
+  def test_create_cell_debug(self, mock_default_context, mock_notebook_environment):
     env = {}
     mock_default_context.return_value = TestCases._create_context()
     mock_notebook_environment.return_value = env
@@ -134,7 +132,7 @@ tasks:
     google.datalab.contrib.pipeline.commands._pipeline._create_cell({'name': 'p1'}, p_body)
     p1 = env['p1']
     self.assertIsNotNone(p1)
-    self.assertEqual(p1._get_airflow_spec(), """
+    self.assertEqual(p1.get_airflow_spec(), """
 import datetime
 from airflow import DAG
 from airflow.operators.bash_operator import BashOperator
@@ -150,15 +148,10 @@ from datetime import timedelta
 from pytz import timezone
 
 default_args = {
-    'owner': 'Datalab',
-    'depends_on_past': False,
+    'owner': 'Google Cloud Datalab',
     'email': ['foo1@test.com', 'foo2@test.com'],
     'start_date': datetime.datetime.strptime('2009-05-05T22:28:15', '%Y-%m-%dT%H:%M:%S').replace(tzinfo=timezone('UTC')),
     'end_date': datetime.datetime.strptime('2009-05-06T22:28:15', '%Y-%m-%dT%H:%M:%S').replace(tzinfo=timezone('UTC')),
-    'email_on_failure': True,
-    'email_on_retry': False,
-    'retries': 1,
-    'retry_delay': timedelta(minutes=1),
 }
 
 dag = DAG(dag_id='p1', schedule_interval='@hourly', default_args=default_args)


### PR DESCRIPTION
 - datetime.now() as default start_date
 - infinity as default end_date
 - '@once' as default for interval
 - Airflow's defaults for the rest

Bonus: _get_airflow_spec() -> get_airflow_spec() after code-review feedback.