### PR TITLE
Changing default of catchup from False to True

### DIFF
--- a/google/datalab/contrib/bigquery/commands/_bigquery.py
+++ b/google/datalab/contrib/bigquery/commands/_bigquery.py
@@ -53,6 +53,7 @@ Creates a GCS/BigQuery ETL pipeline. The cell-body is specified as follows:
     start: <formatted as '%Y-%m-%dT%H:%M:%S'; default is 'now'>
     end:  <formatted as '%Y-%m-%dT%H:%M:%S'; default is 'forever'>
     interval: {@once (default) | @hourly | @daily | @weekly | @ monthly | @yearly | <cron ex>}
+    catchup: {True (default) | False}; Whether to have pipelines execute in the past.
   parameters: <syntax is same as that in '%%bq execute'>')
 """)
 

--- a/google/datalab/contrib/pipeline/_pipeline.py
+++ b/google/datalab/contrib/pipeline/_pipeline.py
@@ -69,7 +69,7 @@ from datetime import timedelta
     default_args = Pipeline._get_default_args(schedule_config,
                                               self._pipeline_spec.get('emails', {}))
     dag_definition = self._get_dag_definition(schedule_config.get('interval', '@once'),
-                                              schedule_config.get('catchup', False))
+                                              schedule_config.get('catchup', True))
     self._airflow_spec = Pipeline._imports + default_args + dag_definition + task_definitions + \
         up_steam_statements
     return self._airflow_spec
@@ -177,7 +177,7 @@ default_args = {{{0}}}
       return ', {0}={1}'
     return ', {0}="""{1}"""'
 
-  def _get_dag_definition(self, schedule_interval, catchup=False):
+  def _get_dag_definition(self, schedule_interval, catchup):
     dag_definition = 'dag = DAG(dag_id=\'{0}\', schedule_interval=\'{1}\', ' \
                      'catchup={2}, default_args=default_args)\n\n'.format(self._name,
                                                                           schedule_interval,

--- a/tests/bigquery/pipeline_tests.py
+++ b/tests/bigquery/pipeline_tests.py
@@ -669,7 +669,7 @@ default_args = {
     'end_date': datetime.datetime.strptime\('2009-05-06T22:28:15', '%Y-%m-%dT%H:%M:%S'\),
 }
 
-dag = DAG\(dag_id='bq_pipeline_test', schedule_interval='@hourly', catchup=False, default_args=default_args\)
+dag = DAG\(dag_id='bq_pipeline_test', schedule_interval='@hourly', catchup=True, default_args=default_args\)
 
 bq_pipeline_execute_task = ExecuteOperator\(task_id='bq_pipeline_execute_task_id', parameters=(.*), sql=\"\"\"WITH input AS \(
   SELECT \* FROM `cloud-datalab-samples\.httplogs\.logs_{{ ds_nodash }}`

--- a/tests/kernel/pipeline_tests.py
+++ b/tests/kernel/pipeline_tests.py
@@ -157,7 +157,7 @@ default_args = {
     'end_date': datetime.datetime.strptime('2009-05-06T22:28:15', '%Y-%m-%dT%H:%M:%S'),
 }
 
-dag = DAG(dag_id='p1', schedule_interval='@hourly', catchup=False, default_args=default_args)
+dag = DAG(dag_id='p1', schedule_interval='@hourly', catchup=True, default_args=default_args)
 
 foo_task_1 = BigQueryOperator(task_id='foo_task_1_id', bql=\"\"\"SELECT * FROM publicdata.samples.wikipedia LIMIT 5\"\"\", use_legacy_sql=False, dag=dag)
 foo_task_2 = BashOperator(task_id='foo_task_2_id', bash_command=\"\"\"date\"\"\", dag=dag)

--- a/tests/pipeline/pipeline_tests.py
+++ b/tests/pipeline/pipeline_tests.py
@@ -264,14 +264,9 @@ LIMIT 5""")
 
   def test_get_dag_definition(self):
     test_pipeline = pipeline.Pipeline('foo', None)
-    self.assertEqual(test_pipeline._get_dag_definition('bar'),
+    self.assertEqual(test_pipeline._get_dag_definition('bar', False),
                      'dag = DAG(dag_id=\'foo\', schedule_interval=\'bar\', '
                      'catchup=False, default_args=default_args)\n\n')
-
-    test_pipeline = pipeline.Pipeline('foo', None)
-    self.assertEqual(test_pipeline._get_dag_definition('bar', True),
-                     'dag = DAG(dag_id=\'foo\', schedule_interval=\'bar\', '
-                     'catchup=True, default_args=default_args)\n\n')
 
   def test_get_datetime_expr(self):
     dag_dict = yaml.load(PipelineTest._test_pipeline_yaml_spec)


### PR DESCRIPTION
This is so that users can completely leave out the 'schedule' section and expect that their pipeline will run once. 

Currently this is broken because:
1. When the user schedules a pipeline, the start-date is assumed to be now, the end-date is assumed to be infinity, and interval is assumed to be 'once'.
2. Typically, a few minutes have passed between the time the user executes the bq-pipeline cell in Datalab and the time the airflow scheduler picks it up.
3. Because catchup=False, airflow will not execute the pipeline because the the start-date is a few minutes in the past. 

To enable the convenience feature of a user scheduling a pipeline  to 'run-once' without specifying a schedule section at all, we need to the default value for catchup to be True. When the user does not want this sort of "backfill", they will need to specify catchup as False. This is just as well since the user would be specifying a schedule section with defined start-date and end-date values anyway, so adding a 'catch-up' flag would not be much of an inconvenience.
 