### PR TITLE
Update calls to a since-renamed beam API.

### DIFF
--- a/solutionbox/ml_workbench/tensorflow/transform.py
+++ b/solutionbox/ml_workbench/tensorflow/transform.py
@@ -349,8 +349,7 @@ class TransformFeaturesDoFn(beam.DoFn):
         yield transformed_features
 
     except Exception as e:  # pylint: disable=broad-except
-      yield beam.pvalue.SideOutputValue('errors',
-                                        (str(e), element))
+      yield beam.pvalue.TaggedOutput('errors', (str(e), element))
 
 
 def decode_csv(csv_string, column_names):

--- a/solutionbox/ml_workbench/xgboost/transform.py
+++ b/solutionbox/ml_workbench/xgboost/transform.py
@@ -349,8 +349,7 @@ class TransformFeaturesDoFn(beam.DoFn):
         yield transformed_features
 
     except Exception as e:  # pylint: disable=broad-except
-      yield beam.pvalue.SideOutputValue('errors',
-                                        (str(e), element))
+      yield beam.pvalue.TaggedOutput('errors', (str(e), element))
 
 
 def decode_csv(csv_string, column_names):

--- a/solutionbox/structured_data/mltoolbox/_structured_data/prediction/predict.py
+++ b/solutionbox/structured_data/mltoolbox/_structured_data/prediction/predict.py
@@ -212,8 +212,7 @@ class RunGraphDoFn(beam.DoFn):
         yield predictions
 
     except Exception as e:  # pylint: disable=broad-except
-      yield beam.pvalue.SideOutputValue('errors',
-                                        (str(e), element))
+      yield beam.pvalue.TaggedOutput('errors', (str(e), element))
 
 
 class RawJsonCoder(beam.coders.Coder):

--- a/solutionbox/structured_data/test_mltoolbox/test_datalab_e2e.py
+++ b/solutionbox/structured_data/test_mltoolbox/test_datalab_e2e.py
@@ -152,7 +152,9 @@ class TestLinearRegression(unittest.TestCase):
     # check errors file is empty
     errors = file_io.get_matching_files(os.path.join(output_dir, 'errors*'))
     self.assertEqual(len(errors), 1)
-    self.assertEqual(os.path.getsize(errors[0]), 0)
+    if os.path.getsize(errors[0]):
+      with open(errors[0]) as errors_file:
+        self.fail(msg=errors_file.read())
 
     # check predictions files are not empty
     predictions = file_io.get_matching_files(os.path.join(output_dir,

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ skip_missing_interpreters = true
 # For pandas-profiling, we have to install 1.4.0 as 1.4.1 triggers division-by-zero errors.
 deps = pandas-profiling==1.4.0
        apache-airflow==1.9.0
+       dill==0.2.6
        tensorflow==1.8.0
        lime==0.1.1.23
        xgboost==0.6a2
@@ -26,9 +27,9 @@ commands =
   python ./legacy_tests/main.py
 
 [testenv:py27]
-# google-cloud-dataflow only supports python2.7, so we add that here.
+# apache-beam only supports python2.7, so we add that here.
 deps = {[testenv]deps}
-       google-cloud-dataflow==2.0.0
+       apache-beam==2.4.0
 
 [testenv:flake8]
 commands = flake8 --exclude=.tox,.git,./*.egg,build,.cache,env,__pycache__,docs


### PR DESCRIPTION
The `beam.pvalue.SideOutputValue` method was renamed to
`beam.pvalue.TaggedOutput` in release
[2.0.0](https://cloud.google.com/dataflow/release-notes/release-notes-python#200_may_31_2017)
of the Cloud Dataflow SDK.

This change updates calls to that method to instead use the new name.