### PR TITLE
Pin pandas-profiling to 1.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'oauth2client>=2.2.0',
     'pandas>=0.22.0',
     'google_auth_httplib2>=0.0.2',
-    'pandas-profiling>=1.0.0a2',
+    'pandas-profiling==1.4.1',
     'python-dateutil>=2.5.0',
     'pytz>=2015.4',
     'pyyaml>=3.11',


### PR DESCRIPTION
1.4.2 deprecates Python 2 support: https://github.com/pandas-profiling/pandas-profiling/commit/8a7430fc7607f121b64e408eb69363e14cdddc70#diff-2eeaed663bd0d25b7e608891384b7298