### PR TITLE
bump pandas-profiling from 1.4.0 to 2.x and 3.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 
 from setuptools import setup
 
-version = '1.2.0'
+version = '1.2.1'
 
 setup(
   name='datalab',
@@ -103,7 +103,7 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'oauth2client>=2.2.0',
     'pandas>=0.22.0',
     'google_auth_httplib2>=0.0.2',
-    'pandas-profiling==1.4.0',
+    'pandas-profiling>=2.0.0',
     'python-dateutil>=2.5.0',
     'pytz>=2015.4',
     'pyyaml>=3.11',


### PR DESCRIPTION
the latest version of pandas profiling is 3.2.0 and the zero division error has been already fixed years ago.

https://github.com/ydataai/pandas-profiling
https://github.com/ydataai/pandas-profiling/issues?q=zero+division+error