### PR TITLE
Fix an issue that TF Events are not parsed because tf record appears to be corrupted.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     env: TOX_ENV=coveralls
 
 before_install:
-  - npm install -g typescript
+  - npm install -g typescript@3.0.3
   - tsc --module amd --noImplicitAny --outdir datalab/notebook/static datalab/notebook/static/*.ts
   # We use tox for actually running tests.
   - pip install --upgrade pip tox

--- a/google/datalab/ml/_summary.py
+++ b/google/datalab/ml/_summary.py
@@ -81,7 +81,7 @@ class Summary(object):
               continue
             event_dir_dict[value.tag].add(dir)
       except tf.errors.DataLossError:
-        # DataLossError seems happening sometimes for small logs. We want to show good records regardless.
+        # DataLossError seems to happen sometimes for small logs. We want to show good records regardless.
         continue
     return dict(event_dir_dict)
 
@@ -126,7 +126,7 @@ class Summary(object):
             df = dir_event_dict[dir]
             df.loc[len(df)] = [event_time, event.step, value.simple_value]
       except tf.errors.DataLossError:
-        # DataLossError seems happening sometimes for small logs. We want to show good records regardless.
+        # DataLossError seems to happen sometimes for small logs. We want to show good records regardless.
         continue
 
     for idx, dir_event_dict in enumerate(ret_events):

--- a/google/datalab/ml/_summary.py
+++ b/google/datalab/ml/_summary.py
@@ -81,7 +81,8 @@ class Summary(object):
               continue
             event_dir_dict[value.tag].add(dir)
       except tf.errors.DataLossError:
-        # DataLossError seems to happen sometimes for small logs. We want to show good records regardless.
+        # DataLossError seems to happen sometimes for small logs.
+        # We want to show good records regardless.
         continue
     return dict(event_dir_dict)
 
@@ -126,7 +127,8 @@ class Summary(object):
             df = dir_event_dict[dir]
             df.loc[len(df)] = [event_time, event.step, value.simple_value]
       except tf.errors.DataLossError:
-        # DataLossError seems to happen sometimes for small logs. We want to show good records regardless.
+        # DataLossError seems to happen sometimes for small logs.
+        # We want to show good records regardless.
         continue
 
     for idx, dir_event_dict in enumerate(ret_events):


### PR DESCRIPTION
It seems recent TensorFlow introduced the issue again. For some reasons tensorboard still works, and I think they did similar things (ignore the error).