### PR TITLE
Fix the usage of `google.datalab.utils.Iterator`.

### DIFF
--- a/google/datalab/bigquery/_dataset.py
+++ b/google/datalab/bigquery/_dataset.py
@@ -239,16 +239,18 @@ class Datasets(object):
     self._context = context
     self._api = _api.Api(context)
     self._project_id = context.project_id if context else self._api.project_id
+    self._page_size = 0
 
-  def _retrieve_datasets(self, page_token, count):
+  def _retrieve_datasets(self, page_token, _):
     try:
-      list_info = self._api.datasets_list(self._project_id, max_results=count,
+      list_info = self._api.datasets_list(self._project_id, max_results=self._page_size,
                                           page_token=page_token)
     except Exception as e:
       raise e
 
     datasets = list_info.get('datasets', [])
     if len(datasets):
+      self._page_size = self._page_size or len(datasets)
       try:
         datasets = [Dataset((info['datasetReference']['projectId'],
                              info['datasetReference']['datasetId']), self._context)

--- a/google/datalab/ml/_cloud_models.py
+++ b/google/datalab/ml/_cloud_models.py
@@ -38,7 +38,8 @@ class Models(object):
 
   def _retrieve_models(self, page_token, _):
     list_info = self._api.projects().models().list(
-        parent='projects/' + self._project_id, pageToken=page_token, pageSize=self._page_size).execute()
+        parent='projects/' + self._project_id, pageToken=page_token,
+        pageSize=self._page_size).execute()
     models = list_info.get('models', [])
     self._page_size = self._page_size or len(models)
     page_token = list_info.get('nextPageToken', None)

--- a/google/datalab/ml/_cloud_models.py
+++ b/google/datalab/ml/_cloud_models.py
@@ -34,11 +34,13 @@ class Models(object):
     self._project_id = project_id
     self._credentials = datalab.Context.default().credentials
     self._api = discovery.build('ml', 'v1', credentials=self._credentials)
+    self._page_size = 0
 
-  def _retrieve_models(self, page_token, page_size):
+  def _retrieve_models(self, page_token, _):
     list_info = self._api.projects().models().list(
-        parent='projects/' + self._project_id, pageToken=page_token, pageSize=page_size).execute()
+        parent='projects/' + self._project_id, pageToken=page_token, pageSize=self._page_size).execute()
     models = list_info.get('models', [])
+    self._page_size = self._page_size or len(models)
     page_token = list_info.get('nextPageToken', None)
     return models, page_token
 
@@ -142,13 +144,15 @@ class ModelVersions(object):
       model_name = ('projects/%s/models/%s' % (self._project_id, model_name))
     self._full_model_name = model_name
     self._model_name = self._full_model_name.split('/')[-1]
+    self._page_size = 0
 
-  def _retrieve_versions(self, page_token, page_size):
+  def _retrieve_versions(self, page_token, _):
     parent = self._full_model_name
     list_info = self._api.projects().models().versions().list(parent=parent,
                                                               pageToken=page_token,
-                                                              pageSize=page_size).execute()
+                                                              pageSize=self._page_size).execute()
     versions = list_info.get('versions', [])
+    self._page_size = self._page_size or len(versions)
     page_token = list_info.get('nextPageToken', None)
     return versions, page_token
 

--- a/google/datalab/ml/_job.py
+++ b/google/datalab/ml/_job.py
@@ -164,12 +164,14 @@ class Jobs(object):
     self._filter = filter
     self._context = datalab.Context.default()
     self._api = discovery.build('ml', 'v1', credentials=self._context.credentials)
+    self._page_size = 0
 
-  def _retrieve_jobs(self, page_token, page_size):
+  def _retrieve_jobs(self, page_token, _):
     list_info = self._api.projects().jobs().list(parent='projects/' + self._context.project_id,
-                                                 pageToken=page_token, pageSize=page_size,
+                                                 pageToken=page_token, pageSize=self._page_size,
                                                  filter=self._filter).execute()
     jobs = list_info.get('jobs', [])
+    self._page_size = self._page_size or len(jobs)
     page_token = list_info.get('nextPageToken', None)
     return jobs, page_token
 

--- a/tests/_util/util_tests.py
+++ b/tests/_util/util_tests.py
@@ -19,6 +19,7 @@ import mock
 import os
 
 import google.datalab.utils._utils as _utils
+import google.datalab.utils._iterator as _iterator
 from datetime import datetime
 import google.auth
 import google.auth.exceptions
@@ -186,3 +187,19 @@ class TestCases(unittest.TestCase):
 
     with mock.patch.dict(os.environ, {'PROJECT_ID': 'test-project3'}):
       self.assertEquals(_utils.get_default_project_id(), 'test-project3')
+
+  def test_iterator(self):
+    max_count = 100
+    page_size = 10
+
+    def limited_retriever(next_item, running_count):
+      next_item = next_item or 1
+      result_count = min(page_size, max_count - running_count)
+      if result_count <= 0:
+        return [], None
+      return range(next_item, next_item + result_count), next_item + result_count
+
+    read_count = 0
+    for item in _iterator.Iterator(limited_retriever):
+      read_count += 1
+      self.assertLessEqual(read_count, max_count)


### PR DESCRIPTION
The Iterator class takes a `retriever` method to which it passes
two arguments. Until now, the various `retriever` methods passed
in have interpreted the second argument differently; some treat
it as a page size, while others rely on it representing the total
number of items iterated over so far.

This change fixes the inconsitency by making every implementation
treat the second argument as the number of items retrieved so far.

For implementations that were relying on that value being the
page size, they have been updated to calculate the page size themselves
the same way that it would have been calculated by the previous
version of the Iterator class.

This fixes #686