### PR TITLE
Fix an MLToolbox preprocessing failure caused by pickling of TF objects.

### DIFF
--- a/solutionbox/image_classification/mltoolbox/image/classification/_preprocess.py
+++ b/solutionbox/image_classification/mltoolbox/image/classification/_preprocess.py
@@ -237,6 +237,7 @@ class TFExampleFromImageDoFn(beam.DoFn):
   def process(self, element):
 
     import tensorflow as tf
+
     def _bytes_feature(value):
       return tf.train.Feature(bytes_list=tf.train.BytesList(value=value))
 
@@ -281,7 +282,7 @@ class ExampleProtoCoder(beam.coders.Coder):
     return example_proto.SerializeToString()
 
   def decode(self, serialized_str):
-    import tensorflow as tf 
+    import tensorflow as tf
     example = tf.train.Example()
     example.ParseFromString(serialized_str)
     return example


### PR DESCRIPTION
It seems happening after we upgrade DataFlow version to 2.0. The issue happens when:

1. You have "import tensorflow as tf" in a DoFn's __init__.
2. At run time, DataFlow initializes the DoFn first, and then pickle and unpickle the instance to multiple workers. That means it needs to pickle the state including imports.
3. Under tensorflow there are some objects that are not pickle friendly. So pickling everything under tensorflow namespace causes it to fail at run time.

The issue also occur if you have global "import tensorflow" statement.

The fix is to move tensorflow import into either DoFn's process(), or start_bundle() function. That way the import occurs for each instance on each worker and no tensorflow pickling is needed.