### PR TITLE
Pins the google-cloud-monitoring version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'configparser>=3.5.0',
     'mock>=2.0.0',
     'future>=0.16.0',
-    'google-cloud>=0.30.0',
+    'google-cloud-monitoring==0.28.0',
     'google-api-python-client>=1.6.2',
     'seaborn>=0.7.0',
     'plotly>=1.12.5',


### PR DESCRIPTION
This may be all that's necessary to fix pydatalab at head. `google-cloud-monitoring` versions `0.29.0` and above contain a significant overhaul of the APIs, mainly the concept of `Client` which are incompatible with much of our code under `[google]/datalab/stackdriver/monitoring`