### PR TITLE
utils: fix error handling for http requests in utils in py3

### DIFF
--- a/google/datalab/utils/_http.py
+++ b/google/datalab/utils/_http.py
@@ -52,7 +52,7 @@ class RequestException(Exception):
         error = error['errors'][0]
       self.message += ': ' + error['message']
     except Exception:
-      lines = str(content).split('\n') if isinstance(content, basestring) else []
+      lines = content.decode('utf-8').split('\n') if isinstance(content, basestring) else []
       if lines:
         self.message += ': ' + lines[0]
 

--- a/google/datalab/utils/_http.py
+++ b/google/datalab/utils/_http.py
@@ -44,15 +44,17 @@ class RequestException(Exception):
     self.message = 'HTTP request failed'
     # Try extract a message from the body; swallow possible resulting ValueErrors and KeyErrors.
     try:
-      error = json.loads(content, encoding='UTF-8')['error']
+      if isinstance(content, str):
+        error = json.loads(content)['error']
+      else:
+        error = json.loads(str(content, encoding='UTF-8'))['error']
       if 'errors' in error:
         error = error['errors'][0]
-      self.message += ': ' + error['message']
+      self.message += ': {}'.format(error['message'])
     except Exception:
       lines = content.splitlines() if isinstance(content, basestring) else []
       if lines:
-        msg = lines[0]
-        self.message += ': ' + (msg.decode('UTF-8') if isinstance(msg, bytes) else msg)
+        self.message += ': {}'.format(lines[0])
 
   def __str__(self):
     return self.message

--- a/google/datalab/utils/_http.py
+++ b/google/datalab/utils/_http.py
@@ -52,7 +52,7 @@ class RequestException(Exception):
         error = error['errors'][0]
       self.message += ': ' + error['message']
     except Exception:
-      lines = content.split('\n') if isinstance(content, basestring) else []
+      lines = str(content).split('\n') if isinstance(content, basestring) else []
       if lines:
         self.message += ': ' + lines[0]
 

--- a/google/datalab/utils/_http.py
+++ b/google/datalab/utils/_http.py
@@ -44,17 +44,15 @@ class RequestException(Exception):
     self.message = 'HTTP request failed'
     # Try extract a message from the body; swallow possible resulting ValueErrors and KeyErrors.
     try:
-      if type(content) == str:
-        error = json.loads(content)['error']
-      else:
-        error = json.loads(str(content, encoding='UTF-8'))['error']
+      error = json.loads(content, encoding='UTF-8')['error']
       if 'errors' in error:
         error = error['errors'][0]
       self.message += ': ' + error['message']
     except Exception:
-      lines = content.decode('utf-8').split('\n') if isinstance(content, basestring) else []
+      lines = content.splitlines() if isinstance(content, basestring) else []
       if lines:
-        self.message += ': ' + lines[0]
+        msg = lines[0]
+        self.message += ': ' + (msg.decode('UTF-8') if isinstance(msg, bytes) else msg)
 
   def __str__(self):
     return self.message

--- a/tests/_util/http_tests.py
+++ b/tests/_util/http_tests.py
@@ -92,29 +92,40 @@ class TestCases(unittest.TestCase):
 
   @mock.patch('httplib2.Response')
   @mock.patch('google.datalab.utils._http.Http.http.request')
-  def test_raises_http_error_str(self, mock_request, mock_response):
-    TestCases._setup_mocks(mock_request, mock_response, 'Not Found\nDiscarded Msg', 404)
-
+  def test_raises_http_error_json(self, mock_request, mock_response):
+    TestCases._setup_mocks(
+      mock_request, mock_response,
+      b'{"error": {"errors": [{"message": "Not Found"}]}}', 404)
     with self.assertRaises(Exception) as error:
       Http.request('http://www.example.org')
 
     e = error.exception
     self.assertEqual(e.status, 404)
-    self.assertEqual(e.content, 'Not Found\nDiscarded Msg')
     self.assertEqual(e.message, 'HTTP request failed: Not Found')
 
   @mock.patch('httplib2.Response')
   @mock.patch('google.datalab.utils._http.Http.http.request')
-  def test_raises_http_error_bytes(self, mock_request, mock_response):
-    TestCases._setup_mocks(mock_request, mock_response, b'Not Found\nDiscarded Msg', 404)
+  def test_raises_http_error_str(self, mock_request, mock_response):
+    TestCases._setup_mocks(mock_request, mock_response, 'Not Found', 404)
 
     with self.assertRaises(Exception) as error:
       Http.request('http://www.example.org')
 
     e = error.exception
     self.assertEqual(e.status, 404)
