### PR TITLE
Change the log level for 'google.auth._default' to ERROR.

### DIFF
--- a/google/datalab/utils/_utils.py
+++ b/google/datalab/utils/_utils.py
@@ -21,9 +21,9 @@ try:
 except ImportError:
     import httplib
 
+import json
 import logging
 import os
-import json
 import pytz
 import six
 import subprocess

--- a/google/datalab/utils/_utils.py
+++ b/google/datalab/utils/_utils.py
@@ -21,14 +21,16 @@ try:
 except ImportError:
     import httplib
 
+import logging
+import os
+import json
 import pytz
 import six
 import subprocess
 import socket
 import traceback
 import types
-import os
-import json
+
 import oauth2client.client
 import google.auth
 import google.auth.exceptions
@@ -187,8 +189,14 @@ def get_credentials():
       overriding these the defaults should suffice.
   """
   try:
+    # We temporarily disable warning logs from the "_default" module to avoid
+    # a spurious warning about the project not being set.
+    authDefaultLogger = logging.getLogger("google.auth._default")
+    previousLevel = authDefaultLogger.getEffectiveLevel()
+    authDefaultLogger.setLevel(logging.ERROR)
     credentials, _ = google.auth.default()
     credentials = google.auth.credentials.with_scopes_if_required(credentials, CREDENTIAL_SCOPES)
+    authDefaultLogger.setLevel(previousLevel)
     return credentials
   except Exception as e:
 


### PR DESCRIPTION
With version 1.3.0 of the "google-auth-library-python", the behavior
changed so that it logs a warning if it reads the credentials from
a metadata server but gets an empty project ID from that server.

The resulting log message is erroneous, telling the user to call
`gcloud config set project ...` to silence the warning, when in
reality it never looks in the gcloud config for that scenario.

This causes issues if you run Datalab with the fake metadata server
[here](https://github.com/googledatalab/datalab/blob/master/sources/web/datalab/metadata.ts),
but do not provide a value for the project ID.

This change mitigates that issue by raising the log level of the
offending module to `ERROR` prior to fetching the credentials.

The error is then set back to the previous level in case the
user is using the `google.auth._default` module in their own code.