### PR TITLE
tox: add posargs for easier contrib testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,8 +23,8 @@ deps = pandas-profiling==1.4.0
        solutionbox/structured_data/
        solutionbox/image_classification/
 commands =
-  python ./tests/main.py
-  python ./legacy_tests/main.py
+  python ./tests/main.py {posargs}
+  python ./legacy_tests/main.py {posargs}
 
 [testenv:py27]
 # apache-beam only supports python2.7, so we add that here.
@@ -41,5 +41,5 @@ deps = {[testenv]deps}
        google-cloud-dataflow==2.5.0
        coveralls 
 commands =
-  coverage run tests/main.py
+  coverage run tests/main.py {posargs}
   - coveralls --rcfile=.coveragerc


### PR DESCRIPTION
this allows us to do `tox -- --unittestonly` without affecting current tox behaviour