-    self.assertEqual(e.content, b'Not Found\nDiscarded Msg')
-    self.assertEqual(e.message, 'HTTP request failed: Not Found')
+    self.assertEqual(e.content, 'Not Found')
+
+  @mock.patch('httplib2.Response')
+  @mock.patch('google.datalab.utils._http.Http.http.request')
+  def test_raises_http_error_bytes(self, mock_request, mock_response):
+    TestCases._setup_mocks(mock_request, mock_response, b'Not Found', 404)
+
+    with self.assertRaises(Exception) as error:
+      Http.request('http://www.example.org')
+
+    e = error.exception
+    self.assertEqual(e.status, 404)
+    self.assertEqual(e.content, b'Not Found')
 
   @staticmethod
   def _setup_mocks(mock_request, mock_response, content, status=200):

--- a/tests/_util/http_tests.py
+++ b/tests/_util/http_tests.py
@@ -92,15 +92,29 @@ class TestCases(unittest.TestCase):
 
   @mock.patch('httplib2.Response')
   @mock.patch('google.datalab.utils._http.Http.http.request')
-  def test_raises_http_error(self, mock_request, mock_response):
-    TestCases._setup_mocks(mock_request, mock_response, b'Not Found', 404)
+  def test_raises_http_error_str(self, mock_request, mock_response):
+    TestCases._setup_mocks(mock_request, mock_response, 'Not Found\nDiscarded Msg', 404)
 
     with self.assertRaises(Exception) as error:
       Http.request('http://www.example.org')
 
     e = error.exception
     self.assertEqual(e.status, 404)
-    self.assertEqual(e.content, b'Not Found')
+    self.assertEqual(e.content, 'Not Found\nDiscarded Msg')
+    self.assertEqual(e.message, 'HTTP request failed: Not Found')
+
+  @mock.patch('httplib2.Response')
+  @mock.patch('google.datalab.utils._http.Http.http.request')
+  def test_raises_http_error_bytes(self, mock_request, mock_response):
+    TestCases._setup_mocks(mock_request, mock_response, b'Not Found\nDiscarded Msg', 404)
+
+    with self.assertRaises(Exception) as error:
+      Http.request('http://www.example.org')
+
+    e = error.exception
+    self.assertEqual(e.status, 404)
+    self.assertEqual(e.content, b'Not Found\nDiscarded Msg')
+    self.assertEqual(e.message, 'HTTP request failed: Not Found')
 
   @staticmethod
   def _setup_mocks(mock_request, mock_response, content, status=200):

--- a/tests/_util/http_tests.py
+++ b/tests/_util/http_tests.py
@@ -93,14 +93,14 @@ class TestCases(unittest.TestCase):
   @mock.patch('httplib2.Response')
   @mock.patch('google.datalab.utils._http.Http.http.request')
   def test_raises_http_error(self, mock_request, mock_response):
-    TestCases._setup_mocks(mock_request, mock_response, 'Not Found', 404)
+    TestCases._setup_mocks(mock_request, mock_response, b'Not Found', 404)
 
     with self.assertRaises(Exception) as error:
       Http.request('http://www.example.org')
 
     e = error.exception
     self.assertEqual(e.status, 404)
-    self.assertEqual(e.content, 'Not Found')
+    self.assertEqual(e.content, b'Not Found')
 
   @staticmethod
   def _setup_mocks(mock_request, mock_response, content, status=200):


### PR DESCRIPTION
Minor bug in http request error parsing happens as `bytes` is `basestring` type in py3 and does not want to be split by an `'\n'` string. Introducing a simple fix for this by forcing the case (inelegant solution as opposed to actually decoding the message. Though that will take a bit more more type detection code)

Updated test to be both 2 and 3 compatible and reflects this error for py3 accurately. On a side note, I believe most of the payload comes out of py3 builtins as `bytes` so it's quite fortunate that we have to ran into any issues right now. We should update tests to reflect this in order to ensure that the api is py3 compatible too

```
...
  File "/root/.local/lib/python3.5/site-packages/google/datalab/utils/_http.py", line 158, in request
    raise RequestException(response.status, content)
  File "/root/.local/lib/python3.5/site-packages/google/datalab/utils/_http.py", line 55, in __init__
    lines = content.split('\n') if isinstance(content, basestring) else []
TypeError: a bytes-like object is required, not 'str'"
```