### PR TITLE
Allow the newer versions of PyYAML to be used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'pandas-profiling>=1.0.0a2',
     'python-dateutil==2.5.0',
     'pytz>=2015.4',
-    'pyyaml==3.11',
+    'pyyaml>=3.11',
     'requests==2.9.1',
     'scikit-image==0.13.0',
     'scikit-learn==0.18.2',


### PR DESCRIPTION
This change allows the pydatalab library to be installed alongside versions of PyYAML newer than 3.11

This was prompted by a build breakage to the `datalab` repository where PyYAML 3.12 was installed in the image and could not be removed because it was installed with distutils.