### PR TITLE
Upgrade google.cloud.monitoring

### DIFF
--- a/google/datalab/stackdriver/monitoring/__init__.py
+++ b/google/datalab/stackdriver/monitoring/__init__.py
@@ -14,7 +14,11 @@
 
 from __future__ import absolute_import
 
-from google.cloud.monitoring import Aligner, Reducer
+from google.cloud.monitoring import enums
+
+Aligner = enums.Aggregation.Aligner
+Reducer = enums.Aggregation.Reducer
+
 from ._group import Groups
 from ._metric import MetricDescriptors
 from ._query import Query

--- a/google/datalab/stackdriver/monitoring/_query.py
+++ b/google/datalab/stackdriver/monitoring/_query.py
@@ -14,17 +14,17 @@
 
 from __future__ import absolute_import
 
-import google.cloud.monitoring
+import google.cloud.monitoring_v3.query
 
 from . import _query_metadata
 from . import _utils
 
 
-class Query(google.cloud.monitoring.Query):
+class Query(google.cloud.monitoring_v3.query.Query):
   """Query object for retrieving metric data."""
 
   def __init__(self,
-               metric_type=google.cloud.monitoring.Query.DEFAULT_METRIC_TYPE,
+               metric_type=google.cloud.monitoring_v3.query.Query.DEFAULT_METRIC_TYPE,
                end_time=None, days=0, hours=0, minutes=0, context=None):
     """Initializes the core query parameters.
 
@@ -33,13 +33,13 @@ class Query(google.cloud.monitoring.Query):
     the resulting duration from the end time.
 
     It is also allowed to omit the end time and duration here,
-    in which case :meth:`~google.cloud.monitoring.query.Query.select_interval`
+    in which case :meth:`~google.cloud.monitoring_v3.query.Query.select_interval`
     must be called before the query is executed.
 
     Args:
       metric_type: The metric type name. The default value is
           :data:`Query.DEFAULT_METRIC_TYPE
-          <google.cloud.monitoring.query.Query.DEFAULT_METRIC_TYPE>`, but
+          <google.cloud.monitoring_v3.query.Query.DEFAULT_METRIC_TYPE>`, but
           please note that this default value is provided only for
           demonstration purposes and is subject to change.
       end_time: The end time (inclusive) of the time interval for which
@@ -54,7 +54,7 @@ class Query(google.cloud.monitoring.Query):
         ValueError: ``end_time`` was specified but ``days``, ``hours``, and
             ``minutes`` are all zero. If you really want to specify a point in
             time, use
-            :meth:`~google.cloud.monitoring.query.Query.select_interval`.
+            :meth:`~google.cloud.monitoring_v3.query.Query.select_interval`.
     """
     client = _utils.make_client(context)
     super(Query, self).__init__(client, metric_type,

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'configparser>=3.5.0',
     'mock>=2.0.0',
     'future>=0.16.0',
-    'google-cloud>=0.30.0',
+    'google-cloud-monitoring>=0.30.1',
     'google-api-python-client>=1.6.2',
     'seaborn>=0.7.0',
     'plotly>=1.12.5',


### PR DESCRIPTION
See relevant `google-cloud-python` repo directory:
https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/monitoring/google/cloud

This should address the build failures that were blocking https://github.com/googledatalab/pydatalab/pull/700